### PR TITLE
delete a book

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,11 @@ creates a file (or, in a Calibre folder, a Calibre book) and then runs
 a pass. It never touches a catalog table itself, so an uploaded book
 and a book somebody copied in by hand are the same kind of thing. (It
 does write one non-catalog row: the uploader's `user_book_work` link, so
-a book whose position was already syncing does not appear twice.) One watcher goroutine
+a book whose position was already syncing does not appear twice.)
+`DELETE /v1/books/{id}` is its counterpart
+([ADR-0025](docs/adr/0025-deleting-a-book.md)), bounded by the same
+flag: the file goes and then the row, and only in a folder that accepts
+uploads. One watcher goroutine
 (`internal/content/watch_linux.go`) triggers a pass at startup, on a
 debounced fsnotify event, and on a slow safety timer. There is no ingest
 job, no content-addressed store, no quota, no trash and no review queue:
@@ -145,13 +149,17 @@ of them.
 - **`root_path` never reaches a non-admin.** It is a filesystem oracle;
   a `library-read` response names books, not paths.
 - **The server writes under a watched folder only where an
-  administrator asked it to, and then only by creating something new.**
-  Everywhere else: rooted, read-only opens; symlinks refused; no temp
-  files, no cover extracted beside the book, no `metadata.db` writes. In
-  a folder marked `accepts_uploads` an upload creates a file — and in a
-  Calibre folder a book directory and a `metadata.db` row — and still
-  never modifies or deletes one that was already there
-  ([ADR-0023](docs/adr/0023-uploads-land-in-a-folder.md)).
+  administrator asked it to.** Everywhere else: rooted, read-only opens;
+  symlinks refused; no temp files, no cover extracted beside the book,
+  no `metadata.db` writes. In a folder marked `accepts_uploads` an
+  upload creates a file — and in a Calibre folder a book directory and a
+  `metadata.db` row
+  ([ADR-0023](docs/adr/0023-uploads-land-in-a-folder.md)) — and a delete
+  takes one back out
+  ([ADR-0025](docs/adr/0025-deleting-a-book.md)). It still never
+  modifies or renames anything, and the delete refuses a file that has
+  changed since the last pass: there is no trash behind it, so it
+  deletes the book the catalog described or nothing.
 - **A pass that did not fully succeed, or that observed nothing, never
   marks anything missing, and never purges.** Both rules are enforced by
   `ReconcileFolder`'s signature rather than by care.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,8 +35,9 @@ backend (throwaway database).
 
 The web reader has a browser check (`TestReaderOpensInARealBrowser`)
 that drives Chromium over CDP. It skips when no Chromium is found,
-including in CI; set `LISEUR_CHROME` to point at one, and
-`LISEUR_READER_SCREENSHOT=/tmp/reader.png` to keep what it saw. Run it
+including in CI. On a desktop run, set `LISEUR_CHROME=/path/to/chrome`
+to opt in explicitly; CI likewise runs it only when that variable is set.
+Set `LISEUR_READER_SCREENSHOT=/tmp/reader.png` to keep what it saw. Run it
 after touching `static/reader*.js`, `reader.templ` or the reader's CSP:
 a `srcdoc` document inherits the framing page's policy, so a page CSP
 that is slightly too strict renders a blank frame with no error

--- a/cmd/liseur-sync/main.go
+++ b/cmd/liseur-sync/main.go
@@ -172,6 +172,9 @@ func cmdServe(args []string) error {
 		MaxDepth: cfg.Content.ScanMaxDepth,
 	}, cfg.EPUBLimits(), slog.Default())
 
+	// One Ingester is both halves of ADR-0023 and ADR-0025: it is the
+	// only thing that writes under a folder root, in either direction.
+	ingester := content.NewIngester(reconciler)
 	apiSrv := &api.Server{
 		St:           st,
 		Auth:         auth.NewService(st),
@@ -179,7 +182,8 @@ func cmdServe(args []string) error {
 		LoginLimiter: loginLimiter,
 		Files:        content.NewFiles(st),
 		Covers:       cache,
-		Ingest:       content.NewIngester(reconciler),
+		Ingest:       ingester,
+		Removal:      ingester,
 		Kosync: &kosync.Server{
 			St:          st,
 			OpenReg:     cfg.OpenRegistration,

--- a/cmd/liseur-sync/main.go
+++ b/cmd/liseur-sync/main.go
@@ -207,6 +207,7 @@ func cmdServe(args []string) error {
 		Downloads:    apiSrv,
 		Covers:       apiSrv,
 		Uploads:      apiSrv,
+		Deletes:      apiSrv,
 		Watching:     watcher,
 	}
 	mux := apiSrv.Handler()

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -453,10 +453,10 @@ rules: `add-folder <name> <root>`, `list-folders`, `remove-folder
 `root_path` is stored absolute and never appears in a non-admin API
 response. A folder root is opened read-only; symlinks inside the tree
 are refused. The server writes under a watched folder only where an
-administrator set `accepts_uploads`, and only to create something that
-was not there (ADR-0023); it never modifies, renames or deletes. The
-only unconditionally writable directory in the content system is the
-cover cache.
+administrator set `accepts_uploads` — to create something that was not
+there (ADR-0023), or to delete something it could have created
+(ADR-0025). It never modifies or renames. The only unconditionally
+writable directory in the content system is the cover cache.
 
 There is one implementation of that write, reached two ways.
 `api.ReceiveUpload` bounds the body, validates the EPUB, hashes it,
@@ -467,6 +467,22 @@ a signed-in browser, through the same kind of interface downloads and
 covers already use. A browser has no scope, so its gate is the folder
 flag plus the session — the decision about which folder may be written
 to having already been made, once, by whoever marked it.
+
+Deleting is the same shape in the other direction. `api.DeleteBook`
+removes the file and then the row — that order, because a crash between
+them leaves a book the next pass marks missing, a state the system
+models, while the reverse leaves a file the next pass puts straight
+back. `DELETE /v1/books/{id}` calls it for an app holding
+`library-delete`; the book page's control calls it for a signed-in
+administrator. The scope is separate from `library-upload` because
+adding your own book and destroying everyone's are different questions,
+and the browser's gate is the role rather than a scope because a
+session carries none.
+
+A Calibre folder inverts that order, and only it can: there the row is
+the book, `metadata.db` is a transaction, and a failed directory
+removal rolls the row back rather than leaving a library whose files
+have no book.
 
 ### 9.2 Reconcile passes
 

--- a/docs/adr/0025-deleting-a-book.md
+++ b/docs/adr/0025-deleting-a-book.md
@@ -1,0 +1,183 @@
+# ADR-0025: A book may be deleted where a book may be written
+
+- **Status:** Accepted
+- **Date:** 2026-08-19
+- **Depends on:** [ADR-0017](0017-folders-not-pipelines.md),
+  [ADR-0022](0022-calibre-metadata-db-is-authoritative.md),
+  [ADR-0023](0023-uploads-land-in-a-folder.md),
+  [ADR-0024](0024-deleting-a-work.md)
+- **Amends:** ADR-0024, which deliberately left the file alone; and
+  ADR-0023's amendment to ADR-0017 rule 3, which allowed one kind of
+  write under a folder root and now allows its inverse
+
+## Context
+
+[ADR-0023](0023-uploads-land-in-a-folder.md) gave this server a way to
+put a book into a folder. A reader sends one from a phone or from the
+browser form, and the bytes land under a root an administrator marked
+`accepts_uploads`. Nothing gives it a way back out.
+
+What exists is [ADR-0024](0024-deleting-a-work.md), and it is two
+narrower things, neither of which touches a file. A reader deletes their
+own *work* — reading, not a book — and only once no catalog book backs
+it. An administrator *retires* a catalog row a pass already reported
+missing, which is a decision that a file is not coming back.
+
+Both rest on a sentence that was true when it was written: those files
+were never this server's to delete
+([ADR-0017](0017-folders-not-pipelines.md)). A folder is somebody's
+directory, curated with their own tools, and a server that deletes out
+of it is a server that has to be trusted with a backup.
+
+Uploads broke the symmetry. A reader who sends the wrong book, or sends
+the same book twice under two names, has asked this server to write a
+file and has no way to ask it to stop. The recourse is a shell on the
+machine — which the phone does not have, and which the browser form's
+user may not either. The one place the server *is* the curator is the one
+place a reader cannot curate.
+
+## Decision
+
+**A book may be deleted from a folder that accepts uploads, and from no
+other folder.** The file goes, and the catalog row with it.
+
+The flag already carries exactly this meaning. `accepts_uploads` is
+described in `store.Folder` as "the one place the server is allowed to
+write under a folder root", and deleting is a write. A folder without it
+is what it always was: read-only to this server, observed by a pass and
+never touched. So this needs no new setting and no new decision from an
+administrator. The one they already made — *this directory is the
+server's to manage* — is the one being honoured.
+
+A book whose file a pass reports **missing** is still not deletable
+through this route. Absence is evidence about a disk, not a decision
+about a book, and ADR-0024's retire path already covers the case where
+somebody has decided otherwise.
+
+### Over the API, a new scope
+
+`library-delete`, beside `library-upload` rather than folded into it.
+
+Uploading is a reader adding their own book. Deleting removes a file
+every account on this server can see. They are different questions, and
+this is the same reasoning that kept `library-upload` out of
+`library-manage`: tidying your own shelves and writing to the server's
+disk are not one permission, and neither are adding and destroying.
+
+It is worth being exact about what this scope *is not*. Any account can
+mint a token for itself with any non-admin scope, so `library-delete` is
+not a privilege boundary between users: it bounds what a **token** may
+do, so that a device holding a sync token cannot delete a library by
+accident or by compromise. Every account that wants it can have it, and
+every holder can delete any book in a writable folder. A server whose
+readers should not be able to do that should not mark a folder
+`accepts_uploads`.
+
+### In the browser, an administrator
+
+Not the scope, because there is nothing to check it against: a web
+`AuthSession` carries an account and a CSRF hash and no capabilities at
+all. That is not an oversight but the model — `store.User.IsAdmin` says
+it plainly, that a token carries capabilities and the account carries the
+role.
+
+So the browser asks the question it can answer, and answers it the way
+the sibling control in the same file already does: retiring a missing
+book is admin-only, and deleting a live one is no smaller a decision. A
+reader who wants to delete from a phone holds a token, and the token
+route is the scoped one.
+
+The two surfaces therefore answer *who* differently. That is not a
+compromise to apologise for; sessions and tokens genuinely are different
+credentials, and pretending a browser login is a scoped token would mean
+inventing session scopes for one button.
+
+### The file, and the order it goes in
+
+Removal reuses the discipline `internal/content` already applies to
+opening one: a relative path checked, the root opened as a root, a
+symlink or a non-regular file refused. A delete is the last place to
+join two strings and hope.
+
+Before unlinking, the size and modification time must still match what
+the catalog recorded. That is already the change gate a plain folder
+uses, so it costs one stat, and with no trash behind this it is the
+difference between deleting the book that was described and deleting
+whatever replaced it.
+
+**The file first, then the row.** A crash between them leaves a book a
+pass will mark missing — a state this server already models, and one an
+administrator can retire. The reverse leaves a file with no row, which
+the next pass adds straight back, and the reader is told a delete
+succeeded that visibly did not.
+
+A **Calibre** folder inverts that, and only it, because it can. There the
+library is a transaction: the book's directory is read from
+`metadata.db` — authoritative per [ADR-0022](0022-calibre-metadata-db-is-authoritative.md),
+and the only place that knows where Calibre has since renamed it to — the
+row is deleted, the directory is removed, and the transaction commits.
+If the removal fails the delete rolls back, which a plain folder has no
+way to do.
+
+Deleting the `books` row is the whole of the database work: Calibre's own
+`books_delete_trg` removes the links, formats, comments, identifiers,
+annotations, positions, conversion options and plugin data. Enumerating
+those here would be a list that drifts out of date the first time Calibre
+adds a table.
+
+### The reading is a second question, asked at the same time
+
+ADR-0024 stands: a work is per-user, and only its own reader may remove
+it. Deleting a book therefore leaves each reader's reading behind, as a
+bookless work that only they can delete.
+
+But the reader doing the deleting is *there*, and has an opinion. So the
+delete takes an optional "and forget mine", which removes the caller's
+own work and nobody else's. It is offered rather than implied, because
+the two are genuinely different decisions — the file is shared, the
+reading is yours — and because the answer differs by case: a book
+uploaded by mistake wants both, a book being tidied off a full disk while
+another device still reads it wants only the first.
+
+One work can back several books; the mapping's key is per user and book.
+`DeleteWork` already refuses a work anything still maps, and that refusal
+is the guard here too: if another copy of the book remains, the reading
+stays with it, and that is an outcome to report rather than an error.
+
+## Consequences
+
+- The first operation in this server that destroys a reader's bytes.
+  There is no trash and none is added: ADR-0023 declined one, and adding
+  it now would be a store to sweep, expire and account for, to insure
+  against a mistake a confirmation already asks about.
+- `accepts_uploads` now means more than it did. An administrator who set
+  it to let a phone send a book has also allowed that phone to remove
+  one. The flag's own comment must say so.
+- The API and the browser disagree about who may delete, and always
+  will, because they authenticate differently.
+- A concurrent pass can still observe a folder between the unlink and the
+  commit. The outcome is a book marked missing, which is recoverable and
+  already understood, and closing the window would mean a per-folder
+  mutation lock this server has no other use for.
+- A client paired before this scope existed does not hold it, and cannot
+  be granted it silently: widening a token's scopes authenticates with
+  the account password, which a client does not keep. Reconnecting is the
+  route, and a client should say so rather than hide the feature.
+
+## Acceptance criteria
+
+- A book in a folder that does not accept uploads cannot be deleted, by
+  either surface, and the check is made against the folder as it is at
+  the moment of deletion.
+- A file whose size or modification time no longer matches the catalog is
+  refused rather than deleted.
+- Deleting a book removes its file and its row, and collects the works
+  and entities a pass would have collected.
+- A Calibre delete finds the book's directory through `metadata.db`, so a
+  directory Calibre renamed since the last pass is still the one removed,
+  and a failed removal leaves `metadata.db` unchanged.
+- Deleting without asking to forget leaves every reader's work, including
+  the caller's. Asking to forget removes the caller's and no other
+  reader's, and keeps it when another book still maps it.
+- The API route requires `library-delete`; the browser route requires an
+  administrator and a CSRF token.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -49,6 +49,7 @@ loose ends that must come before any of it, are in
 | [0022](0022-calibre-metadata-db-is-authoritative.md) | A Calibre library's `metadata.db` is authoritative | Later | Accepted; implemented | Purge, unservable observations and digest re-registration; amends rules on [0017](0017-folders-not-pipelines.md) |
 | [0023](0023-uploads-land-in-a-folder.md) | An upload is a file written into a folder | Later | Accepted; implemented | Folder opt-in, `library-upload` scope, plain and Calibre folders; amends rule 3 of [0017](0017-folders-not-pipelines.md) and reinstates phase C of [0008](0008-android-client.md) |
 | [0024](0024-deleting-a-work.md) | Deleting is a reader forgetting, or an administrator retiring | Later | Accepted; implemented | Per-user work delete for a work no book backs, admin delete of a missing catalog row; amends the append-only rule for that one case |
+| [0025](0025-deleting-a-book.md) | A book may be deleted where a book may be written | Later | Accepted | Deleting a book's file and row from an `accepts_uploads` folder; `library-delete` scope over the API, admin in the browser; amends [0024](0024-deleting-a-work.md) and rule 3 of [0017](0017-folders-not-pipelines.md) again |
 
 ## Convention
 

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -42,7 +42,7 @@ change capabilities without changing the token secret, device id, or
 retry identity.
 
 The scopes are `sync`, `read-insights`, `library-read`,
-`library-manage`, `library-upload`, and `admin`. `admin` implies every scope and is not
+`library-manage`, `library-upload`, `library-delete`, and `admin`. `admin` implies every scope and is not
 self-grantable: requesting it returns `403` unless the account is
 already an administrator. Clients normally need only `sync`; add
 `library-read` to browse and download books, `read-insights` to show
@@ -54,6 +54,13 @@ Add `library-upload` to send a book up to a folder that accepts them
 from `GET /v1/folders`, because the right and the folder are two
 separate answers and an account can hold the first with no folder
 giving the second.
+
+Add `library-delete` to take a book back out of such a folder
+(ADR-0025). It is deliberately not implied by `library-upload`: that
+one adds your own book, this one destroys everyone's, and the file is
+gone with no trash behind it. The same `accepts_uploads` caveat
+applies, and for the same reason — it is the flag that decides where
+this server may write at all.
 
 All API calls then use `Authorization: Bearer <secret>`.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -970,6 +970,59 @@ paths:
               schema: { $ref: "#/components/schemas/CatalogBook" }
         "404": { $ref: "#/components/responses/Error", description: "Unknown book, or no access" }
 
+    delete:
+      tags: [library]
+      summary: Delete a book from the server
+      security: [{ deviceToken: [] }]  # requires library-delete scope
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string, format: uuid } }
+        - name: forget_reading
+          in: query
+          required: false
+          schema: { type: boolean, default: false }
+          description: |
+            Also forget the caller's own reading of this book, and only
+            theirs. Another reader's history is never touched.
+      description: |
+        The counterpart of an upload, bounded the same way (ADR-0025).
+        This deletes the file itself and then the catalog row: the bytes
+        are gone from this server's disk, for every device, and there is
+        no trash to take them back out of.
+
+        Two conditions, and they mirror the upload's. The book's folder
+        must have `accepts_uploads` — that flag marks the one place this
+        server may write under a folder root, and deleting is a write —
+        and the token must carry `library-delete`, which no other route
+        uses. `library-upload` is not enough: sending your own book and
+        destroying everyone's are different questions.
+
+        Reading survives by default. A work with history outlives its
+        book and becomes an entry only its own reader can remove
+        (ADR-0024), which is what lets a reader on another device keep
+        their position. `forget_reading=true` removes the caller's, and
+        is declined silently when another copy of the same book still
+        maps that work — the reader asked to forget a book they still
+        have.
+
+        In a Calibre folder the row is the book, so the delete goes
+        through `metadata.db`: the row goes, Calibre's own triggers take
+        the links with it, and the book's directory is removed. The
+        directory comes from `books.path`, not from anything cached,
+        because Calibre renames directories when metadata changes.
+      responses:
+        "204": { description: The book is gone. }
+        "403":
+          description: |
+            The book's folder does not accept uploads, or the token
+            lacks `library-delete`.
+        "404": { description: No such book }
+        "409":
+          description: |
+            The file changed since it was last scanned and was left
+            alone, or a Calibre library is busy — close Calibre and
+            retry.
+        "503": { description: This server is running without a folder watcher }
+
   /v1/books/{id}/series:
     get:
       tags: [library]
@@ -2188,11 +2241,15 @@ components:
 
     Scope:
       type: string
-      enum: [sync, read-insights, library-read, library-manage, admin]
+      enum: [sync, read-insights, library-read, library-manage, library-upload, library-delete, admin]
       description: |
         `sync` writes and reads positions, `read-insights` reads
         statistics, `library-read` reads the catalog, and
-        `library-manage` states series claims. `library-manage` does
+        `library-manage` states series claims. `library-upload` sends a
+        book into a folder that accepts uploads (ADR-0023), and
+        `library-delete` takes one back out of one (ADR-0025); the two
+        are separate because sending your own book and destroying
+        everyone's are different questions. `library-manage` does
         not grant catalog reads; request `library-read` too when a
         client needs both. `admin` implies all scopes. No other scope
         implies another. `admin` cannot be self-granted: creating or

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -32,6 +32,11 @@ type Server struct {
 	// reports 503: a server with no watcher has nothing to reconcile
 	// with, so accepting the bytes would be a promise it cannot keep.
 	Ingest BookIngest
+	// Removal deletes a book's file from its folder (ADR-0025). Nil
+	// disables the delete route for the same reason Ingest's nil
+	// disables the upload one: without a watcher there is nothing to
+	// reconcile the folder back to.
+	Removal BookRemover
 	// uploading serialises an upload from the digest check through the
 	// write it guards. Two copies of one book arriving together would
 	// otherwise both find nothing in the catalog and both be written,

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -149,3 +149,13 @@ func (s *Server) HandleDeleteBook(w http.ResponseWriter, r *http.Request) {
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
+
+// DeleteBookFrom is DeleteBook in the shape the web UI needs. It lives
+// here so that the web package can delegate to these rules while still
+// depending on nothing but the store.
+func (s *Server) DeleteBookFrom(
+	ctx context.Context, bookID, userID string, forgetReading bool,
+) (string, bool, bool, error) {
+	out, err := s.DeleteBook(ctx, bookID, userID, forgetReading)
+	return out.Title, out.ReadingForgotten, out.ReadingKept, err
+}

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/calibre"
+	"github.com/chmouel/liseur-sync/internal/content"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// Deleting a book, ADR-0025. The counterpart of upload.go, and bounded
+// the same way: only a folder somebody marked as accepting uploads, and
+// only what this server could have written.
+
+// BookRemover deletes a catalog book's file from its folder. It is an
+// interface for the same two reasons BookIngest is: the API package
+// stays off the content package's platform files, and a nil value
+// disables the route rather than panicking.
+type BookRemover interface {
+	Remove(
+		ctx context.Context, folder store.Folder, book store.CatalogBook,
+	) error
+}
+
+// DeleteOutcome is what happened, for a caller that has to say so.
+type DeleteOutcome struct {
+	// Title is the book's, kept because the row is gone by the time
+	// anybody phrases a sentence about it.
+	Title string
+	store.DeleteBookResult
+}
+
+// DeleteBook removes one catalog book: its file, then its row, and
+// optionally the caller's own reading of it.
+//
+// Both surfaces call this — the route below and the browser control in
+// the web UI — so there is one implementation of what deleting a book
+// means and the two cannot drift into different ideas of it.
+//
+// The file goes before the row, and the order is not arbitrary. A crash
+// between the two leaves a book the next pass marks missing, which is a
+// state this system already models and an administrator can retire in
+// one click. The reverse leaves a file the next pass puts straight back,
+// which reads to the reader as a delete that silently failed.
+//
+// forgetReading is the caller's own reading and only ever theirs
+// (ADR-0024). Declining to forget it because a second copy still holds
+// it is reported, not failed.
+func (s *Server) DeleteBook(
+	ctx context.Context, bookID, userID string, forgetReading bool,
+) (DeleteOutcome, error) {
+	if s.Removal == nil {
+		return DeleteOutcome{}, deleteErr(http.StatusServiceUnavailable,
+			"this server is running without a folder watcher")
+	}
+	book, err := s.St.CatalogBookByID(ctx, bookID)
+	if errors.Is(err, store.ErrNotFound) {
+		return DeleteOutcome{}, deleteErr(http.StatusNotFound, "no such book")
+	}
+	if err != nil {
+		return DeleteOutcome{}, err
+	}
+	folder, err := s.St.FolderByID(ctx, book.FolderID)
+	if errors.Is(err, store.ErrNotFound) {
+		return DeleteOutcome{}, deleteErr(http.StatusNotFound, "no such book")
+	}
+	if err != nil {
+		return DeleteOutcome{}, err
+	}
+	// Answered the same way an upload into the same folder would be, so
+	// a reader who cannot add a book here learns they cannot remove one
+	// here in the same words.
+	if !folder.AcceptsUploads {
+		return DeleteOutcome{}, deleteErr(http.StatusForbidden,
+			"this folder does not accept uploads, so this server "+
+				"will not delete from it")
+	}
+	if err := s.Removal.Remove(ctx, folder, book); err != nil {
+		return DeleteOutcome{}, removeRefusal(err)
+	}
+
+	opts := store.DeleteBookOptions{}
+	if forgetReading {
+		opts.ForgetReadingFor = userID
+	}
+	result, err := s.St.DeleteCatalogBook(ctx, bookID, opts)
+	if errors.Is(err, store.ErrNotFound) {
+		// The file is gone and so is the row. Somebody else got here
+		// first, which is the outcome that was asked for.
+		return DeleteOutcome{Title: book.Title}, nil
+	}
+	if err != nil {
+		return DeleteOutcome{}, err
+	}
+	return DeleteOutcome{Title: book.Title, DeleteBookResult: result}, nil
+}
+
+// removeRefusal turns what the filesystem said into what the caller is
+// told. Everything unrecognised stays a 500 with no detail: the
+// messages under it name paths on this server's disk.
+func removeRefusal(err error) error {
+	switch {
+	case errors.Is(err, content.ErrUploadsRefused):
+		return deleteErr(http.StatusForbidden,
+			"this folder does not accept uploads, so this server "+
+				"will not delete from it")
+	case errors.Is(err, content.ErrRemoveChanged):
+		return deleteErr(http.StatusConflict,
+			"that file has changed since it was last scanned; "+
+				"it was left alone")
+	case errors.Is(err, calibre.ErrLocked):
+		return deleteErr(http.StatusConflict,
+			"the Calibre library is busy; close Calibre and try again")
+	case errors.Is(err, content.ErrUnsafePath),
+		errors.Is(err, content.ErrRootMissing):
+		return deleteErr(http.StatusConflict,
+			"that book's file is not where the catalog says it is; "+
+				"it was left alone")
+	default:
+		return err
+	}
+}
+
+func deleteErr(status int, msg string) *WriteError {
+	return &WriteError{Status: status, Message: msg}
+}
+
+// HandleDeleteBook implements DELETE /v1/books/{id}.
+//
+// ?forget_reading=true asks for the caller's own work to go with the
+// book. The answer is 204 either way: what happened to the reading is
+// reported to the browser, which has a page to say it on, and a client
+// that asked already knows what it asked for.
+func (s *Server) HandleDeleteBook(w http.ResponseWriter, r *http.Request) {
+	tok, ok := auth.TokenFrom(r)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+	forget := r.URL.Query().Get("forget_reading") == "true"
+	if _, err := s.DeleteBook(
+		r.Context(), r.PathValue("id"), tok.UserID, forget,
+	); err != nil {
+		writeWriteError(w, err, "the delete failed")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/delete_test.go
+++ b/internal/api/delete_test.go
@@ -1,0 +1,165 @@
+//go:build linux
+
+package api
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// The delete route is ADR-0025, and like the upload route it is mostly
+// about what it refuses. It is the only thing in this server that
+// destroys a reader's bytes and there is no trash behind it, so a
+// folder nobody marked, a token without the scope and a file that is
+// not the one the catalog described each have to be turned away with
+// the file still there.
+
+func (f *folderFixture) deleteBook(
+	t *testing.T, token, bookID, query string,
+) *http.Response {
+	t.Helper()
+	resp, _ := f.req(t, http.MethodDelete, "/v1/books/"+bookID+query, token)
+	return resp
+}
+
+// pushPosition gives a work some reading, the way a client does.
+func (f *folderFixture) pushPosition(
+	t *testing.T, token, workID, editionSHA string,
+) {
+	t.Helper()
+	resp, raw := f.postRaw(t, "/v1/ops", token, `{"ops":[{
+		"op_id":"018e6f1a-0000-7000-8000-0000000000d1",
+		"work_id":"`+workID+`","edition_sha":"`+editionSHA+`",
+		"client_ts":"2024-01-01T00:00:00Z","progression":0.4,
+		"locator":{"href":"/text/ch1.xhtml"}}]}`)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("push a position: %d (%s)", resp.StatusCode, raw)
+	}
+}
+
+func TestDeleteBookRemovesTheFileAndTheRow(t *testing.T) {
+	f := newFolderFixture(t)
+	f.allowUploads(t)
+	bookID, _ := f.publishAs(t, "gone", "Gone", []byte("bytes"))
+	token := f.mintToken(t, f.user.ID, store.ScopeLibraryDelete)
+
+	if resp := f.deleteBook(t, token, bookID, ""); resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	if _, err := os.Stat(filepath.Join(f.root, "gone.epub")); !os.IsNotExist(err) {
+		t.Errorf("the file survived: %v", err)
+	}
+	if _, err := f.st.CatalogBookByID(t.Context(), bookID); err == nil {
+		t.Error("the catalog row survived")
+	}
+}
+
+// The flag that bounds writing bounds unwriting, and it is answered in
+// the same words an upload into the same folder would be.
+func TestDeleteBookRefusesAFolderThatDoesNotAcceptUploads(t *testing.T) {
+	f := newFolderFixture(t)
+	bookID, _ := f.publishAs(t, "kept", "Kept", []byte("bytes"))
+	token := f.mintToken(t, f.user.ID, store.ScopeLibraryDelete)
+
+	if resp := f.deleteBook(t, token, bookID, ""); resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	if _, err := os.Stat(filepath.Join(f.root, "kept.epub")); err != nil {
+		t.Errorf("the file was deleted from a folder nobody marked: %v", err)
+	}
+	if _, err := f.st.CatalogBookByID(t.Context(), bookID); err != nil {
+		t.Errorf("the row went even though the file stayed: %v", err)
+	}
+}
+
+// There is no trash behind this. A file replaced since the last pass is
+// not the book the reader asked to delete.
+func TestDeleteBookRefusesAFileThatChanged(t *testing.T) {
+	f := newFolderFixture(t)
+	f.allowUploads(t)
+	bookID, _ := f.publishAs(t, "swapped", "Swapped", []byte("bytes"))
+	token := f.mintToken(t, f.user.ID, store.ScopeLibraryDelete)
+	if err := os.WriteFile(filepath.Join(f.root, "swapped.epub"),
+		[]byte("a different book entirely"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp := f.deleteBook(t, token, bookID, ""); resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", resp.StatusCode)
+	}
+	if _, err := os.Stat(filepath.Join(f.root, "swapped.epub")); err != nil {
+		t.Errorf("the replacement was deleted: %v", err)
+	}
+}
+
+func TestDeleteBookAnswers404ForABookThatIsNotThere(t *testing.T) {
+	f := newFolderFixture(t)
+	f.allowUploads(t)
+	token := f.mintToken(t, f.user.ID, store.ScopeLibraryDelete)
+
+	if resp := f.deleteBook(t, token, "no-such-book", ""); resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// A server with no watcher has no folder to delete from, and says so
+// rather than panicking — the same answer the upload route gives.
+func TestDeleteBookIsUnavailableWithoutAWatcher(t *testing.T) {
+	f := newFolderFixture(t)
+	f.allowUploads(t)
+	bookID, _ := f.publishAs(t, "orphan", "Orphan", []byte("bytes"))
+	token := f.mintToken(t, f.user.ID, store.ScopeLibraryDelete)
+	f.srv.Removal = nil
+
+	if resp := f.deleteBook(t, token, bookID, ""); resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+}
+
+// The reading is a separate question, asked separately (ADR-0024). By
+// default the work survives its book, and only the caller's own goes
+// when they ask.
+func TestDeleteBookLeavesTheReadingUnlessAsked(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"kept by default", "", true},
+		{"forgotten when asked", "?forget_reading=true", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFolderFixture(t)
+			f.allowUploads(t)
+			bookID, digest := f.publishAs(t, "read", "Read", []byte("bytes"))
+			// Resolving is how a reader comes to have a work behind a
+			// catalog book at all, so the reading here is made the way
+			// a real one is.
+			resolveTok := f.mintToken(t, f.user.ID,
+				store.ScopeLibraryRead, store.ScopeSync)
+			resp, out := f.resolveBook(t, bookID, resolveTok)
+			if resp.StatusCode != http.StatusCreated {
+				t.Fatalf("resolve: %d", resp.StatusCode)
+			}
+			workID := out.WorkID
+			// And a position, because a work with no reading behind it
+			// is collected as empty whatever this route does — ADR-0024
+			// only promises to keep a work that is worth keeping.
+			f.pushPosition(t, resolveTok, workID, digest)
+			token := f.mintToken(t, f.user.ID, store.ScopeLibraryDelete)
+
+			if resp := f.deleteBook(t, token, bookID, tc.query); resp.StatusCode != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204", resp.StatusCode)
+			}
+			_, err := f.st.WorkByID(t.Context(), f.user.ID, workID)
+			if survived := err == nil; survived != tc.want {
+				t.Fatalf("work survived = %v, want %v (err %v)",
+					survived, tc.want, err)
+			}
+		})
+	}
+}

--- a/internal/api/fixture_test.go
+++ b/internal/api/fixture_test.go
@@ -113,7 +113,9 @@ func newFolderFixture(t *testing.T) *folderFixture {
 	// The upload route hands its bytes to the same reconciler the tests
 	// drive by hand, so an uploaded book and a book written under the
 	// root go through exactly one pass implementation (ADR-0023).
-	srv.Ingest = content.NewIngester(f.rec)
+	ingester := content.NewIngester(f.rec)
+	srv.Ingest = ingester
+	srv.Removal = ingester
 	return f
 }
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -421,6 +421,15 @@ func (s *Server) Routes() *http.ServeMux {
 			auth.RequireScope(s.Auth, store.ScopeLibraryUpload,
 				http.HandlerFunc(s.HandleUploadBook))))
 
+	// library-delete scope: taking a book back out of a folder that
+	// accepts one (ADR-0025). Separate from library-upload for the
+	// reason upload is separate from library-manage — adding your own
+	// book and removing everyone's are different questions.
+	mux.Handle("DELETE /v1/books/{id}",
+		auth.RequireSecureTransport(s.Cfg,
+			auth.RequireScope(s.Auth, store.ScopeLibraryDelete,
+				http.HandlerFunc(s.HandleDeleteBook))))
+
 	// Joining a catalog book to a sync work is the one route that spans
 	// both layers, so it demands both capabilities: it reads the catalog
 	// and it writes the caller's work graph (ADR-0003).

--- a/internal/api/token_scope_test.go
+++ b/internal/api/token_scope_test.go
@@ -136,6 +136,7 @@ const (
 	gateLibraryRead                    // bearer, scope library-read
 	gateLibraryManage                  // bearer, scope library-manage
 	gateLibraryUpload                  // bearer, scope library-upload
+	gateLibraryDelete                  // bearer, scope library-delete
 	gateResolveBoth                    // bearer, library-read AND sync
 	gateOPDS                           // HTTP Basic, scope library-read
 	gateTokenSelf                      // bearer, no scope beyond authenticating
@@ -194,6 +195,10 @@ var registeredRouteGates = map[string]routeGate{
 	// series claims and nothing else, and writing to this server's disk
 	// is a different question.
 	"POST /v1/folders/{folder}/books": gateLibraryUpload,
+
+	// ADR-0025. Deliberately not library-upload either: sending your own
+	// book and destroying everyone's are not the same permission.
+	"DELETE /v1/books/{id}": gateLibraryDelete,
 
 	"POST /v1/books/{id}/resolve": gateResolveBoth,
 
@@ -308,6 +313,7 @@ func TestScopeMatrixCoversEveryRegisteredRoute(t *testing.T) {
 	both := mint(store.ScopeLibraryRead, store.ScopeSync)
 	libraryManageOnly := mint(store.ScopeLibraryManage)
 	libraryUploadOnly := mint(store.ScopeLibraryUpload)
+	libraryDeleteOnly := mint(store.ScopeLibraryDelete)
 
 	// A real login credential, minted the same way HandleLogin mints one
 	// — through Login itself, in-process, since this matrix is about
@@ -420,6 +426,21 @@ func TestScopeMatrixCoversEveryRegisteredRoute(t *testing.T) {
 				}
 				if got := bearer(method, path, libraryUploadOnly); got == http.StatusUnauthorized || got == http.StatusForbidden {
 					t.Errorf("library-upload token on a library-upload route: %d, should have passed the gate", got)
+				}
+			case gateLibraryDelete:
+				if got := bearer(method, path, ""); got != http.StatusUnauthorized {
+					t.Errorf("no token: %d, want 401", got)
+				}
+				// Being allowed to add a book is not being allowed to
+				// destroy one, and neither is tidying the shelves.
+				if got := bearer(method, path, libraryUploadOnly); got != http.StatusForbidden {
+					t.Errorf("library-upload token on a library-delete route: %d, want 403", got)
+				}
+				if got := bearer(method, path, libraryManageOnly); got != http.StatusForbidden {
+					t.Errorf("library-manage token on a library-delete route: %d, want 403", got)
+				}
+				if got := bearer(method, path, libraryDeleteOnly); got == http.StatusUnauthorized || got == http.StatusForbidden {
+					t.Errorf("library-delete token on a library-delete route: %d, should have passed the gate", got)
 				}
 			case gateResolveBoth:
 				if got := bearer(method, path, ""); got != http.StatusUnauthorized {

--- a/internal/api/upload.go
+++ b/internal/api/upload.go
@@ -103,28 +103,37 @@ type UploadResult struct {
 	Duplicate     bool
 }
 
-// UploadError is a refusal with the status and the sentence that goes
-// with it. Every message here is written to be shown to whoever sent the
-// file, so a browser form can print it as it stands and the JSON API can
-// put it in an error body.
-type UploadError struct {
+// WriteError is a refusal with the status and the sentence that goes
+// with it, from either of the two writes this server makes to a folder:
+// putting a book in (ADR-0023) and taking one out (ADR-0025). Every
+// message is written to be shown to whoever asked, so a browser form
+// can print it as it stands and the JSON API can put it in an error
+// body.
+type WriteError struct {
 	Status  int
 	Message string
 }
 
-func (e *UploadError) Error() string { return e.Message }
+func (e *WriteError) Error() string { return e.Message }
 
-func uploadErr(status int, msg string) *UploadError {
-	return &UploadError{Status: status, Message: msg}
+func uploadErr(status int, msg string) *WriteError {
+	return &WriteError{Status: status, Message: msg}
 }
 
 func writeUploadError(w http.ResponseWriter, err error) {
-	var refusal *UploadError
+	writeWriteError(w, err, "the upload failed")
+}
+
+// writeWriteError turns a refusal into an answer, and anything else
+// into a 500 with the given sentence — never the underlying error,
+// which may name a path on this server's disk.
+func writeWriteError(w http.ResponseWriter, err error, fallback string) {
+	var refusal *WriteError
 	if errors.As(err, &refusal) {
 		writeError(w, refusal.Status, refusal.Message)
 		return
 	}
-	writeError(w, http.StatusInternalServerError, "the upload failed")
+	writeError(w, http.StatusInternalServerError, fallback)
 }
 
 // uploadFolder resolves a folder and satisfies itself that somebody
@@ -155,7 +164,7 @@ func (s *Server) uploadFolder(ctx context.Context, id string) (store.Folder, err
 // web UI — so the rules about what may be written where exist once.
 //
 // The response writer is here only so the body can be bounded; nothing
-// is written to it. Every refusal comes back as an *UploadError holding
+// is written to it. Every refusal comes back as an *WriteError holding
 // the status and a sentence fit to show.
 //
 // userID is who is sending it, and is what lets the book be joined to
@@ -337,7 +346,7 @@ func (u spooledUpload) cleanup() {
 }
 
 // spoolUpload reads the multipart body, hashes and validates it. Every
-// refusal comes back as an *UploadError; nothing is written to the
+// refusal comes back as an *WriteError; nothing is written to the
 // response writer, which is here only to bound the body.
 func (s *Server) spoolUpload(
 	w http.ResponseWriter, r *http.Request,
@@ -397,7 +406,7 @@ func (s *Server) spoolUpload(
 // than the publication, and a client that sent too much should be told
 // the same thing either way rather than being told its request was
 // malformed.
-func oversizeOr(limit int64, err error, status int, msg string) *UploadError {
+func oversizeOr(limit int64, err error, status int, msg string) *WriteError {
 	var tooLarge *http.MaxBytesError
 	if errors.As(err, &tooLarge) {
 		return uploadErr(http.StatusRequestEntityTooLarge,

--- a/internal/calibre/writer.go
+++ b/internal/calibre/writer.go
@@ -630,3 +630,108 @@ func FilenameSafe(value string, maxBytes int) string {
 	}
 	return out
 }
+
+// ErrNoSuchBook is a book id metadata.db does not have. Deleting one
+// that is already gone is the caller's business to forgive, not this
+// package's to hide.
+var ErrNoSuchBook = errors.New("calibre: no such book")
+
+// DeleteBook removes one book from the library: its row, everything the
+// schema hangs off that row, and the directory holding its files
+// (ADR-0025).
+//
+// The cascade is Calibre's own. books_delete_trg deletes the author,
+// publisher, rating, series, tag and language links, the formats, the
+// comments, the identifiers, the annotations, the read positions, the
+// conversion options and the plugin data. Enumerating those here would
+// be a second copy of the schema to drift out of date, so this deletes
+// the row and lets the trigger do what it exists to do. What the
+// trigger does not do is prune the author, tag or series rows it
+// unlinked: Calibre leaves those to its own clean pass, and so does
+// this — pruning a shared row is a library-wide decision.
+//
+// The directory comes from books.path read inside the transaction, not
+// from anything a caller cached. Calibre renames a book's directory when
+// its title or author changes, so a path from an earlier pass may name a
+// directory that has since moved — or one Calibre has since given to a
+// different book.
+//
+// This is the one delete in the server that removes the file after the
+// row rather than before, because here it can: metadata.db is a
+// transaction, so a failed removal rolls the row back rather than
+// leaving a library whose files have no book.
+func (w *Writer) DeleteBook(ctx context.Context, id int64) error {
+	tx, err := w.db.BeginTx(ctx, nil)
+	if err != nil {
+		if isLocked(err) {
+			return ErrLocked
+		}
+		return fmt.Errorf("calibre: begin: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	var dir string
+	switch err := tx.QueryRowContext(ctx,
+		`SELECT path FROM books WHERE id = ?`, id).Scan(&dir); {
+	case errors.Is(err, sql.ErrNoRows):
+		return ErrNoSuchBook
+	case isLocked(err):
+		return ErrLocked
+	case err != nil:
+		return fmt.Errorf("calibre: read book path: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`DELETE FROM books WHERE id = ?`, id); err != nil {
+		if isLocked(err) {
+			return ErrLocked
+		}
+		return fmt.Errorf("calibre: delete book: %w", err)
+	}
+	if err := w.removeBookDir(dir); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		if isLocked(err) {
+			return ErrLocked
+		}
+		return fmt.Errorf("calibre: commit: %w", err)
+	}
+	committed = true
+	return nil
+}
+
+// removeBookDir removes a book's directory and, if that empties it, the
+// author's above it. Rooted, and refusing anything that is not a plain
+// directory: a symlink where a book's directory should be is not a book
+// this server put there, and following it would delete somewhere else.
+func (w *Writer) removeBookDir(dir string) error {
+	dir = path.Clean(dir)
+	if dir == "" || dir == "." || dir == "/" || strings.HasPrefix(dir, "../") {
+		return fmt.Errorf("calibre: refusing to remove %q", dir)
+	}
+	info, err := w.dir.Lstat(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		// Already gone. The row is what the library reads, and it is
+		// about to go too.
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("calibre: stat book directory: %w", err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("calibre: %q is not a directory", dir)
+	}
+	if err := w.dir.RemoveAll(dir); err != nil {
+		return fmt.Errorf("calibre: remove book directory: %w", err)
+	}
+	// Remove, not RemoveAll: an author with other books keeps them.
+	if author := path.Dir(dir); author != "." && author != "/" {
+		_ = w.dir.Remove(author)
+	}
+	return nil
+}

--- a/internal/calibre/writer_delete_test.go
+++ b/internal/calibre/writer_delete_test.go
@@ -1,0 +1,180 @@
+package calibre_test
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chmouel/liseur-sync/internal/calibre"
+	_ "modernc.org/sqlite"
+)
+
+// A Calibre book is rows as much as bytes, and the rows come apart by
+// Calibre's own books_delete_trg rather than by an enumeration here
+// that would drift out of date. This runs against the real schema in
+// testdata, which is where those triggers actually live.
+func TestDeleteBookLetsCalibresOwnTriggersRun(t *testing.T) {
+	root := newLibrary(t)
+	writer, err := calibre.OpenWriter(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	id, relative, err := writer.AddBook(t.Context(), calibre.NewBook{
+		Title:       "The Word for World Is Forest",
+		Authors:     []string{"Ursula K. Le Guin"},
+		Publisher:   "Berkley",
+		Languages:   []string{"eng"},
+		Tags:        []string{"Science Fiction"},
+		Series:      "Hainish Cycle",
+		SeriesIndex: 5,
+		Cover:       []byte("cover bytes"),
+	}, strings.NewReader("bytes"), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, relative)); err != nil {
+		t.Fatalf("the book was never written: %v", err)
+	}
+
+	if err := writer.DeleteBook(t.Context(), id); err != nil {
+		t.Fatal(err)
+	}
+	_ = writer.Close()
+
+	db, err := sql.Open("sqlite", filepath.Join(root, calibre.MetadataDB))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// The links the trigger is responsible for, not just the row. The
+	// authors and tags themselves stay: Calibre's trigger unlinks them
+	// and its own "clean" pass is what prunes the orphans, which is a
+	// library-wide decision this server does not get to make.
+	var books, data, authorLinks, tagLinks, seriesLinks, langLinks int
+	if err := db.QueryRow(`SELECT
+		(SELECT COUNT(*) FROM books),
+		(SELECT COUNT(*) FROM data),
+		(SELECT COUNT(*) FROM books_authors_link),
+		(SELECT COUNT(*) FROM books_tags_link),
+		(SELECT COUNT(*) FROM books_series_link),
+		(SELECT COUNT(*) FROM books_languages_link)`,
+	).Scan(&books, &data, &authorLinks, &tagLinks,
+		&seriesLinks, &langLinks); err != nil {
+		t.Fatal(err)
+	}
+	if books != 0 || data != 0 {
+		t.Errorf("books=%d data=%d, want the book gone", books, data)
+	}
+	if authorLinks+tagLinks+seriesLinks+langLinks != 0 {
+		t.Errorf("links left behind: authors=%d tags=%d series=%d languages=%d",
+			authorLinks, tagLinks, seriesLinks, langLinks)
+	}
+	if _, err := os.Stat(filepath.Join(root, relative)); !os.IsNotExist(err) {
+		t.Errorf("the file survived the delete: %v", err)
+	}
+	// The author directory goes only because it emptied.
+	if _, err := os.Stat(filepath.Join(root, "Ursula K. Le Guin")); !os.IsNotExist(err) {
+		t.Errorf("the emptied author directory survived: %v", err)
+	}
+}
+
+// Calibre renames a book's directory when its title changes, and
+// metadata.db is authoritative (ADR-0022). A delete that trusted a path
+// cached at an earlier pass would miss the files — or, worse, remove
+// somebody else's. The path has to come from the row being deleted.
+func TestDeleteBookFollowsARenamedDirectory(t *testing.T) {
+	root := newLibrary(t)
+	writer, err := calibre.OpenWriter(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	id, relative, err := writer.AddBook(t.Context(), calibre.NewBook{
+		Title: "Rocannon's World", Authors: []string{"Ursula K. Le Guin"},
+	}, strings.NewReader("bytes"), 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDir := filepath.Dir(relative)
+	_ = writer.Close()
+
+	// Calibre moves the directory and updates the row; this server was
+	// not there for it.
+	newDir := "Ursula K. Le Guin/Renamed By Calibre (" + itoa(id) + ")"
+	if err := os.Rename(
+		filepath.Join(root, oldDir), filepath.Join(root, newDir),
+	); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", filepath.Join(root, calibre.MetadataDB))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(
+		`UPDATE books SET path = ? WHERE id = ?`, newDir, id); err != nil {
+		t.Fatal(err)
+	}
+	db.Close()
+
+	writer2, err := calibre.OpenWriter(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer2.Close() }()
+	if err := writer2.DeleteBook(t.Context(), id); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, newDir)); !os.IsNotExist(err) {
+		t.Errorf("the renamed directory survived: %v", err)
+	}
+}
+
+// An author with another book keeps their directory, because Remove
+// refuses a directory that is not empty.
+func TestDeleteBookKeepsAnAuthorWhoStillHasABook(t *testing.T) {
+	root := newLibrary(t)
+	writer, err := calibre.OpenWriter(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	var first int64
+	for i, title := range []string{"A Wizard of Earthsea", "The Tombs of Atuan"} {
+		id, _, err := writer.AddBook(t.Context(), calibre.NewBook{
+			Title: title, Authors: []string{"Ursula K. Le Guin"},
+		}, strings.NewReader("x"), 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i == 0 {
+			first = id
+		}
+	}
+	if err := writer.DeleteBook(t.Context(), first); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "Ursula K. Le Guin")); err != nil {
+		t.Errorf("an author with a book left lost their directory: %v", err)
+	}
+}
+
+func TestDeleteBookAnswersForABookThatIsNotThere(t *testing.T) {
+	root := newLibrary(t)
+	writer, err := calibre.OpenWriter(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = writer.Close() }()
+	if err := writer.DeleteBook(t.Context(), 4242); !errors.Is(
+		err, calibre.ErrNoSuchBook,
+	) {
+		t.Fatalf("err = %v, want ErrNoSuchBook", err)
+	}
+}

--- a/internal/content/ingest_linux.go
+++ b/internal/content/ingest_linux.go
@@ -219,3 +219,18 @@ func (i *Ingester) Ingest(
 	_, _ = i.rec.Reconcile(ctx, folder)
 	return relative, nil
 }
+
+// Remove deletes a book's file from its folder, the mirror of Ingest
+// and the other half of what this type is for: it is the one place the
+// server writes under a folder root, in either direction.
+//
+// Unlike Ingest it does not ask for a pass. An upload needs one because
+// a pass is the only thing that writes the catalog; a delete does not,
+// because the caller removes the row itself in the same breath. A pass
+// run here would run between the two and see a file gone whose row is
+// still there, and mark missing a book that is about to be deleted.
+func (i *Ingester) Remove(
+	ctx context.Context, folder store.Folder, book store.CatalogBook,
+) error {
+	return Remove(ctx, folder, book)
+}

--- a/internal/content/remove_linux.go
+++ b/internal/content/remove_linux.go
@@ -1,0 +1,142 @@
+package content
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/chmouel/liseur-sync/internal/calibre"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// Removing a book's file, ADR-0025.
+//
+// This is the counterpart of ingest_linux.go and carries the same
+// bound: a folder the administrator did not mark as accepting uploads
+// is untouchable, and this server may only unmake there what it could
+// have made. Everything else in this package still opens read-only.
+//
+// A delete is the last place to be careless about a path. There is no
+// trash behind it, so it reuses the rooted, symlink-refusing discipline
+// openUnderRoot established, and it checks that the file it is about to
+// unlink is still the file the catalog described.
+
+// ErrRemoveChanged is a file whose size or modification time no longer
+// matches the catalog row. It is the same change gate a plain folder
+// scans with, used here to answer a different question: is this still
+// the book the reader asked to delete, or a replacement somebody put at
+// the same path. A mismatch is a refusal.
+var ErrRemoveChanged = errors.New(
+	"content: file changed since it was scanned")
+
+// Remove deletes one catalog book's file from its folder.
+//
+// It refuses a folder that does not accept uploads, refuses a path that
+// is not safely under the root, refuses a symlink or anything that is
+// not a regular file, and refuses a file the catalog would not
+// recognise. A file that is already gone is not a failure: the caller's
+// goal is that it not be there.
+//
+// A Calibre folder goes a different way, because a Calibre book is rows
+// as much as bytes; see Writer.DeleteBook.
+func Remove(
+	ctx context.Context, folder store.Folder, book store.CatalogBook,
+) error {
+	if !folder.AcceptsUploads {
+		return ErrUploadsRefused
+	}
+	if folder.Kind == store.FolderCalibre {
+		return removeCalibre(ctx, folder, book)
+	}
+	if err := removeUnderRoot(
+		folder.RootPath, book.RelativePath, &book,
+	); err != nil {
+		return err
+	}
+	// The cover is Calibre's shape of thing and rare beside a loose
+	// EPUB, but a row that names one names a file this server would
+	// otherwise leave behind. It is not size-checked: it is not the
+	// publication, and refusing the whole delete over a re-encoded
+	// thumbnail would be worse than leaving it.
+	if book.CoverRelativePath != nil && *book.CoverRelativePath != "" {
+		if err := removeUnderRoot(
+			folder.RootPath, *book.CoverRelativePath, nil,
+		); err != nil && !errors.Is(err, ErrRemoveChanged) {
+			return err
+		}
+	}
+	return nil
+}
+
+// removeCalibre deletes the book from metadata.db and takes its
+// directory with it. The path comes from the database rather than from
+// the catalog row, because Calibre renames directories and ADR-0022
+// makes metadata.db authoritative.
+func removeCalibre(
+	ctx context.Context, folder store.Folder, book store.CatalogBook,
+) error {
+	if book.CalibreID == nil {
+		return fmt.Errorf(
+			"content: book %s has no Calibre id in a Calibre folder",
+			book.ID)
+	}
+	writer, err := calibre.OpenWriter(folder.RootPath)
+	if err != nil {
+		return fmt.Errorf("content: open Calibre library: %w", err)
+	}
+	defer func() { _ = writer.Close() }()
+
+	switch err := writer.DeleteBook(ctx, *book.CalibreID); {
+	case err == nil, errors.Is(err, calibre.ErrNoSuchBook):
+		return nil
+	default:
+		return err
+	}
+}
+
+// removeUnderRoot is the only way this package deletes a file beneath a
+// watched folder, and the mirror of openUnderRoot: rooted, lstat before
+// touching, symlinks and non-regular files refused.
+//
+// When want is non-nil the file has to still match the catalog row by
+// fileMatches — the same cheap proof a download uses before serving
+// bytes. Opening first and unlinking after would be stronger still,
+// but Linux has no unlink-by-descriptor, so the window between the stat
+// and the unlink stays — narrowed to microseconds under a root that
+// cannot be escaped, which is the same trade every scan in this package
+// already makes.
+func removeUnderRoot(
+	rootPath, relative string, want *store.CatalogBook,
+) error {
+	if rootPath == "" {
+		return ErrRootMissing
+	}
+	if !SafeRelativePath(relative) {
+		return ErrUnsafePath
+	}
+	root, err := os.OpenRoot(rootPath)
+	if err != nil {
+		return fmt.Errorf("%w: %s: %v", ErrRootMissing, rootPath, err)
+	}
+	defer root.Close()
+
+	info, err := root.Lstat(relative)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return ErrUnsafePath
+	}
+	if want != nil && !fileMatches(*want, info) {
+		return ErrRemoveChanged
+	}
+	if err := root.Remove(relative); err != nil &&
+		!errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	return nil
+}

--- a/internal/content/remove_linux_test.go
+++ b/internal/content/remove_linux_test.go
@@ -1,0 +1,217 @@
+//go:build linux
+
+package content
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/chmouel/liseur-sync/internal/calibre"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// placeBook writes a file under a root and answers the catalog row that
+// would describe it, so the change gate has something true to check
+// against.
+func placeBook(t *testing.T, root, relative string, body []byte) store.CatalogBook {
+	t.Helper()
+	full := filepath.Join(root, relative)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(full)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store.CatalogBook{
+		ID:           "book-1",
+		RelativePath: relative,
+		SizeBytes:    info.Size(),
+		MTime:        info.ModTime().UTC(),
+	}
+}
+
+func uploadFolder(root string) store.Folder {
+	return store.Folder{
+		ID: "f1", Kind: store.FolderPlain,
+		RootPath: root, AcceptsUploads: true,
+	}
+}
+
+func TestRemoveDeletesTheFileAndItsCover(t *testing.T) {
+	root := t.TempDir()
+	book := placeBook(t, root, "sub/book.epub", []byte("bytes"))
+	cover := "sub/cover.jpg"
+	if err := os.WriteFile(
+		filepath.Join(root, cover), []byte("jpg"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	book.CoverRelativePath = &cover
+
+	if err := Remove(t.Context(), uploadFolder(root), book); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{book.RelativePath, cover} {
+		if _, err := os.Stat(filepath.Join(root, name)); !os.IsNotExist(err) {
+			t.Errorf("%s survived: %v", name, err)
+		}
+	}
+}
+
+// The flag that bounds writing bounds unwriting. A folder nobody marked
+// is still read-only to this server, and that is checked here rather
+// than only at the handler edge.
+func TestRemoveRefusesAFolderThatDoesNotAcceptUploads(t *testing.T) {
+	root := t.TempDir()
+	book := placeBook(t, root, "book.epub", []byte("bytes"))
+	folder := uploadFolder(root)
+	folder.AcceptsUploads = false
+
+	if err := Remove(t.Context(), folder, book); !errors.Is(
+		err, ErrUploadsRefused,
+	) {
+		t.Fatalf("err = %v, want ErrUploadsRefused", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, book.RelativePath)); err != nil {
+		t.Errorf("the file was deleted anyway: %v", err)
+	}
+}
+
+// There is no trash behind this, so the difference between deleting the
+// book and deleting whatever replaced it is the whole difference.
+func TestRemoveRefusesAFileThatChangedSinceItWasScanned(t *testing.T) {
+	root := t.TempDir()
+	book := placeBook(t, root, "book.epub", []byte("bytes"))
+	if err := os.WriteFile(
+		filepath.Join(root, book.RelativePath),
+		[]byte("a different book entirely"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Remove(t.Context(), uploadFolder(root), book); !errors.Is(
+		err, ErrRemoveChanged,
+	) {
+		t.Fatalf("err = %v, want ErrRemoveChanged", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, book.RelativePath)); err != nil {
+		t.Errorf("the replacement was deleted: %v", err)
+	}
+}
+
+// A pass never records a symlink, so one at a catalog path is something
+// the catalog never validated. Following it would delete outside the
+// folder — the exact reason openUnderRoot refuses them on the way in.
+func TestRemoveRefusesASymlink(t *testing.T) {
+	root := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "somebody-elses.epub")
+	if err := os.WriteFile(outside, []byte("not yours"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "book.epub")); err != nil {
+		t.Fatal(err)
+	}
+	book := store.CatalogBook{ID: "book-1", RelativePath: "book.epub"}
+
+	if err := Remove(t.Context(), uploadFolder(root), book); !errors.Is(
+		err, ErrUnsafePath,
+	) {
+		t.Fatalf("err = %v, want ErrUnsafePath", err)
+	}
+	if _, err := os.Stat(outside); err != nil {
+		t.Errorf("the file the symlink pointed at was deleted: %v", err)
+	}
+}
+
+func TestRemoveRefusesAPathThatEscapesTheRoot(t *testing.T) {
+	root := t.TempDir()
+	book := store.CatalogBook{ID: "book-1", RelativePath: "../escape.epub"}
+	if err := Remove(t.Context(), uploadFolder(root), book); !errors.Is(
+		err, ErrUnsafePath,
+	) {
+		t.Fatalf("err = %v, want ErrUnsafePath", err)
+	}
+}
+
+// The caller's goal is that the file not be there, and it is not.
+func TestRemoveForgivesAFileThatIsAlreadyGone(t *testing.T) {
+	root := t.TempDir()
+	book := placeBook(t, root, "book.epub", []byte("bytes"))
+	if err := os.Remove(filepath.Join(root, book.RelativePath)); err != nil {
+		t.Fatal(err)
+	}
+	if err := Remove(t.Context(), uploadFolder(root), book); err != nil {
+		t.Fatalf("err = %v, want a delete of nothing to succeed", err)
+	}
+}
+
+// A Calibre folder goes the other way round: the row is the book, and
+// the directory comes from metadata.db rather than from the catalog
+// row, which Calibre may have renamed out from under.
+func TestRemoveInACalibreFolderTakesTheRowAndTheDirectory(t *testing.T) {
+	root := writeCalibreLibrary(t)
+	id := int64(1)
+	book := store.CatalogBook{
+		ID:           "book-1",
+		RelativePath: "A Writer/Here (1)/Here.epub",
+		CalibreID:    &id,
+	}
+	folder := store.Folder{
+		ID: "f-calibre", Kind: store.FolderCalibre,
+		RootPath: root, AcceptsUploads: true,
+	}
+
+	if err := Remove(t.Context(), folder, book); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(
+		filepath.Join(root, "A Writer/Here (1)"),
+	); !os.IsNotExist(err) {
+		t.Errorf("the book directory survived: %v", err)
+	}
+	db, err := sql.Open("sqlite", filepath.Join(root, calibre.MetadataDB))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var books int
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM books WHERE id = 1`).Scan(&books); err != nil {
+		t.Fatal(err)
+	}
+	if books != 0 {
+		t.Error("the row survived the delete")
+	}
+	// The other book's row is untouched. Its directory was never on the
+	// disk in this fixture, which is why the author's went with the one
+	// book that was; an author who still holds a book keeps it, and
+	// that is asserted in internal/calibre.
+	if err := db.QueryRow(
+		`SELECT COUNT(*) FROM books WHERE id = 2`).Scan(&books); err != nil {
+		t.Fatal(err)
+	}
+	if books != 1 {
+		t.Error("deleting one book took the other with it")
+	}
+}
+
+// A Calibre row is what makes a Calibre book, so a catalog row without
+// one names nothing this server can safely delete.
+func TestRemoveRefusesACalibreBookWithNoCalibreID(t *testing.T) {
+	root := writeCalibreLibrary(t)
+	folder := store.Folder{
+		ID: "f-calibre", Kind: store.FolderCalibre,
+		RootPath: root, AcceptsUploads: true,
+	}
+	err := Remove(t.Context(), folder, store.CatalogBook{
+		ID: "book-1", RelativePath: "A Writer/Here (1)/Here.epub",
+	})
+	if err == nil {
+		t.Fatal("a Calibre book with no Calibre id was deleted anyway")
+	}
+}

--- a/internal/store/postgres/delete.go
+++ b/internal/store/postgres/delete.go
@@ -22,30 +22,50 @@ func (s *Store) DeleteWork(ctx context.Context, userID, workID string) error {
 		if err := lockWorkGraph(ctx, tx, userID); err != nil {
 			return err
 		}
-		var mapped bool
-		if err := tx.QueryRowContext(ctx, q(
-			`SELECT EXISTS (SELECT 1 FROM user_book_works
-			                 WHERE user_id = ? AND work_id = ?)`),
-			userID, workID).Scan(&mapped); err != nil {
-			return err
-		}
-		if mapped {
+		switch err := deleteWorkTx(ctx, tx, userID, workID); {
+		case errors.Is(err, errWorkStillMapped):
 			return store.ErrInvalidInput
-		}
-		res, err := tx.ExecContext(ctx, q(
-			`DELETE FROM works WHERE user_id = ? AND id = ?`), userID, workID)
-		if err != nil {
+		default:
 			return err
 		}
-		n, err := res.RowsAffected()
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return store.ErrNotFound
-		}
-		return nil
 	})
+}
+
+// errWorkStillMapped is deleteWorkTx refusing a work a catalog book
+// still maps. Its two callers report it differently — a reader asking
+// directly is told no, a reader deleting a book they own a second copy
+// of is told their reading was kept — so the distinction lives here
+// rather than being flattened into ErrInvalidInput too early.
+var errWorkStillMapped = errors.New("work is still mapped by a book")
+
+// deleteWorkTx is DeleteWork without the transaction or the lock, so
+// that deleting a book can forget the caller's reading in the same
+// transaction that removes the book. Both paths share the guard, which
+// is the point: there is one definition of when a work may go.
+func deleteWorkTx(ctx context.Context, tx *sql.Tx, userID, workID string) error {
+	var mapped bool
+	if err := tx.QueryRowContext(ctx, q(
+		`SELECT EXISTS (SELECT 1 FROM user_book_works
+		                 WHERE user_id = ? AND work_id = ?)`),
+		userID, workID).Scan(&mapped); err != nil {
+		return err
+	}
+	if mapped {
+		return errWorkStillMapped
+	}
+	res, err := tx.ExecContext(ctx, q(
+		`DELETE FROM works WHERE user_id = ? AND id = ?`), userID, workID)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
 }
 
 // DeleteMissingBook removes a catalog book a pass already marked
@@ -84,4 +104,84 @@ func (s *Store) DeleteMissingBook(ctx context.Context, bookID string) error {
 		}
 		return collectOrphanEntitiesTx(ctx, tx)
 	})
+}
+
+// DeleteCatalogBook removes a catalog book whose file this server has
+// just deleted (ADR-0025).
+//
+// The shape follows DeleteMissingBook, including taking the shared gate
+// exclusively so that collecting empty works keeps the lock order
+// reconciliation uses. What differs is the guard: not "a pass called
+// this missing" but "an administrator marked this folder writable",
+// because that flag is what makes the file this server's to remove at
+// all, and it is re-read here rather than trusted from the check the
+// caller made before unlinking.
+func (s *Store) DeleteCatalogBook(
+	ctx context.Context, bookID string, opts store.DeleteBookOptions,
+) (store.DeleteBookResult, error) {
+	var out store.DeleteBookResult
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		out = store.DeleteBookResult{}
+		if err := lockAllWorkGraphs(ctx, tx); err != nil {
+			return err
+		}
+		var folderID string
+		var accepts bool
+		err := tx.QueryRowContext(ctx, q(
+			`SELECT b.folder_id, f.accepts_uploads
+			   FROM books b JOIN folders f ON f.id = b.folder_id
+			  WHERE b.id = ? FOR UPDATE OF b`), bookID).Scan(&folderID, &accepts)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return store.ErrNotFound
+			}
+			return err
+		}
+		if !accepts {
+			return store.ErrInvalidInput
+		}
+		// Read before the delete, not after: user_book_works is
+		// cascaded away with the book, so afterwards there is nothing
+		// left to say which work this reader's reading hangs off.
+		var workID string
+		if opts.ForgetReadingFor != "" {
+			err := tx.QueryRowContext(ctx, q(
+				`SELECT work_id FROM user_book_works
+				  WHERE user_id = ? AND book_id = ?`),
+				opts.ForgetReadingFor, bookID).Scan(&workID)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+		}
+		if err := deleteBookTx(ctx, tx, folderID, bookID); err != nil {
+			return err
+		}
+		if workID != "" {
+			switch err := deleteWorkTx(
+				ctx, tx, opts.ForgetReadingFor, workID,
+			); {
+			case err == nil:
+				out.ReadingForgotten = true
+			case errors.Is(err, errWorkStillMapped):
+				// Another catalog book maps this work: a second copy of
+				// the same book, which the reading now belongs to. The
+				// reader asked to forget a book they still have, so the
+				// book goes and the reading stays with the copy.
+				out.ReadingKept = true
+			case errors.Is(err, store.ErrNotFound):
+				// The mapping named a work that is not there. Nothing
+				// to forget, and nothing worth failing a delete over.
+			default:
+				return err
+			}
+		}
+		if err := collectEmptyWorksTx(ctx, tx); err != nil {
+			return err
+		}
+		return collectOrphanEntitiesTx(ctx, tx)
+	})
+	if err != nil {
+		return store.DeleteBookResult{}, err
+	}
+	return out, nil
 }

--- a/internal/store/sqlite/delete.go
+++ b/internal/store/sqlite/delete.go
@@ -22,30 +22,50 @@ func (s *Store) DeleteWork(ctx context.Context, userID, workID string) error {
 		if err := lockWorkGraph(ctx, tx, userID); err != nil {
 			return err
 		}
-		var mapped int
-		if err := tx.QueryRowContext(ctx,
-			`SELECT EXISTS (SELECT 1 FROM user_book_works
-			                 WHERE user_id = ? AND work_id = ?)`,
-			userID, workID).Scan(&mapped); err != nil {
-			return err
-		}
-		if mapped == 1 {
+		switch err := deleteWorkTx(ctx, tx, userID, workID); {
+		case errors.Is(err, errWorkStillMapped):
 			return store.ErrInvalidInput
-		}
-		res, err := tx.ExecContext(ctx,
-			`DELETE FROM works WHERE user_id = ? AND id = ?`, userID, workID)
-		if err != nil {
+		default:
 			return err
 		}
-		n, err := res.RowsAffected()
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return store.ErrNotFound
-		}
-		return nil
 	})
+}
+
+// errWorkStillMapped is deleteWorkTx refusing a work a catalog book
+// still maps. Its two callers report it differently — a reader asking
+// directly is told no, a reader deleting a book they own a second copy
+// of is told their reading was kept — so the distinction lives here
+// rather than being flattened into ErrInvalidInput too early.
+var errWorkStillMapped = errors.New("work is still mapped by a book")
+
+// deleteWorkTx is DeleteWork without the transaction or the lock, so
+// that deleting a book can forget the caller's reading in the same
+// transaction that removes the book. Both paths share the guard, which
+// is the point: there is one definition of when a work may go.
+func deleteWorkTx(ctx context.Context, tx *sql.Tx, userID, workID string) error {
+	var mapped int
+	if err := tx.QueryRowContext(ctx,
+		`SELECT EXISTS (SELECT 1 FROM user_book_works
+		                 WHERE user_id = ? AND work_id = ?)`,
+		userID, workID).Scan(&mapped); err != nil {
+		return err
+	}
+	if mapped == 1 {
+		return errWorkStillMapped
+	}
+	res, err := tx.ExecContext(ctx,
+		`DELETE FROM works WHERE user_id = ? AND id = ?`, userID, workID)
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
 }
 
 // DeleteMissingBook removes a catalog book a pass already marked
@@ -88,4 +108,95 @@ func (s *Store) DeleteMissingBook(ctx context.Context, bookID string) error {
 		}
 		return collectOrphanEntitiesTx(ctx, tx)
 	})
+}
+
+// DeleteCatalogBook removes a catalog book whose file this server has
+// just deleted (ADR-0025).
+//
+// The shape follows DeleteMissingBook, including the no-op write that
+// takes the writer lock before anything is read. What differs is the
+// guard: not "a pass called this missing" but "an administrator marked
+// this folder writable", because that flag is what makes the file this
+// server's to remove at all, and it is re-read here rather than trusted
+// from the check the caller made before unlinking.
+func (s *Store) DeleteCatalogBook(
+	ctx context.Context, bookID string, opts store.DeleteBookOptions,
+) (store.DeleteBookResult, error) {
+	var out store.DeleteBookResult
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		out = store.DeleteBookResult{}
+		if opts.ForgetReadingFor != "" {
+			if err := lockWorkGraph(ctx, tx, opts.ForgetReadingFor); err != nil {
+				return err
+			}
+		}
+		res, err := tx.ExecContext(ctx,
+			`UPDATE books SET id = id WHERE id = ?`, bookID)
+		if err != nil {
+			return err
+		}
+		switch n, err := res.RowsAffected(); {
+		case err != nil:
+			return err
+		case n == 0:
+			return store.ErrNotFound
+		}
+		var folderID string
+		var accepts bool
+		if err := tx.QueryRowContext(ctx,
+			`SELECT b.folder_id, f.accepts_uploads
+			   FROM books b JOIN folders f ON f.id = b.folder_id
+			  WHERE b.id = ?`, bookID).Scan(&folderID, &accepts); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return store.ErrNotFound
+			}
+			return err
+		}
+		if !accepts {
+			return store.ErrInvalidInput
+		}
+		// Read before the delete, not after: user_book_works is
+		// cascaded away with the book, so afterwards there is nothing
+		// left to say which work this reader's reading hangs off.
+		var workID string
+		if opts.ForgetReadingFor != "" {
+			err := tx.QueryRowContext(ctx,
+				`SELECT work_id FROM user_book_works
+				  WHERE user_id = ? AND book_id = ?`,
+				opts.ForgetReadingFor, bookID).Scan(&workID)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return err
+			}
+		}
+		if err := deleteBookTx(ctx, tx, folderID, bookID); err != nil {
+			return err
+		}
+		if workID != "" {
+			switch err := deleteWorkTx(
+				ctx, tx, opts.ForgetReadingFor, workID,
+			); {
+			case err == nil:
+				out.ReadingForgotten = true
+			case errors.Is(err, errWorkStillMapped):
+				// Another catalog book maps this work: a second copy of
+				// the same book, which the reading now belongs to. The
+				// reader asked to forget a book they still have, so the
+				// book goes and the reading stays with the copy.
+				out.ReadingKept = true
+			case errors.Is(err, store.ErrNotFound):
+				// The mapping named a work that is not there. Nothing
+				// to forget, and nothing worth failing a delete over.
+			default:
+				return err
+			}
+		}
+		if err := collectEmptyWorksTx(ctx, tx); err != nil {
+			return err
+		}
+		return collectOrphanEntitiesTx(ctx, tx)
+	})
+	if err != nil {
+		return store.DeleteBookResult{}, err
+	}
+	return out, nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,6 +70,14 @@ const (
 	// because tidying your own shelves and writing to the server's disk
 	// are different questions, and one token should not answer both.
 	ScopeLibraryUpload Scope = "library-upload"
+	// ScopeLibraryDelete permits deleting a book out of a folder that
+	// accepts uploads (ADR-0025). Separate from library-upload for the
+	// reason that one is separate from library-manage: adding your own
+	// book and removing one every account can see are different
+	// questions. It bounds a token rather than dividing users — any
+	// account may mint it — so its job is to stop a sync token from
+	// deleting a library by accident or by compromise.
+	ScopeLibraryDelete Scope = "library-delete"
 	ScopeAdmin         Scope = "admin"
 )
 
@@ -79,7 +87,8 @@ var scopeOrder = map[Scope]int{
 	ScopeLibraryRead:   2,
 	ScopeLibraryManage: 3,
 	ScopeLibraryUpload: 4,
-	ScopeAdmin:         5,
+	ScopeLibraryDelete: 5,
+	ScopeAdmin:         6,
 }
 
 // ScopeSet is the canonical, duplicate-free set of capabilities on a token.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -251,17 +251,19 @@ func (k FolderKind) Valid() bool {
 // It has no owner, no quota principal and no access list. Every
 // signed-in account sees every folder's books; only an administrator
 // sees RootPath, which is a filesystem oracle and not a reader's
-// business. Nothing beneath RootPath is ever written.
+// business. Nothing beneath RootPath is written unless AcceptsUploads
+// says somebody asked for it.
 type Folder struct {
 	ID       string
 	Name     string
 	RootPath string
 	Kind     FolderKind
 	// AcceptsUploads is the one place the server is allowed to write
-	// under a folder root (ADR-0023). It is false unless an
+	// under a folder root (ADR-0023, ADR-0025). It is false unless an
 	// administrator set it, and it is the amendment to ADR-0017's rule
-	// 3: writes happen only where somebody asked for them, and only by
-	// creating a file that was not there.
+	// 3: writes happen only where somebody asked for them — creating a
+	// file that was not there, or deleting one this server could have
+	// created. Never modifying or renaming one.
 	AcceptsUploads bool
 	CreatedAt      time.Time
 	UpdatedAt      time.Time

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -267,6 +267,28 @@ type Folder struct {
 	UpdatedAt      time.Time
 }
 
+// DeleteBookOptions tunes deleting a catalog book (ADR-0025).
+type DeleteBookOptions struct {
+	// ForgetReadingFor is the reader whose work goes with the book, or
+	// empty to leave every reader's reading behind. It is only ever one
+	// reader — the one who asked — because a work is per-user and the
+	// caller has no standing to forget anybody else's (ADR-0024).
+	ForgetReadingFor string
+}
+
+// DeleteBookResult reports what happened to the caller's reading, which
+// they cannot infer from success alone.
+type DeleteBookResult struct {
+	// ReadingForgotten is true when the caller's work went with the
+	// book.
+	ReadingForgotten bool
+	// ReadingKept is true when forgetting was asked for and declined
+	// because another catalog book still maps that work — a second copy
+	// of the same book, which the reading now belongs to. Not a failure:
+	// the reader asked to forget a book they still have.
+	ReadingKept bool
+}
+
 // FolderCursor is the opaque pagination cursor of the folder list,
 // ordered by name then id. The id comes first because it cannot contain
 // a space and a folder name can contain anything, so cutting at the
@@ -1176,6 +1198,22 @@ type Store interface {
 	// deleted with it — a work with reading history survives its book
 	// and becomes an entry only its own reader can remove.
 	DeleteMissingBook(ctx context.Context, bookID string) error
+	// DeleteCatalogBook removes one catalog book whose file this server
+	// has just deleted (ADR-0025), with the same cascade and the same
+	// entity collection DeleteMissingBook runs.
+	//
+	// It is the counterpart of an upload, and bounded the same way: a
+	// book whose folder does not accept uploads is ErrInvalidInput, and
+	// that is re-read inside the transaction rather than trusted from a
+	// check the caller made earlier. Unlike DeleteMissingBook it does
+	// not require the book to be marked missing — the file is already
+	// gone by the time this is called, so no pass will put it back.
+	//
+	// ForgetReadingFor names the one reader whose work goes with it, and
+	// only ever theirs.
+	DeleteCatalogBook(
+		ctx context.Context, bookID string, opts DeleteBookOptions,
+	) (DeleteBookResult, error)
 
 	// -----------------------------------------------------------------
 	// Reconciliation.

--- a/internal/store/storetest/delete.go
+++ b/internal/store/storetest/delete.go
@@ -3,6 +3,7 @@ package storetest
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -250,5 +251,212 @@ func testDeleteMissingBook(t *testing.T, open OpenFunc) {
 	// And the reader can now remove the work the book left behind.
 	if err := s.DeleteWork(ctx, u.ID, surviving.ID); err != nil {
 		t.Fatalf("DeleteWork on the orphan the delete created: %v", err)
+	}
+}
+
+// mkUploadFolder is a folder an administrator marked writable, which is
+// the only kind a book can be deleted out of (ADR-0025).
+func mkUploadFolder(t *testing.T, s store.Store, name string) store.Folder {
+	t.Helper()
+	f := MkFolder(t, s, name, store.FolderPlain)
+	if err := s.SetFolderUploads(
+		context.Background(), f.ID, true, time.Now().UTC(),
+	); err != nil {
+		t.Fatal(err)
+	}
+	f.AcceptsUploads = true
+	return f
+}
+
+// testDeleteCatalogBook is the delete an upload earns: a book in a
+// folder the server may write into leaves the catalog, and one in a
+// folder it may not is refused however it is asked.
+func testDeleteCatalogBook(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	writable := mkUploadFolder(t, s, "deletable")
+	doReconcile(t, s, writable.ID, []store.ObservedBook{{
+		RelativePath: "sent.epub", SizeBytes: 1, MTime: now,
+		ContentSHA256: "sha-sent", Title: "Sent",
+	}}, true, now)
+	sentID := knownByPath(t, s, writable.ID)["sent.epub"].ID
+
+	// A folder nobody marked is what every folder used to be: observed,
+	// never written, and not this server's to delete out of.
+	readOnly := MkFolder(t, s, "curated", store.FolderPlain)
+	doReconcile(t, s, readOnly.ID, []store.ObservedBook{{
+		RelativePath: "theirs.epub", SizeBytes: 1, MTime: now,
+		ContentSHA256: "sha-theirs-file", Title: "Theirs",
+	}}, true, now)
+	theirsID := knownByPath(t, s, readOnly.ID)["theirs.epub"].ID
+
+	if _, err := s.DeleteCatalogBook(
+		ctx, theirsID, store.DeleteBookOptions{},
+	); !errors.Is(err, store.ErrInvalidInput) {
+		t.Fatalf("deleting out of a folder that takes no uploads: "+
+			"want ErrInvalidInput, got %v", err)
+	}
+	if _, err := s.CatalogBookByID(ctx, theirsID); err != nil {
+		t.Fatalf("a refused delete took the book anyway: %v", err)
+	}
+
+	if _, err := s.DeleteCatalogBook(
+		ctx, sentID, store.DeleteBookOptions{},
+	); err != nil {
+		t.Fatalf("DeleteCatalogBook: %v", err)
+	}
+	if _, err := s.CatalogBookByID(ctx, sentID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("the book survived its own deletion: %v", err)
+	}
+	if _, err := s.DeleteCatalogBook(
+		ctx, sentID, store.DeleteBookOptions{},
+	); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("deleting a book twice: want ErrNotFound, got %v", err)
+	}
+	if _, err := s.DeleteCatalogBook(
+		ctx, "b-never-existed", store.DeleteBookOptions{},
+	); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("deleting an unknown book: want ErrNotFound, got %v", err)
+	}
+}
+
+// testDeleteCatalogBookForgetsOneReader is the second question the
+// delete asks. The file is shared, so it goes for everybody; the
+// reading is per-user, so only the reader who asked loses theirs.
+func testDeleteCatalogBookForgetsOneReader(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	mine := MkUser(t, s, "forget-mine")
+	theirs := MkUser(t, s, "forget-theirs")
+
+	folder := mkUploadFolder(t, s, "shared")
+	doReconcile(t, s, folder.ID, []store.ObservedBook{{
+		RelativePath: "shared.epub", SizeBytes: 1, MTime: now,
+		ContentSHA256: "sha-shared", Title: "Shared",
+	}}, true, now)
+	bookID := knownByPath(t, s, folder.ID)["shared.epub"].ID
+
+	readIt := func(u store.User, workID string) {
+		t.Helper()
+		w := store.Work{ID: workID, UserID: u.ID, Title: "Shared", CreatedAt: now}
+		if _, err := s.ResolveCatalogBookWork(ctx, u.ID, bookID, w,
+			[]store.Edition{{UserID: u.ID, SHA256: "sha-shared", WorkID: workID}},
+			[]store.Identifier{{Kind: "sha256", Value: "sha-shared"}},
+			false, now); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := s.AppendOps(ctx, u.ID, "d-"+workID, []store.Op{{
+			OpID:   "018e6f1a-0000-7000-8000-00000000" + workID[len(workID)-4:],
+			WorkID: workID, EditionSHA: Ptr("sha-shared"), ClientTS: now,
+			Progression: 0.3, Origin: store.OriginNative,
+		}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	readIt(mine, "w-fa01")
+	readIt(theirs, "w-fa02")
+
+	out, err := s.DeleteCatalogBook(ctx, bookID, store.DeleteBookOptions{
+		ForgetReadingFor: mine.ID,
+	})
+	if err != nil {
+		t.Fatalf("DeleteCatalogBook: %v", err)
+	}
+	if !out.ReadingForgotten || out.ReadingKept {
+		t.Fatalf("result = %+v, want the caller's reading forgotten", out)
+	}
+	if _, err := s.WorkByID(ctx, mine.ID, "w-fa01"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("the caller asked to forget and did not: %v", err)
+	}
+	// The other reader never asked, so their reading survives as the
+	// bookless work only they can remove (ADR-0024).
+	if _, err := s.WorkByID(ctx, theirs.ID, "w-fa02"); err != nil {
+		t.Fatalf("one reader's delete took another's reading: %v", err)
+	}
+	if err := s.DeleteWork(ctx, theirs.ID, "w-fa02"); err != nil {
+		t.Fatalf("the surviving work is not its own reader's to remove: %v", err)
+	}
+}
+
+// testDeleteCatalogBookKeepsReadingASecondCopyHolds is the case a
+// per-user, per-book mapping makes possible: the same book twice, one
+// work behind both. Deleting one copy must not take reading the other
+// still holds, and the reader is told so rather than told it failed.
+func testDeleteCatalogBookKeepsReadingASecondCopyHolds(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	u := MkUser(t, s, "two-copies")
+
+	folder := mkUploadFolder(t, s, "twice")
+	doReconcile(t, s, folder.ID, []store.ObservedBook{{
+		RelativePath: "first.epub", SizeBytes: 1, MTime: now,
+		ContentSHA256: "sha-first", Title: "Twice",
+	}, {
+		RelativePath: "second.epub", SizeBytes: 2, MTime: now,
+		ContentSHA256: "sha-second", Title: "Twice",
+	}}, true, now)
+	byPath := knownByPath(t, s, folder.ID)
+
+	// Two files, one book: they differ byte for byte, so the catalog
+	// keeps them apart, but they carry the same partial-md5 and so
+	// resolve to one work — which is the reader's position in a book
+	// they happen to hold twice.
+	var workID string
+	for i, b := range []struct{ id, sha string }{
+		{byPath["first.epub"].ID, "sha-first"},
+		{byPath["second.epub"].ID, "sha-second"},
+	} {
+		proposed := store.Work{
+			ID:     fmt.Sprintf("w-twice-%d", i),
+			UserID: u.ID, Title: "Twice", CreatedAt: now,
+		}
+		res, err := s.ResolveCatalogBookWork(ctx, u.ID, b.id, proposed,
+			[]store.Edition{{UserID: u.ID, SHA256: b.sha, WorkID: proposed.ID}},
+			[]store.Identifier{
+				{Kind: "sha256", Value: b.sha},
+				{Kind: "partial-md5", Value: "md5-twice"},
+			},
+			false, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if workID == "" {
+			workID = res.WorkID
+		} else if res.WorkID != workID {
+			t.Fatalf("the second copy resolved to work %q, want %q: "+
+				"this test needs one work behind both books",
+				res.WorkID, workID)
+		}
+	}
+	w := store.Work{ID: workID}
+
+	out, err := s.DeleteCatalogBook(ctx, byPath["first.epub"].ID,
+		store.DeleteBookOptions{ForgetReadingFor: u.ID})
+	if err != nil {
+		t.Fatalf("DeleteCatalogBook: %v", err)
+	}
+	if out.ReadingForgotten || !out.ReadingKept {
+		t.Fatalf("result = %+v, want the reading kept by the second copy", out)
+	}
+	if _, err := s.WorkByID(ctx, u.ID, w.ID); err != nil {
+		t.Fatalf("reading a second copy still holds was deleted: %v", err)
+	}
+
+	// With the last copy gone there is nothing left to hold it, so the
+	// same request now forgets.
+	out, err = s.DeleteCatalogBook(ctx, byPath["second.epub"].ID,
+		store.DeleteBookOptions{ForgetReadingFor: u.ID})
+	if err != nil {
+		t.Fatalf("DeleteCatalogBook: %v", err)
+	}
+	if !out.ReadingForgotten || out.ReadingKept {
+		t.Fatalf("result = %+v, want the reading forgotten", out)
+	}
+	if _, err := s.WorkByID(ctx, u.ID, w.ID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("the last copy went and the reading stayed: %v", err)
 	}
 }

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -203,6 +203,15 @@ func Run(t *testing.T, open OpenFunc) {
 	t.Run("DeleteMissingBook", func(t *testing.T) {
 		testDeleteMissingBook(t, open)
 	})
+	t.Run("DeleteCatalogBook", func(t *testing.T) {
+		testDeleteCatalogBook(t, open)
+	})
+	t.Run("DeleteCatalogBookForgetsOneReader", func(t *testing.T) {
+		testDeleteCatalogBookForgetsOneReader(t, open)
+	})
+	t.Run("DeleteCatalogBookKeepsReadingASecondCopyHolds", func(t *testing.T) {
+		testDeleteCatalogBookKeepsReadingASecondCopyHolds(t, open)
+	})
 	t.Run("ReconcileCalibreDigestChangeFollowsReader", func(t *testing.T) {
 		testReconcileCalibreDigestChangeFollowsReader(t, open)
 	})

--- a/internal/webui/adminusers.templ
+++ b/internal/webui/adminusers.templ
@@ -217,6 +217,7 @@ templ adminUserBody(prefix string, csrf string, v adminUserView, flash Flash) {
 			@scopeChoice(store.ScopeLibraryRead, false)
 			@scopeChoice(store.ScopeLibraryManage, false)
 			@scopeChoice(store.ScopeLibraryUpload, false)
+			@scopeChoice(store.ScopeLibraryDelete, false)
 			if v.User.IsAdmin {
 				@scopeChoice(store.ScopeAdmin, false)
 			}

--- a/internal/webui/books.go
+++ b/internal/webui/books.go
@@ -141,9 +141,17 @@ func (s *Server) bookView(r *http.Request, u *store.User, bookID string) (BookVi
 	// only where it would stick: a Calibre folder's metadata.db is
 	// authoritative, so a book it still lists comes back on the next
 	// pass (ADR-0022, ADR-0024).
-	if !v.Present && isAdmin(r) {
+	// Deleting a book outright is the other write, and bounded by the
+	// flag that bounds uploading: a folder nobody marked as accepting
+	// one is still read-only to this server (ADR-0023, ADR-0025). Admin
+	// rather than a scope, because a browser session carries no scopes
+	// — the account carries the role.
+	if isAdmin(r) {
 		if folder, err := s.St.FolderByID(r.Context(), book.FolderID); err == nil {
-			v.Retirable = folder.Kind != store.FolderCalibre
+			if !v.Present {
+				v.Retirable = folder.Kind != store.FolderCalibre
+			}
+			v.Deletable = v.Present && folder.AcceptsUploads && s.Deletes != nil
 		}
 	}
 	if rel, err := s.St.CatalogBookRelationsForBooks(

--- a/internal/webui/books.templ
+++ b/internal/webui/books.templ
@@ -55,8 +55,13 @@ type BookView struct {
 	// Calibre folder, where metadata.db is authoritative and the next
 	// pass would put the book back (ADR-0022, ADR-0024).
 	Retirable bool
-	Notice  string
-	Problem string
+	// Deletable is a book an administrator may delete outright: file,
+	// row and all. Only where a book could have been uploaded in the
+	// first place, because that flag is what marks the one place this
+	// server may write under a folder root (ADR-0023, ADR-0025).
+	Deletable bool
+	Notice    string
+	Problem   string
 	// Chips are the book's entities as links: the fastest way from one
 	// book to the rest of its author or its series.
 	Authors []ChipLink
@@ -180,6 +185,26 @@ templ bookBody(prefix, csrf string, b BookView) {
 					<td><a href={ prefix + "books/" + b.ID + "/download" }>Download</a></td>
 				</tr>
 			</table>
+			if b.Deletable {
+				<form
+					method="post"
+					action={ prefix + "books/" + b.ID + "/destroy" }
+					hx-confirm="Delete this book from the server? The file itself is deleted, for every device. This cannot be undone."
+				>
+					<input type="hidden" name="csrf" value={ csrf }/>
+					<button class="danger" type="submit">Delete this book</button>
+					<label class="muted">
+						<input type="checkbox" name="forget_reading" value="true"/>
+						Also delete my reading history for it
+					</label>
+					<span class="muted">
+						The file is deleted from this server's disk. There is no
+						trash to take it back out of. Everybody's reading survives
+						unless they remove it themselves; the box above removes
+						yours.
+					</span>
+				</form>
+			}
 		}
 	</section>
 	<p><a href={ prefix + "library?folder=" + b.FolderID }>Back to the library</a></p>

--- a/internal/webui/books_ext_test.go
+++ b/internal/webui/books_ext_test.go
@@ -91,16 +91,18 @@ func newBooksFixture(t *testing.T) *booksFixture {
 	cfg.InsecureHTTP = true
 	reconciler := content.NewReconciler(st, content.ScanLimits{},
 		cfg.EPUBLimits(), nil)
+	ingester := content.NewIngester(reconciler)
 	apiSrv := &api.Server{
 		St: st, Auth: auth.NewService(st), Cfg: cfg,
 		LoginLimiter: auth.NewRateLimiter(100, time.Minute),
 		Files:        content.NewFiles(st), Covers: cache,
-		Ingest: content.NewIngester(reconciler),
+		Ingest: ingester, Removal: ingester,
 	}
 	ui := &webui.Server{
 		St: st, Auth: auth.NewService(st), Cfg: cfg,
 		LoginLimiter: auth.NewRateLimiter(100, time.Minute),
 		Downloads:    apiSrv, Covers: apiSrv, Uploads: apiSrv,
+		Deletes: apiSrv,
 	}
 	mux := http.NewServeMux()
 	ui.Mount(mux, func(h http.Handler) http.Handler { return h })

--- a/internal/webui/delete.go
+++ b/internal/webui/delete.go
@@ -1,15 +1,20 @@
 package webui
 
-// Deleting: the two ways something leaves this server from a browser.
+// Deleting: the ways something leaves this server from a browser.
 //
-// They are deliberately different things. A reader deletes their own
-// work — the reading, not a file — and may only do it when no catalog
-// book backs it any more, so a disk that is merely unplugged never
-// costs anybody their history. An administrator deletes a catalog row
-// whose file a pass already reported missing, which is a decision that
-// the file is not coming back; the folder on disk is untouched either
-// way, because those files were never this server's to delete
-// (ADR-0017, ADR-0024).
+// The two here are deliberately different things. A reader deletes
+// their own work — the reading, not a file — and may only do it when no
+// catalog book backs it any more, so a disk that is merely unplugged
+// never costs anybody their history. An administrator deletes a catalog
+// row whose file a pass already reported missing, which is a decision
+// that the file is not coming back. Neither touches the folder on disk,
+// because those files were never this server's to delete (ADR-0017,
+// ADR-0024).
+//
+// The third is in librarydelete.go, and is the exception that names the
+// rule: a book this server could have written itself, in a folder an
+// administrator marked as accepting uploads, may be deleted outright —
+// file and all (ADR-0023, ADR-0025).
 
 import (
 	"errors"

--- a/internal/webui/devices.templ
+++ b/internal/webui/devices.templ
@@ -54,6 +54,7 @@ templ devicesBody(prefix string, csrf string, toks []store.Token, browsers []bro
 								@scopeChoice(store.ScopeLibraryRead, hasScope(t.Scopes, store.ScopeLibraryRead))
 								@scopeChoice(store.ScopeLibraryManage, hasScope(t.Scopes, store.ScopeLibraryManage))
 								@scopeChoice(store.ScopeLibraryUpload, hasScope(t.Scopes, store.ScopeLibraryUpload))
+								@scopeChoice(store.ScopeLibraryDelete, hasScope(t.Scopes, store.ScopeLibraryDelete))
 								<button type="submit">Update</button>
 							</form>
 						} else {
@@ -87,6 +88,7 @@ templ devicesBody(prefix string, csrf string, toks []store.Token, browsers []bro
 			@scopeChoice(store.ScopeLibraryRead, false)
 			@scopeChoice(store.ScopeLibraryManage, false)
 			@scopeChoice(store.ScopeLibraryUpload, false)
+			@scopeChoice(store.ScopeLibraryDelete, false)
 			<button type="submit" class="primary">New token</button>
 		</form>
 	</section>

--- a/internal/webui/librarydelete.go
+++ b/internal/webui/librarydelete.go
@@ -1,0 +1,76 @@
+package webui
+
+// Deleting a book from a browser (ADR-0025).
+//
+// The rules about what may be deleted where are not here. They are in
+// the API's DeleteBook, which this delegates to through the Deleter
+// interface, exactly as uploads delegate through Uploader: there is one
+// implementation of "a book may be deleted where a book may be
+// written", and two ways of asking for it.
+//
+// What is here is the browser's half — the session, the CSRF token, and
+// turning an answer into a sentence on the page the form came from.
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// Deleter removes one book from the server: its file, its catalog row,
+// and optionally the caller's own reading of it. It is an interface so
+// this package keeps depending on nothing but the store, and so a nil
+// value hides the control rather than showing one that cannot work.
+type Deleter interface {
+	DeleteBookFrom(
+		ctx context.Context, bookID, userID string, forgetReading bool,
+	) (title string, readingForgotten, readingKept bool, err error)
+}
+
+// handleDeleteBookFile implements POST /ui/books/{id}/destroy.
+//
+// Named for what it does rather than matching its sibling's route: this
+// server already had a /delete on a book, and the two are genuinely
+// different decisions. That one retires a row whose file a pass proved
+// gone; this one deletes the file.
+func (s *Server) handleDeleteBookFile(
+	w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User,
+) {
+	if !s.checkCSRF(r, a) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	bookID := r.PathValue("id")
+	back := relPrefix(r.URL.Path) + "library"
+	if book, err := s.St.CatalogBookByID(r.Context(), bookID); err == nil {
+		back += "?folder=" + url.QueryEscape(book.FolderID)
+	}
+	if s.Deletes == nil {
+		s.deleteDone(w, back, "", "this server cannot delete books")
+		return
+	}
+	title, forgotten, kept, err := s.Deletes.DeleteBookFrom(
+		r.Context(), bookID, u.ID, r.FormValue("forget_reading") == "true")
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		http.NotFound(w, r)
+		return
+	case err != nil:
+		s.deleteDone(w, back, "", err.Error())
+		return
+	}
+	notice := "deleted " + title
+	switch {
+	case forgotten:
+		notice += ", and your reading of it"
+	case kept:
+		// Not a failure worth a red banner: another copy of the same
+		// book still holds the reading, so forgetting it would take a
+		// position the reader is still using.
+		notice += "; your reading stays with the other copy you have"
+	}
+	s.deleteDone(w, back, notice, "")
+}

--- a/internal/webui/librarydelete_ext_test.go
+++ b/internal/webui/librarydelete_ext_test.go
@@ -1,0 +1,105 @@
+//go:build linux
+
+package webui_test
+
+import (
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Deleting a book outright from the browser (ADR-0025). This is the one
+// control on this server that destroys a reader's bytes, so what these
+// tests are mostly about is where it does not appear.
+
+func TestDeleteBookFileIsOfferedOnlyWhereABookCouldBeUploaded(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "here", []byte(strings.Repeat("here", 80)))
+	allowUploads(t, f)
+
+	// Never to an ordinary reader, who has no role for it. The last
+	// enabled admin cannot be demoted, so the plain reader is the
+	// fixture's own account before it is promoted.
+	_, page := f.get(t, "/ui/books/"+bookID, f.cookie)
+	if strings.Contains(page, bookID+"/destroy") {
+		t.Fatalf("a plain reader was offered the delete:\n%s", page)
+	}
+	if resp := f.postForm(t, "/ui/books/"+bookID+"/destroy", f.cookie,
+		url.Values{"csrf": {csrfFrom(t, page)}}); resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("a plain reader deleting a book: status %d", resp.StatusCode)
+	}
+	if _, err := os.Stat(filepath.Join(f.root, "here.epub")); err != nil {
+		t.Errorf("the file went anyway: %v", err)
+	}
+
+	admin := makeAdmin(t, f)
+	_, page = f.get(t, "/ui/books/"+bookID, admin)
+	if !strings.Contains(page, `action="../books/`+bookID+`/destroy"`) {
+		t.Fatalf("an admin was not offered the delete:\n%s", page)
+	}
+}
+
+// A folder nobody marked as accepting uploads is still read-only to
+// this server, even to an administrator: that flag is the whole
+// permission (ADR-0023, ADR-0025).
+func TestDeleteBookFileIsNotOfferedInAFolderThatAcceptsNoUploads(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "elsewhere", []byte(strings.Repeat("else", 80)))
+	admin := makeAdmin(t, f)
+
+	_, page := f.get(t, "/ui/books/"+bookID, admin)
+	if strings.Contains(page, bookID+"/destroy") {
+		t.Fatalf("a delete was offered in a folder that accepts no uploads:\n%s", page)
+	}
+	if resp := f.postForm(t, "/ui/books/"+bookID+"/destroy", admin,
+		url.Values{"csrf": {csrfFrom(t, page)}}); !strings.Contains(
+		resp.Header.Get("Location"), "problem=") {
+		t.Fatalf("the route allowed it anyway: %d %v", resp.StatusCode, resp.Header)
+	}
+	if _, err := os.Stat(filepath.Join(f.root, "elsewhere.epub")); err != nil {
+		t.Errorf("the file was deleted anyway: %v", err)
+	}
+}
+
+func TestDeleteBookFileTakesTheFileAndTheRow(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "doomed", []byte(strings.Repeat("doom", 80)))
+	allowUploads(t, f)
+	admin := makeAdmin(t, f)
+
+	_, page := f.get(t, "/ui/books/"+bookID, admin)
+	resp := f.postForm(t, "/ui/books/"+bookID+"/destroy", admin,
+		url.Values{"csrf": {csrfFrom(t, page)}})
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("delete: status %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Location"); !strings.Contains(got, "notice=deleted") {
+		t.Fatalf("the delete sent the browser to %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(f.root, "doomed.epub")); !os.IsNotExist(err) {
+		t.Errorf("the file survived: %v", err)
+	}
+	if _, err := f.st.CatalogBookByID(t.Context(), bookID); err == nil {
+		t.Error("the catalog row survived")
+	}
+}
+
+// A delete that destroys bytes is exactly the request an attacker would
+// like to make on somebody else's behalf.
+func TestDeleteBookFileNeedsTheCSRFToken(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "safe", []byte(strings.Repeat("safe", 80)))
+	allowUploads(t, f)
+	admin := makeAdmin(t, f)
+
+	if resp := f.postForm(t, "/ui/books/"+bookID+"/destroy", admin,
+		url.Values{}); resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("a delete with no CSRF token: status %d", resp.StatusCode)
+	}
+	if _, err := os.Stat(filepath.Join(f.root, "safe.epub")); err != nil {
+		t.Errorf("the file went without a token: %v", err)
+	}
+}

--- a/internal/webui/readerbrowser_ext_test.go
+++ b/internal/webui/readerbrowser_ext_test.go
@@ -26,6 +26,12 @@ func findChrome() string {
 	if named := os.Getenv("LISEUR_CHROME"); named != "" {
 		return named
 	}
+	// Hosted CI images may include Chrome incidentally. This is an
+	// opt-in browser check, so a runner image change must not turn it
+	// into a flaky gate; LISEUR_CHROME above remains the explicit opt-in.
+	if os.Getenv("CI") != "" {
+		return ""
+	}
 	for _, name := range []string{
 		"chromium", "chromium-browser", "google-chrome", "google-chrome-stable", "chrome",
 	} {
@@ -45,6 +51,15 @@ func findChrome() string {
 		return found[len(found)-1]
 	}
 	return ""
+}
+
+func TestFindChromeDoesNotAutoDiscoverInCI(t *testing.T) {
+	t.Setenv("CI", "1")
+	t.Setenv("LISEUR_CHROME", "")
+
+	if got := findChrome(); got != "" {
+		t.Fatalf("findChrome() = %q in CI without explicit opt-in, want empty", got)
+	}
 }
 
 // browserTestEPUB is a small but real publication, and it is deliberately

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -55,6 +55,9 @@ type Server struct {
 	// set of rules about what may be written into a folder. Nil hides
 	// the form rather than showing one that cannot work.
 	Uploads Uploader
+	// Deletes takes a book back out of a folder that accepts uploads
+	// (ADR-0025). Nil hides the control.
+	Deletes Deleter
 	// Watching is told about a folder the moment somebody adds or
 	// removes one, so "add a folder and the books show up" is true
 	// without a restart. Nil means the server was started without a
@@ -287,6 +290,12 @@ func (s *Server) Mount(mux *http.ServeMux, secure func(http.Handler) http.Handle
 	mux.Handle("POST /ui/works/{id}/delete", sec(s.requireAuth(s.handleDeleteWork)))
 	mux.Handle("POST /ui/books/{id}/delete",
 		sec(s.requireAdmin(s.handleDeleteMissingBook)))
+	// Deleting a book outright (ADR-0025). Admin, because a browser
+	// session carries no scopes at all — the account carries the role,
+	// a token carries capabilities — so there is nothing here to check
+	// library-delete against.
+	mux.Handle("POST /ui/books/{id}/destroy",
+		sec(s.requireAdmin(s.handleDeleteBookFile)))
 	mux.Handle("POST /ui/books/{id}/series/reset",
 		sec(s.requireAuth(s.handleSeriesReset)))
 	// Renaming a series (ADR-0020). The reset arrives on the same route


### PR DESCRIPTION
## Summary

Adds end-to-end book deletion for folders that are explicitly marked to accept uploads. This gives clients and administrators a way to remove an incorrectly uploaded or duplicate book while keeping the server's read-only behavior for all other folders.

## What changed

- Adds `DELETE /v1/books/{id}`, protected by a dedicated `library-delete` capability rather than implicitly granting deletion to upload tokens.
- Adds an administrator-only browser action with CSRF protection, alongside the existing library controls.
- Restricts deletion to `accepts_uploads` folders. Plain-folder deletion validates the cataloged file before removing it; Calibre deletion uses the authoritative library metadata and transaction so renamed book directories and dependent records are handled safely.
- Keeps every reader's history by default. An optional request removes only the caller's own reading history, and preserves it when another copy still maps the same work.
- Returns explicit refusal responses for unsupported folders, changed files, busy Calibre libraries, and other unsafe deletion conditions; the operation is irreversible because there is no trash layer.

## Validation and documentation

Adds coverage for API and browser permissions, CSRF protection, file-change safety, catalog cleanup, per-user reading behavior, both storage backends, and Calibre trigger/path behavior. Updates the API contract, integration guidance, design rules, and ADR-0025 to document the new deletion semantics.

## What it looks like

<img src="https://github.com/user-attachments/assets/849b9cde-d2b2-45e4-9707-dcdb8d89c99e" alt="web-delete.png" width="700">
