### PR TITLE
fix: harden credential enrolment

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -75,8 +75,9 @@ and go out in the next release; there are no backports to older tags.
 - terminate TLS in front of the server and leave `insecure_http =
   false`. Set `trusted_proxies` to the proxy's address so
   `X-Forwarded-Proto` is honoured only from it.
-- leave registration invite-only; hand out invite codes instead of
-  sharing an account.
+- registration is invite-only; hand out invite codes instead of sharing an
+  account. Creating an account or invite in the administration panel requires
+  the acting administrator's password again.
 - give each device its own token so a lost e-reader costs one
   revocation, and enable only the adapters you use.
 - keep backups of the database — it holds the only copy of the op log.
@@ -95,6 +96,8 @@ tests:
   `/v1/register`, and the adapter pairing endpoints
 - credential-bearing routes refuse plain HTTP unless `insecure_http` is
   set; web UI mutations require a per-session CSRF token
+- web creation of an account or invite additionally re-verifies the acting
+  administrator on independent per-account and per-address rate limits
 - tenant isolation and the route/scope matrix have dedicated tests; the
   CI suite runs `go vet` and the full race-enabled tests against both
   SQLite and PostgreSQL on every pull request

--- a/cmd/liseur-sync/main.go
+++ b/cmd/liseur-sync/main.go
@@ -187,7 +187,6 @@ func cmdServe(args []string) error {
 		Kosync: &kosync.Server{
 			St:          st,
 			Cfg:         cfg,
-			OpenReg:     cfg.OpenRegistration,
 			PairingTTL:  time.Duration(cfg.PairingCodeTTLMin) * time.Minute,
 			AuthRateLim: auth.NewRateLimiter(10, time.Minute),
 		},

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -337,7 +337,7 @@ Implements the four calls KOReader's kosync plugin makes:
 
 | kosync call | Translation |
 |---|---|
-| `POST /users/create` | Creates a device credential bound to an existing liseur-sync user via a one-time pairing code used as the kosync password. Open registration is off by default. |
+| `POST /users/create` | Creates a device credential bound to an existing liseur-sync user via a valid, unexpired, single-use pairing code used as the kosync password. It never creates an account. |
 | `GET /users/auth` | Validates the device credential. |
 | `PUT /syncs/progress` | Resolves `document` (a partialMD5) via the alias table, then appends a native op with `origin: kosync`, `foreign_pos` = the xpointer, `progression` = percentage. |
 | `GET /syncs/progress/:document` | Returns the newest op: `progress` = stored `foreign_pos` if the newest op has one, else the percentage string; `percentage`, `device`, `timestamp` filled natively. |
@@ -390,7 +390,9 @@ Designed as the direct negation of the KoInsight findings.
   registration, health, and adapter-pairing routes. There is no
   anonymous catalog read; CORS is deny-by-default with an explicit
   origin allowlist.
-- Registration is invite-only by default.
+- Registration is invite-only. An administrator can also create an account
+  directly, and both account and invite creation in the panel re-verify the
+  acting administrator's password before minting durable access.
 - Per-token and per-IP rate limits protect auth endpoints; credential checks
   use constant-time compares.
 - Reading state is scoped by `user_id` at
@@ -406,6 +408,8 @@ KOReader cannot do better. Containment:
 
 - The kosync user/password pair is a dedicated pairing credential, never
   the account password.
+- `POST /adapter/kosync/users/create` accepts only a one-time pairing code;
+  supplying an account password creates neither an account nor a device.
 - Compromise of that key exposes exactly one
   revocable device slot with `sync` scope, not the account.
 - The kosync

--- a/docs/adr/0026-credential-enrolment-does-not-weaken-account-authentication.md
+++ b/docs/adr/0026-credential-enrolment-does-not-weaken-account-authentication.md
@@ -1,0 +1,153 @@
+# ADR-0026: Credential enrolment does not weaken account authentication
+
+- **Status:** Accepted
+- **Date:** 2026-08-19
+- **Depends on:** [ADR-0013](0013-admin-panel.md)
+- **Amends:** ADR-0013's definition of high-impact administration, and
+  sections 7.1, 8.2 and 8.3 of [DESIGN.md](../DESIGN.md)
+
+## Context
+
+The server has two ways to establish durable access that do not meet the
+security rules around them.
+
+The first is kosync open registration. Stock KOReader sends one value in its
+`password` field and later authenticates with a key derived from that value by
+MD5. The normal liseur-sync flow treats the value as a short-lived pairing
+code: it creates one revocable device credential for an existing account, and
+it is never the account password.
+
+With `open_registration` enabled, the same value instead becomes both the new
+account's password and the kosync device secret. The database then contains an
+Argon2id password hash and a SHA-256 hash of the MD5-derived device key. An
+attacker with the database can test password guesses against the latter with
+two fast hashes, bypassing the cost that Argon2id exists to impose. The outer
+SHA-256 protects the stored device credential from direct use; it does not
+make a human password expensive to guess.
+
+There is no way to repair that mode while keeping its contract. The protocol
+supplies one secret, but an account password and a device credential must be
+independent secrets. Inventing an account password would leave the new user
+unable to sign in, while returning a second secret would no longer be stock
+kosync registration.
+
+The second gap is in the administration panel. ADR-0013 requires the acting
+administrator to re-enter their password before a high-impact mutation. That
+check is independently rate-limited by account and client address so that a
+stolen browser session is not enough to take over another account or mint a
+credential for it.
+
+Creating an account and creating an invite currently require an administrator
+session and its CSRF token, but not the administrator's password. CSRF stops a
+different site from driving the browser; it does not constrain somebody who
+possesses the session, because that person can load the form and receive its
+CSRF token. Either action lets such an attacker establish access that survives
+revocation of the stolen session. An invited or administrator-created account
+can then sign in and mint any non-admin scope for itself.
+
+## Decision
+
+### Kosync enrols a device; it never creates an account
+
+Remove open registration. `POST /adapter/kosync/users/create` always consumes
+a valid, unexpired, single-use pairing code and creates one kosync device slot
+for the account that issued it. Supplying an account password to that route
+never creates an account and never creates a device credential.
+
+Remove `open_registration`, `LISEUR_OPEN_REGISTRATION`, `Config.OpenRegistration`
+and `kosync.Server.OpenReg` rather than leaving a disabled branch behind. A
+TOML file that still names `open_registration` fails startup through the
+existing unknown-key check. The obsolete environment variable has no effect.
+The example configuration, deployment guide and administration overview stop
+advertising the setting.
+
+Account creation remains available through the first-run setup, the
+administrator CLI, the administration panel and invite registration. A user
+created by any of those paths pairs KOReader afterwards, so the account
+password and device credential never share input material.
+
+This project has not shipped and the production instance never enabled open
+registration, so there are no affected credentials to migrate. If evidence of
+an instance that used the mode appears before implementation, every kosync
+device created through it must be revoked: removing the route does not remove
+the fast verifier already stored for such a device.
+
+### Creating durable access requires password re-verification
+
+Creating an account or an invite from the administration panel goes through
+the existing `reauth` gate before it changes the store or generates a secret.
+The form carries `admin_password`, distinct from the new user's password, and
+both account and client-address rate-limit budgets are spent on every
+re-verification attempt.
+
+The order is deliberate:
+
+1. Validate the session and CSRF token.
+2. Re-verify the acting administrator and consume the two rate-limit budgets.
+3. Validate action-specific input.
+4. Create the account or generate and store the invite.
+
+A missing, wrong or rate-limited administrator password creates nothing. Each
+attempt is logged with the acting administrator, the action and its outcome;
+passwords, invite codes and hashes are never logged. Random-number and store
+errors are handled rather than discarded, so a failed operation cannot render
+an empty or unusable secret as though it succeeded.
+
+Revoking an invite remains session-and-CSRF protected without password
+re-verification. Revocation reduces authority and cannot establish access, so
+pricing it like credential creation would add friction without protecting the
+boundary this decision addresses.
+
+## Consequences
+
+- A stock KOReader can no longer create a liseur-sync account by itself. The
+  account must exist first, then the device is enrolled with a pairing code.
+- No stored kosync verifier is derived from an account password. A database
+  compromise therefore cannot use the legacy adapter to bypass Argon2id's
+  password-guessing cost.
+- An administrator performs one additional password check when creating an
+  account or invite. This matches password reset and cross-user credential
+  creation, and makes the panel's re-verification boundary coherent.
+- A stolen administrator session and its CSRF token can still perform ordinary
+  session-authorized work, but cannot turn that session into a new durable
+  login. Knowledge of the administrator's password is a different compromise
+  and is outside the protection re-verification can provide.
+- No route, database schema or native API shape changes. The kosync pairing
+  route keeps its wire shape; only the unsafe optional meaning is removed.
+
+## Implementation phases
+
+**Phase 1 — Pairing-only kosync.** Remove the open-registration branch and its
+configuration surface. Update DESIGN.md, SECURITY.md, the example configuration
+and deployment documentation to say that account registration is invite-only
+and kosync creates device credentials only. Extend adapter and configuration
+tests to pin the removal.
+
+**Phase 2 — Close the administration gap.** Add administrator-password fields
+to the create-account and create-invite forms, put both handlers behind
+`reauth`, handle secret-generation and store failures, and extend the audit
+log. Add focused web tests for CSRF, missing and wrong passwords, both limiter
+budgets, successful creation and absence of partial state.
+
+Both phases are implemented.
+
+## Acceptance criteria
+
+- No code path derives a kosync device credential from an account password.
+- `POST /adapter/kosync/users/create` with a username and account password is
+  refused even when the username does not exist. A valid pairing code still
+  creates exactly one device for its existing account and remains single-use.
+- `open_registration` in TOML is an unknown-key startup error, and
+  `LISEUR_OPEN_REGISTRATION` cannot enable any behavior.
+- Creating an account or invite without the acting administrator's correct
+  password creates no user, invite or secret and records the refused action.
+- Account- and client-address re-verification budgets are enforced
+  independently on both creation paths. A rate-limited request performs no
+  action even when it later carries the correct password.
+- Correct CSRF and administrator credentials still create an account or
+  single-use invite, and the returned secret is shown exactly once and never
+  logged.
+- Revoking an invite continues to require an administrator session and CSRF
+  token, but not password re-verification.
+- The full race-enabled suite passes against SQLite and PostgreSQL, and the
+  secure-transport, route-scope and tenant-isolation matrices remain green.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -50,6 +50,7 @@ loose ends that must come before any of it, are in
 | [0023](0023-uploads-land-in-a-folder.md) | An upload is a file written into a folder | Later | Accepted; implemented | Folder opt-in, `library-upload` scope, plain and Calibre folders; amends rule 3 of [0017](0017-folders-not-pipelines.md) and reinstates phase C of [0008](0008-android-client.md) |
 | [0024](0024-deleting-a-work.md) | Deleting is a reader forgetting, or an administrator retiring | Later | Accepted; implemented | Per-user work delete for a work no book backs, admin delete of a missing catalog row; amends the append-only rule for that one case |
 | [0025](0025-deleting-a-book.md) | A book may be deleted where a book may be written | Later | Accepted | Deleting a book's file and row from an `accepts_uploads` folder; `library-delete` scope over the API, admin in the browser; amends [0024](0024-deleting-a-work.md) and rule 3 of [0017](0017-folders-not-pipelines.md) again |
+| [0026](0026-credential-enrolment-does-not-weaken-account-authentication.md) | Credential enrolment does not weaken account authentication | MVP | Accepted; implemented | Kosync pairing only; administrator password re-verification before creating an account or invite |
 
 ## Convention
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -145,9 +145,9 @@ the instance without a shell. It holds four things:
   administrator role, revoke a device credential or every credential at
   once, disable or enable the account, mint an API token with the scopes
   you choose, generate a kosync pairing code, add a statistics-plugin
-  capability, and map the account's books to works. Everything that
-  hands out or takes away a way into the account asks for your password
-  again, and every attempt is logged.
+  capability, and map the account's books to works. Creating an account or
+  invite, and every action that hands out or takes away a way into an account,
+  asks for your password again; every attempt is logged.
 - **Folders** — every watched
   folder on the instance. Add a plain or Calibre folder by naming an
   existing path, or remove one the server should stop reflecting. Only
@@ -356,8 +356,7 @@ epub_max_xml_depth = 128
 Environment overrides follow the same names: `LISEUR_CACHE_DIR` for the
 cover cache and `LISEUR_FOLDER_ROOTS` for the comma-separated allowed
 roots. `LISEUR_LISTEN_ADDR`, `LISEUR_DATABASE_DRIVER`,
-`LISEUR_DATABASE_URL`, `LISEUR_INSECURE_HTTP`,
-`LISEUR_OPEN_REGISTRATION`, `LISEUR_CORS_ORIGINS`,
+`LISEUR_DATABASE_URL`, `LISEUR_INSECURE_HTTP`, `LISEUR_CORS_ORIGINS`,
 `LISEUR_TRUSTED_PROXIES`, and `LISEUR_READER_ORIGIN` keep their usual
 meanings.
 

--- a/internal/adapter/kosync/kosync.go
+++ b/internal/adapter/kosync/kosync.go
@@ -28,7 +28,6 @@ import (
 type Server struct {
 	St          store.Store
 	Cfg         config.Config // for trusted-proxy-aware rate limiting
-	OpenReg     bool          // open_registration config
 	PairingTTL  time.Duration
 	AuthRateLim *auth.RateLimiter
 	PairingUser func(r *http.Request) string // reserved for future web pairing
@@ -89,10 +88,10 @@ func (s *Server) HandleAuth(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(`{"authorized":"OK"}`))
 }
 
-// HandleCreateUser implements POST /users/create. With open
-// registration off (default), the kosync "password" must be a valid
-// pairing code; the code is redeemed and a device slot created, keyed
-// on MD5(pairing code) — the key KOReader will present on future calls.
+// HandleCreateUser implements POST /users/create. The kosync "password"
+// must be a valid pairing code; the code is redeemed and a device slot
+// created, keyed on MD5(pairing code) — the key KOReader will present on
+// future calls. This route never creates an account (ADR-0026).
 func (s *Server) HandleCreateUser(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Username string `json:"username"`
@@ -109,35 +108,6 @@ func (s *Server) HandleCreateUser(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 	now := time.Now()
-
-	if s.OpenReg {
-		// Open registration: the password IS the account password; create
-		// the account and a device slot. Off by default (design §7.1).
-		hash, err := auth.HashPassword(req.Password)
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal"})
-			return
-		}
-		id, _ := auth.NewSecret()
-		u := store.User{
-			ID: id[:16], Name: req.Username, Argon2Hash: hash, Timezone: "UTC",
-			KosyncEnabled: true, KopluginEnabled: true, CreatedAt: now,
-		}
-		if err := s.St.CreateUser(ctx, u); err != nil {
-			writeJSON(w, http.StatusForbidden, map[string]string{"error": "username taken"})
-			return
-		}
-		d := store.KosyncDevice{
-			UserID: u.ID, DeviceSlot: req.Username,
-			KeySHA256: auth.HashSecret(md5hex(req.Password)), Label: "kosync",
-		}
-		if err := s.St.CreateKosyncDevice(ctx, d); err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal"})
-			return
-		}
-		writeJSON(w, http.StatusCreated, map[string]string{"username": req.Username})
-		return
-	}
 
 	// Pairing flow: password is a pairing code. KOReader will derive
 	// MD5(code) as its auth key, so the slot key is the hash of that.

--- a/internal/adapter/kosync/kosync_test.go
+++ b/internal/adapter/kosync/kosync_test.go
@@ -27,7 +27,7 @@ func testServer(t *testing.T) (*httptest.Server, store.Store) {
 	}
 	cfg := config.Default()
 	cfg.InsecureHTTP = true
-	s := &Server{St: st, Cfg: cfg, OpenReg: false, AuthRateLim: auth.NewRateLimiter(1000, time.Minute)}
+	s := &Server{St: st, Cfg: cfg, AuthRateLim: auth.NewRateLimiter(1000, time.Minute)}
 	mux := http.NewServeMux()
 	s.Mount(mux, func(h http.Handler) http.Handler {
 		return auth.RequireSecureTransport(cfg, h)
@@ -39,21 +39,21 @@ func testServer(t *testing.T) (*httptest.Server, store.Store) {
 
 // pairDevice runs the pairing flow and returns the x-auth headers
 // KOReader would use.
-func pairDevice(t *testing.T, ts *httptest.Server, st store.Store, userID, slot string) (user, key string) {
+func pairDevice(t *testing.T, ts *httptest.Server, st store.Store, userID, slot string) (user, key, pairingCode string) {
 	t.Helper()
 	// Admin generates a pairing code.
-	code, _ := auth.NewSecret()
-	code = code[:32]
+	pairingCode, _ = auth.NewSecret()
+	pairingCode = pairingCode[:32]
 	id, _ := auth.NewSecret()
 	if err := st.CreatePairingCode(t.Context(), store.PairingCode{
-		ID: id, UserID: userID, CodeSHA256: auth.HashSecret(code),
+		ID: id, UserID: userID, CodeSHA256: auth.HashSecret(pairingCode),
 		ExpiresAt: time.Now().Add(15 * time.Minute),
 	}); err != nil {
 		t.Fatal(err)
 	}
 
 	// KOReader calls users/create with username=slot, password=code.
-	body, _ := json.Marshal(map[string]string{"username": slot, "password": code})
+	body, _ := json.Marshal(map[string]string{"username": slot, "password": pairingCode})
 	resp, err := http.Post(ts.URL+"/adapter/kosync/users/create", "application/json", bytes.NewReader(body))
 	if err != nil {
 		t.Fatal(err)
@@ -64,8 +64,8 @@ func pairDevice(t *testing.T, ts *httptest.Server, st store.Store, userID, slot 
 	}
 
 	// KOReader derives MD5(password) as the auth key.
-	key = md5hex(code)
-	return slot, key
+	key = md5hex(pairingCode)
+	return slot, key, pairingCode
 }
 
 func kreq(t *testing.T, method, url, user, key string, body any) (int, map[string]any) {
@@ -98,7 +98,7 @@ func TestPairingFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	user, key := pairDevice(t, ts, st, u.ID, "my-kobo")
+	user, key, pairingCode := pairDevice(t, ts, st, u.ID, "my-kobo")
 
 	// users/auth succeeds with the derived key.
 	code, out := kreq(t, "GET", ts.URL+"/adapter/kosync/users/auth", user, key, nil)
@@ -113,12 +113,45 @@ func TestPairingFlow(t *testing.T) {
 	}
 
 	// Pairing code is single-use.
-	codeBody, _ := json.Marshal(map[string]string{"username": "other", "password": "nonexistent"})
+	codeBody, _ := json.Marshal(map[string]string{"username": "other", "password": pairingCode})
 	resp, _ := http.Post(ts.URL+"/adapter/kosync/users/create", "application/json", bytes.NewReader(codeBody))
 	if resp.StatusCode != 403 {
 		t.Fatalf("bad pairing code: want 403, got %d", resp.StatusCode)
 	}
 	resp.Body.Close()
+	devices, err := st.ListKosyncDevices(t.Context(), u.ID)
+	if err != nil || len(devices) != 1 {
+		t.Fatalf("single-use pairing created more than one device: %+v err=%v", devices, err)
+	}
+}
+
+func TestAccountPasswordCannotRegisterOrPair(t *testing.T) {
+	ts, st := testServer(t)
+	password := "hunter2hunter"
+	hash, _ := auth.HashPassword(password)
+	u := store.User{ID: "u1", Name: "alice", Argon2Hash: hash, KosyncEnabled: true, KopluginEnabled: true, CreatedAt: time.Now()}
+	if err := st.CreateUser(t.Context(), u); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, username := range []string{"alice", "new-account"} {
+		body, _ := json.Marshal(map[string]string{"username": username, "password": password})
+		resp, err := http.Post(ts.URL+"/adapter/kosync/users/create", "application/json", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusForbidden {
+			t.Fatalf("account password for %q: want 403, got %d", username, resp.StatusCode)
+		}
+	}
+	if _, err := st.UserByName(t.Context(), "new-account"); err == nil {
+		t.Fatal("kosync account password created an account")
+	}
+	devices, err := st.ListKosyncDevices(t.Context(), u.ID)
+	if err != nil || len(devices) != 0 {
+		t.Fatalf("kosync account password created a device: %+v err=%v", devices, err)
+	}
 }
 
 func TestProgressRoundTrip(t *testing.T) {
@@ -128,7 +161,7 @@ func TestProgressRoundTrip(t *testing.T) {
 	if err := st.CreateUser(t.Context(), u); err != nil {
 		t.Fatal(err)
 	}
-	user, key := pairDevice(t, ts, st, u.ID, "kobo-1")
+	user, key, _ := pairDevice(t, ts, st, u.ID, "kobo-1")
 
 	doc := "aabbccdd"
 	xpointer := "/body/DocFragment[11]/body/div/p[3]/text()[1].0"
@@ -164,7 +197,7 @@ func TestFalsyZeroPercentage(t *testing.T) {
 	if err := st.CreateUser(t.Context(), u); err != nil {
 		t.Fatal(err)
 	}
-	user, key := pairDevice(t, ts, st, u.ID, "kobo-2")
+	user, key, _ := pairDevice(t, ts, st, u.ID, "kobo-2")
 
 	code, _ := kreq(t, "PUT", ts.URL+"/adapter/kosync/syncs/progress", user, key, map[string]any{
 		"document": "deadbeef01", "progress": "/body/DocFragment[1]/body/p[1]/text()[1].0",
@@ -190,7 +223,7 @@ func TestPendingWorkLaterResolves(t *testing.T) {
 	if err := st.CreateUser(ctx, u); err != nil {
 		t.Fatal(err)
 	}
-	user, key := pairDevice(t, ts, st, u.ID, "kobo-3")
+	user, key, _ := pairDevice(t, ts, st, u.ID, "kobo-3")
 
 	doc := "cafe1234"
 	kreq(t, "PUT", ts.URL+"/adapter/kosync/syncs/progress", user, key, map[string]any{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -93,10 +93,6 @@ type Config struct {
 		Koplugin bool `toml:"koplugin"`
 	} `toml:"adapters"`
 
-	// OpenRegistration allows kosync users/create without a pairing
-	// code. Off by default (design 7.1).
-	OpenRegistration bool `toml:"open_registration"`
-
 	Ops struct {
 		MaxBatch           int   `toml:"max_batch"`            // default 500
 		MaxBodyBytes       int64 `toml:"max_body_bytes"`       // default 1 MiB
@@ -143,7 +139,7 @@ func Default() Config {
 
 // applyEnv applies LISEUR_* environment overrides. Supported:
 // LISEUR_LISTEN_ADDR, LISEUR_DATABASE_DRIVER, LISEUR_DATABASE_URL,
-// LISEUR_CACHE_DIR, LISEUR_INSECURE_HTTP, LISEUR_OPEN_REGISTRATION,
+// LISEUR_CACHE_DIR, LISEUR_INSECURE_HTTP,
 // LISEUR_CORS_ORIGINS (comma-separated), LISEUR_TRUSTED_PROXIES
 // (comma-separated), LISEUR_READER_ORIGIN,
 // LISEUR_FOLDER_ROOTS (comma-separated).
@@ -177,7 +173,6 @@ func (c *Config) applyEnv() {
 	setStr(&c.Content.CacheDir, "LISEUR_CACHE_DIR")
 	setStr(&c.ReaderOrigin, "LISEUR_READER_ORIGIN")
 	setBool(&c.InsecureHTTP, "LISEUR_INSECURE_HTTP")
-	setBool(&c.OpenRegistration, "LISEUR_OPEN_REGISTRATION")
 	setList(&c.CORSAllowedOrigins, "LISEUR_CORS_ORIGINS")
 	setList(&c.TrustedProxies, "LISEUR_TRUSTED_PROXIES")
 	setList(&c.Content.FolderRoots, "LISEUR_FOLDER_ROOTS")

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -31,7 +32,6 @@ func TestShippedExampleParsesIntoTheSettingsItNames(t *testing.T) {
 	text := string(body)
 	for from, to := range map[string]string{
 		"insecure_http = false":                                "insecure_http = true",
-		"open_registration = false":                            "open_registration = true",
 		"pairing_code_ttl_min = 15":                            "pairing_code_ttl_min = 42",
 		`# trusted_proxies = ["10.0.0.0/8", "192.168.0.0/16"]`: `trusted_proxies = ["10.0.0.0/8"]`,
 		`# cors_allowed_origins = ["https://app.example.com"]`: `cors_allowed_origins = ["https://app.example.com"]`,
@@ -48,9 +48,6 @@ func TestShippedExampleParsesIntoTheSettingsItNames(t *testing.T) {
 	}
 	if !cfg.InsecureHTTP {
 		t.Fatal("insecure_http did not reach the top-level setting")
-	}
-	if !cfg.OpenRegistration {
-		t.Fatal("open_registration did not reach the top-level setting")
 	}
 	if cfg.PairingCodeTTLMin != 42 {
 		t.Fatalf("pairing_code_ttl_min: got %d", cfg.PairingCodeTTLMin)
@@ -90,6 +87,11 @@ func TestUnknownKeyIsAStartupError(t *testing.T) {
 			"[nonsense]\nvalue = 1\n",
 			"nonsense.value",
 		},
+		{
+			"removed open registration",
+			"open_registration = true\n",
+			"open_registration",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -101,6 +103,21 @@ func TestUnknownKeyIsAStartupError(t *testing.T) {
 				t.Fatalf("error %q does not mention %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestRemovedOpenRegistrationEnvironmentVariableHasNoEffect(t *testing.T) {
+	want, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LISEUR_OPEN_REGISTRATION", "true")
+	got, err := Load("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("removed environment variable changed config:\n got: %+v\nwant: %+v", got, want)
 	}
 }
 

--- a/internal/webui/admin.go
+++ b/internal/webui/admin.go
@@ -39,7 +39,6 @@ func describeConfig(c config.Config) configFacts {
 	add("Op log compaction", onOff(c.Ops.CompactionEnabled))
 	add("kosync adapter", onOff(c.Adapters.Kosync))
 	add("koplugin adapter", onOff(c.Adapters.Koplugin))
-	add("Open registration", onOff(c.OpenRegistration))
 	add("Credentials over plain HTTP", onOff(c.InsecureHTTP))
 	add("Trusted proxies", listOr(c.TrustedProxies, "none"))
 	add("CORS origins", listOr(c.CORSAllowedOrigins, "none"))

--- a/internal/webui/adminusers.go
+++ b/internal/webui/adminusers.go
@@ -65,10 +65,14 @@ type adminUserView struct {
 // remote address, so one account cannot spend the whole instance's.
 // Both must allow the attempt.
 func (s *Server) reauth(r *http.Request, actor *store.User) error {
-	if s.AdminReauthUserLimiter != nil && !s.AdminReauthUserLimiter.Allow(actor.ID) {
-		return errRateLimited
+	userAllowed, ipAllowed := true, true
+	if s.AdminReauthUserLimiter != nil {
+		userAllowed = s.AdminReauthUserLimiter.Allow(actor.ID)
 	}
-	if s.AdminReauthIPLimiter != nil && !s.AdminReauthIPLimiter.Allow(auth.ClientIP(r, s.Cfg)) {
+	if s.AdminReauthIPLimiter != nil {
+		ipAllowed = s.AdminReauthIPLimiter.Allow(auth.ClientIP(r, s.Cfg))
+	}
+	if !userAllowed || !ipAllowed {
 		return errRateLimited
 	}
 	ok, err := auth.CheckPassword(r.FormValue("admin_password"), actor.Argon2Hash)
@@ -111,15 +115,30 @@ func (s *Server) handleAdminCreateUser(
 		return
 	}
 	name := r.FormValue("name")
+	if err := s.reauth(r, u); err != nil {
+		logAdminAction(r, u, "create-user", name, err)
+		if errors.Is(err, errRateLimited) {
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+		}
+		s.renderAdminUsers(w, r, a, u, Flash{Error: err.Error()})
+		return
+	}
 	pw, repeat := r.FormValue("password"), r.FormValue("repeat")
 	if err := admin.ValidatePassword(pw, repeat); err != nil {
-		s.renderAdminUsers(w, r, a, u, Flash{Notice: "", Error: err.Error()})
+		logAdminAction(r, u, "create-user", name, err)
+		s.renderAdminUsers(w, r, a, u, Flash{Error: err.Error()})
 		return
 	}
 	created, err := admin.CreateUser(r.Context(), s.St, name, pw)
 	logAdminAction(r, u, "create-user", name, err)
 	if err != nil {
-		s.renderAdminUsers(w, r, a, u, Flash{Error: err.Error()})
+		if isUserError(err) {
+			s.renderAdminUsers(w, r, a, u, Flash{Error: err.Error()})
+			return
+		}
+		slog.ErrorContext(r.Context(), "create account failed", "error", err)
+		s.renderAdminUsers(w, r, a, u, Flash{Error: "Could not create account."})
 		return
 	}
 	s.renderAdminUsers(w, r, a, u, Flash{

--- a/internal/webui/adminusers.templ
+++ b/internal/webui/adminusers.templ
@@ -61,6 +61,7 @@ templ adminUsersBody(prefix string, csrf string, users []store.User, next string
 			<label>Name <input name="name" required autocomplete="off"/></label>
 			<label>Password <input name="password" type="password" required autocomplete="new-password"/></label>
 			<label>Repeat <input name="repeat" type="password" required autocomplete="new-password"/></label>
+			@adminPasswordField(csrf)
 			<button type="submit" class="primary">Create</button>
 		</form>
 	</section>
@@ -69,6 +70,7 @@ templ adminUsersBody(prefix string, csrf string, users []store.User, next string
 		<p class="muted">Registration is invite-only. Codes expire after 7 days and are single-use.</p>
 		<form method="post" action={ prefix + "admin/invites" } class="inline">
 			<input type="hidden" name="csrf" value={ csrf }/>
+			@adminPasswordField(csrf)
 			<button type="submit" class="primary">New invite</button>
 		</form>
 		if len(invites) > 0 {

--- a/internal/webui/adminusers_test.go
+++ b/internal/webui/adminusers_test.go
@@ -406,6 +406,12 @@ func TestAdminCreationFailuresLeaveNoPartialState(t *testing.T) {
 			},
 		},
 		{
+			name: "invite short entropy output",
+			tune: func(s *Server) {
+				s.newSecret = func() (string, error) { return "short", nil }
+			},
+		},
+		{
 			name: "invite store failure",
 			tune: func(s *Server) { s.St = createInviteFailStore{Store: s.St} },
 		},

--- a/internal/webui/adminusers_test.go
+++ b/internal/webui/adminusers_test.go
@@ -1,6 +1,10 @@
 package webui
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strings"
@@ -8,6 +12,7 @@ import (
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/config"
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
@@ -253,19 +258,73 @@ func TestAdminReauthIsRateLimited(t *testing.T) {
 	}
 }
 
+func TestAdminReauthSpendsBothBudgetsOnEveryAttempt(t *testing.T) {
+	hash, _ := auth.HashPassword("hunter2hunter")
+	actor1 := &store.User{ID: "admin-1", Argon2Hash: hash}
+	actor2 := &store.User{ID: "admin-2", Argon2Hash: hash}
+	s := &Server{
+		Cfg:                    config.Default(),
+		AdminReauthUserLimiter: auth.NewRateLimiter(1, time.Minute),
+		AdminReauthIPLimiter:   auth.NewRateLimiter(1, time.Minute),
+	}
+	request := func(addr string) *http.Request {
+		r, _ := http.NewRequest(http.MethodPost, "/", strings.NewReader(
+			url.Values{"admin_password": {"wrong"}}.Encode()))
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		r.RemoteAddr = addr
+		_ = r.ParseForm()
+		return r
+	}
+
+	if err := s.reauth(request("192.0.2.1:1000"), actor1); !errors.Is(err, errBadAdminPassword) {
+		t.Fatalf("first attempt: got %v", err)
+	}
+	if err := s.reauth(request("192.0.2.2:1000"), actor1); !errors.Is(err, errRateLimited) {
+		t.Fatalf("exhausted user budget: got %v", err)
+	}
+	// The second request must still have spent 192.0.2.2's IP budget even
+	// though actor1's user budget was already exhausted.
+	if err := s.reauth(request("192.0.2.2:1000"), actor2); !errors.Is(err, errRateLimited) {
+		t.Fatalf("IP budget was skipped after user refusal: got %v", err)
+	}
+}
+
 // TestAdminCreateUserFromThePanel covers the create form and the shared
 // validation behind it.
 func TestAdminCreateUserFromThePanel(t *testing.T) {
-	ts, st := testServer(t)
+	ts, st := testServerCfg(t, nil, generousReauth)
 	if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
 		t.Fatal(err)
 	}
 	cookie := loginCookie(t, ts)
 	_, body := page(t, ts, cookie, "/ui/settings?section=admin&view=users")
 	csrf := extractCSRF(t, body)
+	if !strings.Contains(body, `name="admin_password"`) {
+		t.Fatal("account and invite forms do not ask for the administrator password")
+	}
+
+	if c, _ := postForm(t, ts, cookie, "/ui/admin/users", url.Values{
+		"name": {"carol"}, "password": {"a-good-password"}, "repeat": {"a-good-password"},
+		"admin_password": {"hunter2hunter"},
+	}); c != http.StatusForbidden {
+		t.Fatalf("create without CSRF: want 403, got %d", c)
+	}
+	for _, adminPassword := range []string{"", "wrong-password"} {
+		c, body := postForm(t, ts, cookie, "/ui/admin/users", url.Values{
+			"csrf": {csrf}, "name": {"carol"}, "password": {"a-good-password"},
+			"repeat": {"a-good-password"}, "admin_password": {adminPassword},
+		})
+		if c != http.StatusOK || !strings.Contains(body, "your password is wrong") {
+			t.Fatalf("admin password %q: got %d %q", adminPassword, c, body)
+		}
+		if _, err := st.UserByName(t.Context(), "carol"); err == nil {
+			t.Fatal("refused re-verification still created carol")
+		}
+	}
 
 	c, body := postForm(t, ts, cookie, "/ui/admin/users", url.Values{
 		"csrf": {csrf}, "name": {"carol"}, "password": {"short"}, "repeat": {"short"},
+		"admin_password": {"hunter2hunter"},
 	})
 	if c != 200 || !strings.Contains(body, "at least 8 characters") {
 		t.Fatalf("short password: %d %q", c, body)
@@ -273,6 +332,7 @@ func TestAdminCreateUserFromThePanel(t *testing.T) {
 	c, body = postForm(t, ts, cookie, "/ui/admin/users", url.Values{
 		"csrf": {csrf}, "name": {"carol dvorak"},
 		"password": {"a-good-password"}, "repeat": {"a-good-password"},
+		"admin_password": {"hunter2hunter"},
 	})
 	if c != 200 || !strings.Contains(body, "may contain letters") {
 		t.Fatalf("invalid name: %d %q", c, body)
@@ -280,6 +340,7 @@ func TestAdminCreateUserFromThePanel(t *testing.T) {
 	c, body = postForm(t, ts, cookie, "/ui/admin/users", url.Values{
 		"csrf": {csrf}, "name": {"carol"},
 		"password": {"a-good-password"}, "repeat": {"a-good-password"},
+		"admin_password": {"hunter2hunter"},
 	})
 	if c != 200 || !strings.Contains(body, "Created carol") {
 		t.Fatalf("create: %d %q", c, body)
@@ -291,9 +352,168 @@ func TestAdminCreateUserFromThePanel(t *testing.T) {
 	c, body = postForm(t, ts, cookie, "/ui/admin/users", url.Values{
 		"csrf": {csrf}, "name": {"carol"},
 		"password": {"a-good-password"}, "repeat": {"a-good-password"},
+		"admin_password": {"hunter2hunter"},
 	})
 	if c != 200 || !strings.Contains(body, "taken") {
 		t.Fatalf("duplicate name: %d %q", c, body)
+	}
+}
+
+type createUserFailStore struct{ store.Store }
+
+func (createUserFailStore) CreateUser(context.Context, store.User) error {
+	return errors.New("injected create-user failure")
+}
+
+type createInviteFailStore struct{ store.Store }
+
+func (createInviteFailStore) CreateInvite(context.Context, store.Invite) error {
+	return errors.New("injected create-invite failure")
+}
+
+func TestAdminCreationFailuresLeaveNoPartialState(t *testing.T) {
+	t.Run("account store failure", func(t *testing.T) {
+		ts, st := testServerCfg(t, nil, func(s *Server) {
+			generousReauth(s)
+			s.St = createUserFailStore{Store: s.St}
+		})
+		if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
+			t.Fatal(err)
+		}
+		cookie := loginCookie(t, ts)
+		_, pageBody := page(t, ts, cookie, "/ui/settings?section=admin&view=users")
+		code, body := postForm(t, ts, cookie, "/ui/admin/users", url.Values{
+			"csrf": {extractCSRF(t, pageBody)}, "name": {"carol"},
+			"password": {"a-good-password"}, "repeat": {"a-good-password"},
+			"admin_password": {"hunter2hunter"},
+		})
+		if code != http.StatusOK || !strings.Contains(body, "Could not create account") {
+			t.Fatalf("store failure: %d %q", code, body)
+		}
+		if _, err := st.UserByName(t.Context(), "carol"); err == nil {
+			t.Fatal("failed account creation left an account behind")
+		}
+	})
+
+	for _, tc := range []struct {
+		name string
+		tune func(*Server)
+	}{
+		{
+			name: "invite entropy failure",
+			tune: func(s *Server) {
+				s.newSecret = func() (string, error) { return "", errors.New("injected entropy failure") }
+			},
+		},
+		{
+			name: "invite store failure",
+			tune: func(s *Server) { s.St = createInviteFailStore{Store: s.St} },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts, st := testServerCfg(t, nil, func(s *Server) {
+				generousReauth(s)
+				tc.tune(s)
+			})
+			if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
+				t.Fatal(err)
+			}
+			cookie := loginCookie(t, ts)
+			_, pageBody := page(t, ts, cookie, "/ui/settings?section=admin&view=users")
+			code, body := postForm(t, ts, cookie, "/ui/admin/invites", url.Values{
+				"csrf": {extractCSRF(t, pageBody)}, "admin_password": {"hunter2hunter"},
+			})
+			if code != http.StatusOK || !strings.Contains(body, "Could not create invite") ||
+				strings.Contains(body, `class="big"`) {
+				t.Fatalf("failed invite creation: %d %q", code, body)
+			}
+			if invites, err := st.ListInvites(t.Context(), "u1"); err != nil || len(invites) != 0 {
+				t.Fatalf("failed invite creation left state: %+v err=%v", invites, err)
+			}
+		})
+	}
+}
+
+func TestAdminCreationPathsEnforceBothLimiters(t *testing.T) {
+	for _, action := range []string{"account", "invite"} {
+		for _, limited := range []string{"user", "ip"} {
+			t.Run(action+"/"+limited, func(t *testing.T) {
+				ts, st := testServerCfg(t, nil, func(s *Server) {
+					userLimit, ipLimit := 100, 100
+					if limited == "user" {
+						userLimit = 1
+					} else {
+						ipLimit = 1
+					}
+					s.AdminReauthUserLimiter = auth.NewRateLimiter(userLimit, time.Minute)
+					s.AdminReauthIPLimiter = auth.NewRateLimiter(ipLimit, time.Minute)
+				})
+				if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
+					t.Fatal(err)
+				}
+				cookie := loginCookie(t, ts)
+				_, pageBody := page(t, ts, cookie, "/ui/settings?section=admin&view=users")
+				csrf := extractCSRF(t, pageBody)
+				path := "/ui/admin/invites"
+				form := url.Values{"csrf": {csrf}}
+				if action == "account" {
+					path = "/ui/admin/users"
+					form.Set("name", "blocked-user")
+					form.Set("password", "a-good-password")
+					form.Set("repeat", "a-good-password")
+				}
+				form.Set("admin_password", "wrong")
+				if code, _ := postForm(t, ts, cookie, path, form); code != http.StatusOK {
+					t.Fatalf("first attempt: got %d", code)
+				}
+				form.Set("admin_password", "hunter2hunter")
+				if code, body := postForm(t, ts, cookie, path, form); code != http.StatusTooManyRequests ||
+					!strings.Contains(body, "too many attempts") {
+					t.Fatalf("limited attempt: got %d %q", code, body)
+				}
+				if _, err := st.UserByName(t.Context(), "blocked-user"); err == nil {
+					t.Fatal("rate-limited request created an account")
+				}
+				if invites, err := st.ListInvites(t.Context(), "u1"); err != nil || len(invites) != 0 {
+					t.Fatalf("rate-limited request created an invite: %+v err=%v", invites, err)
+				}
+			})
+		}
+	}
+}
+
+func TestAdminCreationAuditDoesNotLogSecrets(t *testing.T) {
+	var logs bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&logs, nil)))
+	t.Cleanup(func() { slog.SetDefault(old) })
+
+	ts, st := testServerCfg(t, nil, generousReauth)
+	if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
+		t.Fatal(err)
+	}
+	cookie := loginCookie(t, ts)
+	_, pageBody := page(t, ts, cookie, "/ui/settings?section=admin&view=users")
+	csrf := extractCSRF(t, pageBody)
+	newPassword, wrongAdminPassword := "new-user-secret", "wrong-admin-secret"
+	postForm(t, ts, cookie, "/ui/admin/users", url.Values{
+		"csrf": {csrf}, "name": {"carol"}, "password": {newPassword},
+		"repeat": {newPassword}, "admin_password": {wrongAdminPassword},
+	})
+	_, inviteBody := postForm(t, ts, cookie, "/ui/admin/invites", url.Values{
+		"csrf": {csrf}, "admin_password": {"hunter2hunter"},
+	})
+	inviteCode := secretFromPage(t, inviteBody)
+	got := logs.String()
+	for _, want := range []string{`"actor_id":"u1"`, `"action":"create-user"`, `"action":"create-invite"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("audit log is missing %s: %s", want, got)
+		}
+	}
+	for _, secret := range []string{newPassword, wrongAdminPassword, inviteCode, auth.HashSecret(inviteCode)} {
+		if strings.Contains(got, secret) {
+			t.Errorf("audit log leaked a secret: %s", got)
+		}
 	}
 }
 

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -3,6 +3,7 @@ package webui
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sort"
 	"strings"
@@ -525,13 +526,36 @@ func (s *Server) handleCreateInvite(w http.ResponseWriter, r *http.Request, a st
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
-	code, _ := auth.NewSecret()
+	if err := s.reauth(r, u); err != nil {
+		logAdminAction(r, u, "create-invite", "", err)
+		if errors.Is(err, errRateLimited) {
+			w.Header().Set("Retry-After", "60")
+			w.WriteHeader(http.StatusTooManyRequests)
+		}
+		s.renderAdminUsers(w, r, a, u, Flash{Error: err.Error()})
+		return
+	}
+	code, err := s.generateSecret()
+	if err != nil {
+		logAdminAction(r, u, "create-invite", "", err)
+		slog.ErrorContext(r.Context(), "create invite failed", "error", err)
+		s.renderAdminUsers(w, r, a, u, Flash{Error: "Could not create invite."})
+		return
+	}
 	code = code[:32]
-	id, _ := auth.NewSecret()
-	_ = s.St.CreateInvite(r.Context(), store.Invite{
-		ID: id, CodeSHA256: auth.HashSecret(code), CreatedBy: u.ID,
-		ExpiresAt: time.Now().Add(inviteTTL),
-	})
+	id, err := s.generateSecret()
+	if err == nil {
+		err = s.St.CreateInvite(r.Context(), store.Invite{
+			ID: id, CodeSHA256: auth.HashSecret(code), CreatedBy: u.ID,
+			ExpiresAt: time.Now().Add(inviteTTL),
+		})
+	}
+	logAdminAction(r, u, "create-invite", id, err)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "create invite failed", "error", err)
+		s.renderAdminUsers(w, r, a, u, Flash{Error: "Could not create invite."})
+		return
+	}
 	s.renderAdminUsers(w, r, a, u, Flash{
 		Secret:      code,
 		SecretLabel: "Invite code (7 days, single use)",

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -536,6 +536,9 @@ func (s *Server) handleCreateInvite(w http.ResponseWriter, r *http.Request, a st
 		return
 	}
 	code, err := s.generateSecret()
+	if err == nil && len(code) < 32 {
+		err = errors.New("generated secret is too short")
+	}
 	if err != nil {
 		logAdminAction(r, u, "create-invite", "", err)
 		slog.ErrorContext(r.Context(), "create invite failed", "error", err)

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -76,6 +76,16 @@ type Server struct {
 	// Mount fills in defaults when they are nil.
 	AdminReauthUserLimiter *auth.RateLimiter
 	AdminReauthIPLimiter   *auth.RateLimiter
+	// newSecret is an entropy-failure test hook. Production leaves it nil
+	// and generateSecret uses auth.NewSecret.
+	newSecret func() (string, error)
+}
+
+func (s *Server) generateSecret() (string, error) {
+	if s.newSecret != nil {
+		return s.newSecret()
+	}
+	return auth.NewSecret()
 }
 
 // FolderWatcher is the watcher surface the admin panel needs. It is an

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -125,6 +125,21 @@ func extractCSRF(t *testing.T, html string) string {
 	return rest[:strings.Index(rest, `"`)]
 }
 
+func secretFromPage(t *testing.T, html string) string {
+	t.Helper()
+	const marker = `<code class="big">`
+	i := strings.Index(html, marker)
+	if i < 0 {
+		t.Fatalf("no shown-once secret in page: %s", html)
+	}
+	rest := html[i+len(marker):]
+	end := strings.Index(rest, "</code>")
+	if end < 0 {
+		t.Fatalf("unterminated shown-once secret in page: %s", html)
+	}
+	return rest[:end]
+}
+
 func TestAuthFlowAndPages(t *testing.T) {
 	ts, _ := testServer(t)
 
@@ -358,7 +373,7 @@ func TestSettingsSave(t *testing.T) {
 }
 
 func TestAdminInvites(t *testing.T) {
-	ts, st := testServer(t)
+	ts, st := testServerCfg(t, nil, generousReauth)
 	// Admin is an account property (ADR-0013), not a token.
 	if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
 		t.Fatal(err)
@@ -372,13 +387,46 @@ func TestAdminInvites(t *testing.T) {
 		t.Fatal("Settings hides Administration from an admin")
 	}
 	csrf := extractCSRF(t, body)
-	code, body = postForm(t, ts, cookie, "/ui/admin/invites", url.Values{"csrf": {csrf}})
+	if got, _ := postForm(t, ts, cookie, "/ui/admin/invites", url.Values{
+		"admin_password": {"hunter2hunter"},
+	}); got != http.StatusForbidden {
+		t.Fatalf("invite without CSRF: want 403, got %d", got)
+	}
+	for _, password := range []string{"", "wrong-password"} {
+		code, body = postForm(t, ts, cookie, "/ui/admin/invites", url.Values{
+			"csrf": {csrf}, "admin_password": {password},
+		})
+		if code != http.StatusOK || !strings.Contains(body, "your password is wrong") {
+			t.Fatalf("invite with admin password %q: %d %q", password, code, body)
+		}
+		if invs, err := st.ListInvites(t.Context(), "u1"); err != nil || len(invs) != 0 {
+			t.Fatalf("refused invite created state: %+v err=%v", invs, err)
+		}
+	}
+	code, body = postForm(t, ts, cookie, "/ui/admin/invites", url.Values{
+		"csrf": {csrf}, "admin_password": {"hunter2hunter"},
+	})
 	if code != 200 || !strings.Contains(body, "Invite code") {
 		t.Fatalf("invite create: %d", code)
 	}
+	secret := secretFromPage(t, body)
+	if len(secret) != 32 || strings.Count(body, secret) != 1 {
+		t.Fatalf("invite code should be shown exactly once: %q", secret)
+	}
 	invs, _ := st.ListInvites(t.Context(), "u1")
-	if len(invs) != 1 {
+	if len(invs) != 1 || invs[0].CodeSHA256 != auth.HashSecret(secret) {
 		t.Fatalf("invites: %+v", invs)
+	}
+	_, nextBody := page(t, ts, cookie, "/ui/settings?section=admin&view=users")
+	if strings.Contains(nextBody, secret) {
+		t.Fatal("invite code was shown after its creation response")
+	}
+	// Revocation reduces authority, so CSRF is enough; no password
+	// re-verification field is sent.
+	code, body = postForm(t, ts, cookie, "/ui/admin/invites/"+invs[0].ID+"/revoke",
+		url.Values{"csrf": {csrf}})
+	if code != http.StatusOK || !strings.Contains(body, "Invite revoked") {
+		t.Fatalf("invite revoke without password: %d %q", code, body)
 	}
 }
 

--- a/liseur-sync.example.toml
+++ b/liseur-sync.example.toml
@@ -2,7 +2,7 @@
 # Env overrides: LISEUR_LISTEN_ADDR, LISEUR_DATABASE_DRIVER,
 # LISEUR_DATABASE_URL, LISEUR_CACHE_DIR, LISEUR_FOLDER_ROOTS,
 # LISEUR_INSECURE_HTTP,
-# LISEUR_OPEN_REGISTRATION, LISEUR_CORS_ORIGINS, LISEUR_TRUSTED_PROXIES,
+# LISEUR_CORS_ORIGINS, LISEUR_TRUSTED_PROXIES,
 # LISEUR_READER_ORIGIN.
 
 # Top-level settings must stay above the first [table] header. TOML binds
@@ -29,9 +29,6 @@ insecure_http = false
 # server; it serves the reader page and the static assets and nothing
 # else. Empty (the default) reads books on the main origin.
 # reader_origin = "https://read.example.com"
-
-# Allow kosync users/create without a pairing code (NOT recommended).
-open_registration = false
 
 pairing_code_ttl_min = 15
 


### PR DESCRIPTION
## What changed

- remove kosync open registration and require a valid, unexpired, single-use pairing code for every device enrolment
- require the acting administrator's password before the web UI creates an account or invite
- consume both per-account and per-address reauthentication budgets on every attempt
- handle and audit credential-generation and persistence failures without exposing secrets
- accept and implement ADR-0026, updating the security, design, deployment, and example configuration documentation
- add regression coverage for account-password rejection, single-use pairing, reauthentication, limiter behavior, failure atomicity, and shown-once invite secrets

## Why

Open kosync registration reused the account password as device-credential input, leaving a fast verifier beside the Argon2id password hash. The admin account and invite forms also let a stolen authenticated session mint durable access without re-verifying the administrator.

## Verification

- `go build ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go test -race -count=1 -timeout 300s ./...` with `LISEUR_PG_TEST_DSN` configured
