### PR TITLE
feat: scope catalog access to explicit per-user folder grants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,13 @@ of them.
 - **Every route is authenticated** except `/healthz`, `/v1/login`,
   `/v1/register` (invite), and the adapter pairing endpoints. Add new
   routes to the scope table in `internal/api/routes.go`.
-- **Reading state is scoped by `user_id`; the catalog is deliberately
-  not.** Ops, sessions, insights, devices and `user_book_works` are
+- **Reading state is scoped by `user_id`; catalog access is scoped by folder
+  grants.** Ops, sessions, insights, devices and `user_book_works` are
   per-user and must never be readable across users. Books, folders and
-  catalog entities are shared: every logged-in user sees every folder's
-  books, and only an admin sees or manages folders. **Series,
+  catalog entities remain shared rows, but a real viewer ID sees only books
+  supported by an explicit `user_folders` grant; administrator status never
+  implies a grant. Empty viewer IDs are reserved for reconciliation, watchers
+  and trusted administration. **Series,
   contributors and tags are library-wide, not folder-scoped**
   (ADR-0019): they are keyed by normalized name alone, one series held
   in two folders is one row, and an entity nothing names any more is

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -74,9 +74,9 @@ already have.**
    KoInsight-compatible endpoint. Neither contaminates the native model.
 6. **Multi-user** from day one: a family or small community on one
    instance, reading state strictly scoped per user.
-7. **First-class EPUB catalog**: every logged-in user can browse the
-   watched folders; only administrators manage them, because that is the
-   only place filesystem paths appear.
+7. **First-class EPUB catalog**: each account can browse the watched
+   folders explicitly granted to it; only administrators manage folders
+   and grants, because that is the only place filesystem paths appear.
 8. **Broad reader integration**: a native catalog API for Liseur clients,
    OPDS 1.2 for existing readers, and an isolated web reader using the
    same sync protocol.
@@ -106,9 +106,10 @@ already have.**
   deployments that already operate it. The server's own writable content
   directory is the cover cache, and everything in it can be recreated.
 - **Folders are the catalog source.** A folder is a row: `id`, `name`,
-  `root_path`, and `kind` (`plain` or `calibre`). It has no owner, no
-  access list, and no lease. Every logged-in account
-  sees every folder's books; only administrators see or change folders.
+  `root_path`, and `kind` (`plain` or `calibre`). It has no owner or
+  lease. Explicit `user_folders` grants decide whose library includes it;
+  administrators manage all folders and grants without receiving implicit
+  reading access ([ADR-0027](adr/0027-explicit-per-user-folder-access.md)).
 - **Adapters translate at the edge.** The kosync and koplugin
   endpoints parse the legacy wire formats and write native records
   tagged with their origin. Nothing downstream knows or cares which
@@ -388,10 +389,10 @@ Designed as the direct negation of the KoInsight findings.
   acting administrator's password before minting durable access.
 - Per-token and per-IP rate limits protect auth endpoints; credential checks
   use constant-time compares.
-- Reading state is scoped by `user_id` at
-  the query layer. Catalog rows are deliberately shared across signed-in
-  users, but positions, sessions, works, devices and `user_book_works`
-  are not.
+- Reading state is scoped by `user_id` at the query layer. Catalog rows are
+  shared, while their visibility is filtered through explicit per-user folder
+  grants. Positions, sessions, works, devices and `user_book_works` remain
+  private to one user.
 - `root_path` never reaches a non-admin response.
 
 ### 8.3 The kosync credential problem, contained
@@ -441,11 +442,11 @@ books    id, folder_id, status, relative_path, calibre_id?, stat,
          content digest, filename, media type, metadata, timestamps
 ```
 
-There is no owner on `folders`. Every logged-in account sees every
-folder's books. Only administrators manage folders because adding one
-names a path on the server. The admin panel and CLI share the same
-rules: `add-folder <name> <root>`, `list-folders`, `remove-folder
-<folder-id>` and `folder-uploads <folder-id> <on|off>`.
+There is no owner on `folders`. A reader sees a folder only through an
+explicit `user_folders` grant; new accounts and folders begin with none.
+Only administrators manage folders and grants because adding one names a path
+on the server. Administrator status grants management authority, not catalog
+visibility, so an administrator assigns a folder to themselves to read it.
 
 `root_path` is stored absolute and never appears in a non-admin API
 response. A folder root is opened read-only; symlinks inside the tree
@@ -584,6 +585,7 @@ ops                user_id, seq, op_id, work_id, edition_sha?, device_id,
 sessions           user_id, session_id, work_id, device_id, started_at,
                    ended_at, start_prog, end_prog, idle_ms, origin
 folders            id, name, root_path, kind
+user_folders        user_id, folder_id
 books              id, folder_id, status, relative_path, calibre_id?,
                    content_sha256, size_bytes, mtime, filename, media_type,
                    title, subtitle, description, publisher, published_date
@@ -613,12 +615,12 @@ foreign key that cascades a book's rows away with it. An entity nothing
 names any more (no membership and no reader's claim) is collected at
 the end of the pass that emptied it, and when a folder is removed.
 
-Works are per-user in v1. The catalog is shared, but the
-`user_book_works` bridge keeps the work graph private. Catalog metadata
-requires `library-read`. Work mappings, positions and completion require
-`sync`; aggregate statistics require `read-insights`. OPDS feeds remain
-metadata-only regardless of extra token scopes and therefore cannot
-inspect private reading state.
+Works are per-user in v1. Catalog records are shared, but `user_folders`
+filters which records a reader can reach and the `user_book_works` bridge
+keeps the work graph private. Catalog metadata requires both a folder grant
+and `library-read`. Work mappings, positions and completion require `sync`;
+aggregate statistics require `read-insights`. OPDS feeds apply the same folder
+grants and remain metadata-only regardless of extra token scopes.
 
 The two `book_series_override_*` tables are the one bounded exception to
 "the catalog is not user-scoped" (ADR-0018). `book_series` still means

--- a/docs/adr/0027-explicit-per-user-folder-access.md
+++ b/docs/adr/0027-explicit-per-user-folder-access.md
@@ -1,0 +1,63 @@
+# ADR-0027: Explicit per-user folder access
+
+- **Status:** Accepted
+- **Date:** 2026-08-22
+- **Depends on:** [ADR-0017](0017-folders-not-pipelines.md)
+- **Amends:** ADR-0017's catalog visibility rule and sections 2, 3, 8,
+  9 and 10 of [DESIGN.md](../DESIGN.md)
+
+## Context
+
+A watched folder is shared catalog data, but treating that as permission for
+every account to browse it makes one server unsuitable for people who keep
+separate libraries. Administrator status describes who may operate the
+instance, not what belongs on that person's reading shelf. Token scopes answer
+which operation a credential may perform, not which folders it may reach.
+
+## Decision
+
+Add an explicit many-to-many `user_folders` grant table. New users, new
+folders and migrated accounts have no grants. A folder has no owner and may be
+granted to any number of users. Administrators manage every folder and every
+grant, but browse a folder only when they grant it to themselves.
+
+Every catalog-facing read takes a viewer user id. A real id requires a grant;
+the empty id is reserved for reconciliation, watchers, administration and
+other trusted internal work. Lists omit inaccessible rows and direct access
+returns `404`, including for an empty folder. Series, contributors and tags
+remain library-wide identities, while their counts, facets and book results
+use only books visible to the viewer.
+
+Downloads, covers, OPDS, search, uploads, deletion, work resolution and
+backfill use the same boundary. Capability checks remain separate: a missing
+scope is `403`, while a missing grant is `404`. Upload digest deduplication is
+viewer-scoped so bytes in a hidden folder do not disclose that folder or
+prevent a copy being added to an accessible one.
+
+Revoking a grant removes no reading state and no `user_book_works` row. It
+only makes the catalog side of that mapping inaccessible. Restoring the grant
+therefore reconnects the existing work, positions, sessions and statistics.
+
+Grant management is available in each user's administration page and through
+the administrator CLI. There is no public grant-management API, folder
+ownership, grant copying or user-count field on folders.
+
+## Consequences
+
+- An account's library is empty until an administrator assigns folders.
+- Administrator role and reading access are independent.
+- Catalog queries carry a viewer id even though catalog rows remain shared.
+- Deployments upgrading to migration 4 must assign existing accounts' folders.
+- Revocation is reversible and does not erase reading history.
+
+## Acceptance criteria
+
+- SQLite and PostgreSQL apply migration 4 without creating grants.
+- Assignment, removal and atomic replacement validate both sides and cascade
+  when either side is deleted.
+- Every catalog and file-serving surface returns only granted content, with
+  inaccessible direct URLs answering `404`.
+- Upload and deletion require both the relevant token scope and a folder
+  grant, and digest deduplication cannot reveal hidden books.
+- The web panel and CLI manage grants, including administrator self-assignment.
+- Revoking and restoring a grant preserves and reconnects reading history.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -51,6 +51,7 @@ loose ends that must come before any of it, are in
 | [0024](0024-deleting-a-work.md) | Deleting is a reader forgetting, or an administrator retiring | Later | Accepted; implemented | Per-user work delete for a work no book backs, admin delete of a missing catalog row; amends the append-only rule for that one case |
 | [0025](0025-deleting-a-book.md) | A book may be deleted where a book may be written | Later | Accepted | Deleting a book's file and row from an `accepts_uploads` folder; `library-delete` scope over the API, admin in the browser; amends [0024](0024-deleting-a-work.md) and rule 3 of [0017](0017-folders-not-pipelines.md) again |
 | [0026](0026-credential-enrolment-does-not-weaken-account-authentication.md) | Credential enrolment does not weaken account authentication | MVP | Accepted; implemented | Kosync pairing only; administrator password re-verification before creating an account or invite |
+| [0027](0027-explicit-per-user-folder-access.md) | Explicit per-user folder access | MVP | Accepted; implemented | Folder grants across storage, catalog surfaces, administration and CLI; amends [0017](0017-folders-not-pipelines.md) |
 
 ## Convention
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -174,10 +174,10 @@ the panel or the shell, so an instance cannot lock itself out.
 
 ## Watching folders
 
-A folder is a database row: `id`, `name`, `root_path`, and `kind`. It
-has no owner and no access list. Every logged-in user sees every
-folder's books; only an admin sees or changes folders, because a folder
-is the only place a filesystem path appears.
+A folder is a database row: `id`, `name`, `root_path`, and `kind`. It has no
+owner. An administrator explicitly grants folders to accounts; administrator
+status alone does not add a folder to that administrator's library. Only an
+admin sees or changes folder paths and grants.
 
 Add one from Settings > Administration > Folders, or from a shell:
 
@@ -185,7 +185,17 @@ Add one from Settings > Administration > Folders, or from a shell:
 liseur-sync admin -config liseur-sync.toml add-folder Shelf /srv/books
 liseur-sync admin -config liseur-sync.toml list-folders
 liseur-sync admin -config liseur-sync.toml remove-folder <folder-id>
+liseur-sync admin -config liseur-sync.toml assign-folder alice <folder-id>
+liseur-sync admin -config liseur-sync.toml unassign-folder alice <folder-id>
+liseur-sync admin -config liseur-sync.toml list-user-folders alice
+liseur-sync admin -config liseur-sync.toml assign-all-folders alice
 ```
+
+The per-account checkboxes under Settings > Administration > Users submit
+the account's complete grant set, so the page lists every watched folder
+rather than a page of them. Past 500 folders it stops offering the form —
+a list it had to truncate would revoke whatever fell off the end — and the
+`assign-folder` and `unassign-folder` commands above take over.
 
 Removing a folder removes the catalog rows that came from it and stops
 watching the root. Nothing below the root is touched. Adding it back

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -17,9 +17,10 @@ integrate.
   that sequence.
 - **Session**: one reading session, a measured fact with progression
   fractions. Sessions feed the statistics endpoints.
-- **Folder**: a watched server-side directory of books. It is shared by
-  every logged-in user, and its filesystem path is never returned to a
-  non-admin client.
+- **Folder**: a watched server-side directory of books. An administrator
+  explicitly grants it to accounts; its filesystem path is never returned to
+  a non-admin client. Administrator status does not itself add the folder to
+  that account's library.
 - **Device token**: a scoped bearer token per physical device. The
   server stamps ops and sessions with the token's `device_id`; you do
   not send one. A token may carry several scopes.
@@ -63,6 +64,11 @@ applies, and for the same reason; it is the flag that decides where
 this server may write at all.
 
 All API calls then use `Authorization: Bearer <secret>`.
+
+Folder grants and token scopes are independent. A catalog list contains only
+the caller's granted folders. Direct access to another folder or one of its
+books returns `404`; lacking the scope for the attempted operation returns
+`403`. A newly created account has no folder grants.
 
 ### Finding out what your token can do
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -14,6 +14,10 @@ info:
       for token management; device tokens carry one or more scopes
       (`sync`, `read-insights`, `library-read`, `library-manage`,
       `library-upload`, `library-delete`, `admin`).
+    - **Folder access**: catalog scopes and folder grants are independent.
+      Catalog listings contain only books from folders explicitly granted to
+      the token's account. Direct access to an inaccessible folder, book or
+      entity returns `404`; administrator status does not bypass this rule.
     - **Identity**: books are *works*. Clients never need a work to
       exist before pushing: call `/v1/works/resolve` with every
       identifier you have and use the returned `work_id`.
@@ -730,8 +734,8 @@ paths:
       security: [{ deviceToken: [] }]  # requires library-read scope
       description: |
         Where a catalog client starts: every other route needs a folder
-        id. Every logged-in user sees every folder, because a folder is a
-        shelf rather than an account. `root_path` is deliberately not
+        id. The list contains only folders explicitly granted to the token's
+        account; administrator status does not imply a grant. `root_path` is deliberately not
         here — it is a fact about the server's filesystem, and naming it
         would make this route an oracle for one.
       parameters:
@@ -820,7 +824,7 @@ paths:
                     type: string
                     description: Absent on the last page.
         "400": { $ref: "#/components/responses/Error", description: "Bad limit or malformed cursor" }
-        "404": { $ref: "#/components/responses/Error", description: "No such folder" }
+        "404": { $ref: "#/components/responses/Error", description: "No such folder, or the folder is not granted to this account" }
 
     post:
       tags: [library]
@@ -875,8 +879,8 @@ paths:
                   duplicate: { type: boolean, enum: [false] }
         "200":
           description: |
-            The catalog already held these bytes, here or in another
-            folder. Nothing was written and this is the book.
+            The caller's visible catalog already held these bytes, here or in
+            another granted folder. Nothing was written and this is the book.
           content:
             application/json:
               schema:
@@ -905,7 +909,7 @@ paths:
         "400": { $ref: "#/components/responses/Error", description: "Malformed multipart body or an empty upload" }
         "403":
           description: The folder does not accept uploads, or the token lacks `library-upload`.
-        "404": { description: No such folder }
+        "404": { description: "No such folder, or the folder is not granted to this account" }
         "409":
           description: |
             A Calibre library that is busy. Close Calibre and retry.
@@ -968,7 +972,7 @@ paths:
             application/json:
               schema: { $ref: "#/components/schemas/SearchResult" }
         "400": { $ref: "#/components/responses/Error", description: "Bad limit, over-long query, or malformed entity filter" }
-        "404": { $ref: "#/components/responses/Error", description: "No such folder" }
+        "404": { $ref: "#/components/responses/Error", description: "No such folder, or the folder is not granted to this account" }
 
   /v1/books/{id}:
     get:
@@ -1030,7 +1034,7 @@ paths:
           description: |
             The book's folder does not accept uploads, or the token
             lacks `library-delete`.
-        "404": { description: No such book }
+        "404": { description: "No such book, or its folder is not granted to this account" }
         "409":
           description: |
             The file changed since it was last scanned and was left
@@ -2301,8 +2305,9 @@ components:
         are separate because sending your own book and destroying
         everyone's are different questions. `library-manage` does
         not grant catalog reads; request `library-read` too when a
-        client needs both. `admin` implies all scopes. No other scope
-        implies another. `admin` cannot be self-granted: creating or
+        client needs both. Scopes never imply folder grants, including
+        `admin`. `admin` implies all scopes. No other scope implies
+        another. `admin` cannot be self-granted: creating or
         updating a token to include it requires an existing admin token
         or the admin CLI.
     ScopeSet:

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -58,6 +58,14 @@ func Run(st store.Store, args []string) error {
 		return removeFolder(ctx, st, args[1:])
 	case "folder-uploads":
 		return setFolderUploads(ctx, st, args[1:])
+	case "assign-folder":
+		return assignFolder(ctx, st, args[1:])
+	case "unassign-folder":
+		return unassignFolder(ctx, st, args[1:])
+	case "list-user-folders":
+		return listUserFolders(ctx, st, args[1:])
+	case "assign-all-folders":
+		return assignAllFolders(ctx, st, args[1:])
 	case "backfill-works":
 		return backfillWorks(ctx, st, args[1:])
 	default:
@@ -124,6 +132,12 @@ const Usage = `usage: liseur-sync admin [-config <file>] <subcommand>
   remove-folder <folder-id>     stop watching a folder and forget what
                                 was catalogued from it; nothing under the
                                 directory is touched
+  assign-folder <user> <folder-id>
+                                add a folder to one account's library
+  unassign-folder <user> <folder-id>
+                                remove a folder from one account's library
+  list-user-folders <user>      list folders assigned to one account
+  assign-all-folders <user>     assign every folder watched right now
 
   backfill-works <user>         map every catalog book to a sync work
                                 for this user, so statistics do not wait

--- a/internal/admin/folders.go
+++ b/internal/admin/folders.go
@@ -179,7 +179,7 @@ func listFolders(ctx context.Context, st store.Store, args []string) error {
 	}
 	var after string
 	for {
-		folders, err := st.ListFolders(ctx, after, 100)
+		folders, err := st.ListFolders(ctx, "", after, 100)
 		if err != nil {
 			return err
 		}
@@ -207,7 +207,7 @@ func removeFolder(ctx context.Context, st store.Store, args []string) error {
 		return errors.New("usage: remove-folder <folder-id>")
 	}
 	folderID := strings.TrimSpace(args[0])
-	folder, err := st.FolderByID(ctx, folderID)
+	folder, err := st.FolderByID(ctx, "", folderID)
 	if err != nil {
 		return err
 	}
@@ -239,7 +239,7 @@ func setFolderUploads(ctx context.Context, st store.Store, args []string) error 
 	default:
 		return fmt.Errorf("want on or off, got %q", args[1])
 	}
-	folder, err := st.FolderByID(ctx, folderID)
+	folder, err := st.FolderByID(ctx, "", folderID)
 	if err != nil {
 		return err
 	}
@@ -252,5 +252,96 @@ func setFolderUploads(ctx context.Context, st store.Store, args []string) error 
 	} else {
 		fmt.Printf("%q (%s) no longer accepts uploads\n", folder.Name, folder.RootPath)
 	}
+	return nil
+}
+
+func assignFolder(ctx context.Context, st store.Store, args []string) error {
+	if len(args) != 2 {
+		return errors.New("usage: assign-folder <user> <folder-id>")
+	}
+	user, err := st.UserByName(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	folderID := strings.TrimSpace(args[1])
+	if err := st.AssignUserFolder(ctx, user.ID, folderID); err != nil {
+		return err
+	}
+	folder, err := st.FolderByID(ctx, "", folderID)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("assigned %q (%s) to %q\n", folder.Name, folder.ID, user.Name)
+	return nil
+}
+
+func unassignFolder(ctx context.Context, st store.Store, args []string) error {
+	if len(args) != 2 {
+		return errors.New("usage: unassign-folder <user> <folder-id>")
+	}
+	user, err := st.UserByName(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	folderID := strings.TrimSpace(args[1])
+	if err := st.UnassignUserFolder(ctx, user.ID, folderID); err != nil {
+		return err
+	}
+	fmt.Printf("unassigned folder %s from %q\n", folderID, user.Name)
+	return nil
+}
+
+func listUserFolders(ctx context.Context, st store.Store, args []string) error {
+	if len(args) != 1 {
+		return errors.New("usage: list-user-folders <user>")
+	}
+	user, err := st.UserByName(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	var after string
+	for {
+		folders, err := st.ListUserFolders(ctx, user.ID, after, 100)
+		if err != nil {
+			return err
+		}
+		for _, folder := range folders {
+			fmt.Printf("%s\t%s\t%s\t%s\n",
+				folder.ID, folder.Kind, folder.Name, folder.RootPath)
+		}
+		if len(folders) < 100 {
+			return nil
+		}
+		after = store.FolderCursor(folders[len(folders)-1])
+	}
+}
+
+func assignAllFolders(ctx context.Context, st store.Store, args []string) error {
+	if len(args) != 1 {
+		return errors.New("usage: assign-all-folders <user>")
+	}
+	user, err := st.UserByName(ctx, args[0])
+	if err != nil {
+		return err
+	}
+	var ids []string
+	var after string
+	for {
+		folders, err := st.ListFolders(ctx, "", after, 100)
+		if err != nil {
+			return err
+		}
+		for _, folder := range folders {
+			ids = append(ids, folder.ID)
+		}
+		if len(folders) < 100 {
+			break
+		}
+		after = store.FolderCursor(folders[len(folders)-1])
+	}
+	if err := st.ReplaceUserFolders(ctx, user.ID, ids); err != nil {
+		return err
+	}
+	fmt.Printf("assigned %d folders to %q\n", len(ids), user.Name)
 	return nil
 }

--- a/internal/admin/folders_test.go
+++ b/internal/admin/folders_test.go
@@ -113,7 +113,7 @@ func TestAddListRemoveFolder(t *testing.T) {
 	if !strings.Contains(removed, "nothing under that directory was changed") {
 		t.Fatalf("remove-folder said %q", removed)
 	}
-	after, err := st.ListFolders(t.Context(), "", 10)
+	after, err := st.ListFolders(t.Context(), "", "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -124,6 +124,60 @@ func TestAddListRemoveFolder(t *testing.T) {
 	// not have taken it with them.
 	if _, err := os.Stat(root); err != nil {
 		t.Fatalf("remove-folder touched the disk: %v", err)
+	}
+}
+
+func TestFolderGrantCommands(t *testing.T) {
+	st := newAdminStore(t)
+	user := addUser(t, st, "reader")
+	administrator := addUser(t, st, "administrator")
+	if err := st.SetUserAdmin(t.Context(), administrator.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	one, err := capture(t, st, "add-folder", "One", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	two, err := capture(t, st, "add-folder", "Two", t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	oneID, twoID := folderIDFrom(t, one), folderIDFrom(t, two)
+
+	if _, err := capture(t, st, "assign-folder", user.Name, oneID); err != nil {
+		t.Fatal(err)
+	}
+	listed, err := capture(t, st, "list-user-folders", user.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(listed, oneID) || strings.Contains(listed, twoID) {
+		t.Fatalf("one-folder list = %q", listed)
+	}
+	if _, err := capture(t, st, "assign-all-folders", user.Name); err != nil {
+		t.Fatal(err)
+	}
+	listed, err = capture(t, st, "list-user-folders", user.Name)
+	if err != nil || !strings.Contains(listed, oneID) || !strings.Contains(listed, twoID) {
+		t.Fatalf("all-folder list = %q, %v", listed, err)
+	}
+	if _, err := capture(t, st, "unassign-folder", user.Name, oneID); err != nil {
+		t.Fatal(err)
+	}
+	listed, err = capture(t, st, "list-user-folders", user.Name)
+	if err != nil || strings.Contains(listed, oneID) || !strings.Contains(listed, twoID) {
+		t.Fatalf("unassigned list = %q, %v", listed, err)
+	}
+	listed, err = capture(t, st, "list-user-folders", administrator.Name)
+	if err != nil || listed != "" {
+		t.Fatalf("administrator received implicit folders: %q, %v", listed, err)
+	}
+	if _, err := capture(t, st, "assign-folder", administrator.Name, oneID); err != nil {
+		t.Fatal(err)
+	}
+	listed, err = capture(t, st, "list-user-folders", administrator.Name)
+	if err != nil || !strings.Contains(listed, oneID) {
+		t.Fatalf("administrator explicit assignment = %q, %v", listed, err)
 	}
 }
 
@@ -249,7 +303,7 @@ func TestFolderUploadsIsOffUntilAskedFor(t *testing.T) {
 	}
 	id := folderIDFrom(t, added)
 
-	folder, err := st.FolderByID(t.Context(), id)
+	folder, err := st.FolderByID(t.Context(), "", id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -260,7 +314,7 @@ func TestFolderUploadsIsOffUntilAskedFor(t *testing.T) {
 	if _, err := capture(t, st, "folder-uploads", id, "on"); err != nil {
 		t.Fatal(err)
 	}
-	if folder, err = st.FolderByID(t.Context(), id); err != nil {
+	if folder, err = st.FolderByID(t.Context(), "", id); err != nil {
 		t.Fatal(err)
 	}
 	if !folder.AcceptsUploads {
@@ -270,7 +324,7 @@ func TestFolderUploadsIsOffUntilAskedFor(t *testing.T) {
 	if _, err := capture(t, st, "folder-uploads", id, "off"); err != nil {
 		t.Fatal(err)
 	}
-	if folder, err = st.FolderByID(t.Context(), id); err != nil {
+	if folder, err = st.FolderByID(t.Context(), "", id); err != nil {
 		t.Fatal(err)
 	}
 	if folder.AcceptsUploads {

--- a/internal/api/catalog.go
+++ b/internal/api/catalog.go
@@ -51,7 +51,8 @@ type BookFiles interface {
 // root_path is deliberately absent: it is a filesystem oracle and no
 // part of reading a catalog. Only the admin UI shows it.
 func (s *Server) HandleFolders(w http.ResponseWriter, r *http.Request) {
-	if _, ok := auth.TokenFrom(r); !ok {
+	tok, ok := auth.TokenFrom(r)
+	if !ok {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -65,7 +66,7 @@ func (s *Server) HandleFolders(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "cursor is too long")
 		return
 	}
-	folders, err := s.St.ListFolders(r.Context(), after, limit)
+	folders, err := s.St.ListFolders(r.Context(), tok.UserID, after, limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "folder lookup failed")
 		return
@@ -90,7 +91,8 @@ func (s *Server) HandleFolders(w http.ResponseWriter, r *http.Request) {
 
 // HandleFolderBooks implements GET /v1/folders/{folder}/books.
 func (s *Server) HandleFolderBooks(w http.ResponseWriter, r *http.Request) {
-	if _, ok := auth.TokenFrom(r); !ok {
+	tok, ok := auth.TokenFrom(r)
+	if !ok {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -125,7 +127,7 @@ func (s *Server) HandleFolderBooks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	books, err := list(r.Context(), folderID, after, limit)
+	books, err := list(r.Context(), tok.UserID, folderID, after, limit)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "folder not found")
@@ -160,7 +162,7 @@ func (s *Server) HandleBook(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
-	book, err := s.St.CatalogBookByID(r.Context(), r.PathValue("id"))
+	book, err := s.St.CatalogBookByID(r.Context(), readerID(r), r.PathValue("id"))
 	if err != nil {
 		writeCatalogError(w, err, "book not found")
 		return
@@ -182,7 +184,7 @@ func (s *Server) HandleBookDownload(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
-	s.ServeBookDownload(w, r, r.PathValue("id"))
+	s.ServeBookDownload(w, r, readerID(r), r.PathValue("id"))
 }
 
 // ServeBookDownload is the download itself, without the token. The web
@@ -191,13 +193,13 @@ func (s *Server) HandleBookDownload(w http.ResponseWriter, r *http.Request) {
 // below are what keep a hostile file from becoming a hostile download,
 // and there must not be a second copy of them.
 func (s *Server) ServeBookDownload(
-	w http.ResponseWriter, r *http.Request, bookID string,
+	w http.ResponseWriter, r *http.Request, viewerID, bookID string,
 ) {
 	if s.Files == nil {
 		writeError(w, http.StatusServiceUnavailable, "content storage is unavailable")
 		return
 	}
-	book, err := s.St.CatalogBookByID(r.Context(), bookID)
+	book, err := s.St.CatalogBookByID(r.Context(), viewerID, bookID)
 	if err != nil {
 		writeCatalogError(w, err, "book not found")
 		return
@@ -305,8 +307,8 @@ func writeCatalogError(w http.ResponseWriter, err error, notFound string) {
 }
 
 // readerID is who a catalog read is answered for. Series memberships
-// resolve through that reader's override layers (ADR-0018); every other
-// part of the catalog is shared and does not depend on who is asking.
+// resolve through that reader's override layers (ADR-0018), and folder
+// grants decide which shared catalog rows are visible (ADR-0027).
 // It is empty only for a request that reached here unauthenticated,
 // which the handlers refuse before getting this far.
 func readerID(r *http.Request) string {

--- a/internal/api/catalog_test.go
+++ b/internal/api/catalog_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -133,11 +134,9 @@ func TestDownloadServesRangesAndConditionalRequests(t *testing.T) {
 	}
 }
 
-// TestTheCatalogIsSharedAcrossEveryReader is ADR-0017's central claim
-// checked over HTTP: every signed-in account sees the same folder's
-// books, with no grant involved, while a reading position stays private
-// to whoever set it.
-func TestTheCatalogIsSharedAcrossEveryReader(t *testing.T) {
+// TestAnAssignedCatalogCanBeSharedAcrossReaders checks that a folder may
+// be granted to more than one account while reading state stays private.
+func TestAnAssignedCatalogCanBeSharedAcrossReaders(t *testing.T) {
 	f := newFolderFixture(t)
 	bookID, _ := f.publish(t, "shared", []byte("a shared book"))
 	mine := f.mintToken(t, f.user.ID, store.ScopeLibraryRead, store.ScopeSync)
@@ -176,6 +175,78 @@ func TestTheCatalogIsSharedAcrossEveryReader(t *testing.T) {
 	mapping, err = f.st.UserBookWork(t.Context(), f.other.ID, bookID)
 	if err != nil || mapping.WorkID != b.WorkID {
 		t.Fatalf("other's own mapping: %+v %v", mapping, err)
+	}
+}
+
+func TestFolderGrantsIsolateCatalogSurfaces(t *testing.T) {
+	f := newFolderFixture(t)
+	bookID, _ := f.publishWithAuthor(t, "private", "Private Book", "Private Author", []byte("secret"))
+	if _, err := f.st.SetBookSeriesOverride(t.Context(), f.user.ID, bookID,
+		store.SeriesSourceShared, []store.SeriesClaimItem{{Name: "Private Series"}},
+		store.SeriesClaimMutation{At: time.Now().UTC()}); err != nil {
+		t.Fatal(err)
+	}
+	allContributors, err := f.st.ListCatalogEntities(
+		t.Context(), "", store.EntityContributor, "", 10)
+	if err != nil || len(allContributors) != 1 {
+		t.Fatalf("seed contributors = %+v, %v", allContributors, err)
+	}
+	allSeries, err := f.st.ListCatalogEntities(t.Context(), "", store.EntitySeries, "", 10)
+	if err != nil || len(allSeries) != 1 {
+		t.Fatalf("seed series = %+v, %v", allSeries, err)
+	}
+	if err := f.st.UnassignUserFolder(t.Context(), f.other.ID, f.folder.ID); err != nil {
+		t.Fatal(err)
+	}
+	read := f.mintToken(t, f.other.ID, store.ScopeLibraryRead)
+
+	code, folders := getJSON(t, f.ts.URL+"/v1/folders", read)
+	if code != http.StatusOK || len(folders["folders"].([]any)) != 0 {
+		t.Fatalf("folders = %d %v, want an empty catalog", code, folders)
+	}
+	code, search := getJSON(t, f.ts.URL+f.searchPath(url.Values{"q": {"Private"}}), read)
+	if code != http.StatusNotFound {
+		t.Fatalf("search = %d %v, want 404 for a hidden folder", code, search)
+	}
+	code, entities := getJSON(t, f.ts.URL+"/v1/entities/contributors", read)
+	if code != http.StatusOK || len(entities["entities"].([]any)) != 0 {
+		t.Fatalf("contributors = %d %v, want no hidden contributors", code, entities)
+	}
+
+	for _, path := range []string{
+		"/v1/folders/" + f.folder.ID + "/books",
+		"/v1/books/" + bookID,
+		"/v1/books/" + bookID + "/download",
+		"/v1/books/" + bookID + "/cover",
+		"/v1/entities/contributors/" + allContributors[0].ID + "/books",
+		"/v1/entities/series/" + allSeries[0].ID + "/books",
+	} {
+		resp, _ := f.get(t, path, read)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s = %d, want 404", path, resp.StatusCode)
+		}
+	}
+
+	resp, raw := f.opds(t, "/opds/v1.2", "token", read)
+	if resp.StatusCode != http.StatusOK || len(parseFeed(t, raw).Entries) != 0 {
+		t.Fatalf("OPDS root = %d %s, want an empty feed", resp.StatusCode, raw)
+	}
+	resp, _ = f.opds(t, "/opds/v1.2/folders/"+f.folder.ID, "token", read)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("OPDS folder = %d, want 404", resp.StatusCode)
+	}
+	resp, _ = f.opds(t, "/opds/v1.2/folders/"+f.folder.ID+
+		"/contributors/"+allContributors[0].ID, "token", read)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("OPDS entity = %d, want 404", resp.StatusCode)
+	}
+
+	if err := f.st.SetUserAdmin(t.Context(), f.other.ID, true); err != nil {
+		t.Fatal(err)
+	}
+	resp, _ = f.get(t, "/v1/books/"+bookID, read)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("administrator without a grant = %d, want 404", resp.StatusCode)
 	}
 }
 

--- a/internal/api/catalogwork.go
+++ b/internal/api/catalogwork.go
@@ -36,11 +36,11 @@ type catalogResolveResponse struct {
 func (s *Server) resolveBookWork(
 	ctx context.Context, userID, bookID string, confirmed bool, at time.Time,
 ) (store.WorkResolution, []store.Identifier, error) {
-	book, err := s.St.CatalogBookByID(ctx, bookID)
+	book, err := s.St.CatalogBookByID(ctx, userID, bookID)
 	if err != nil {
 		return store.WorkResolution{}, nil, err
 	}
-	bookIDs, author, err := workident.Evidence(ctx, s.St, bookID)
+	bookIDs, author, err := workident.Evidence(ctx, s.St, userID, bookID)
 	if err != nil {
 		return store.WorkResolution{}, nil, err
 	}

--- a/internal/api/catalogwork_test.go
+++ b/internal/api/catalogwork_test.go
@@ -116,8 +116,8 @@ func TestResolveJoinsADownloadedBookToTheReadersWork(t *testing.T) {
 
 // TestResolveGivesEachReaderTheirOwnWork is the privacy property: a
 // shared catalog book must not become a shared work, or one reader's
-// position would be another's. Unlike the old library-ACL world there is
-// no grant to set up: every reader already sees this book.
+// position would be another's. The fixture assigns the same folder to
+// both readers before they resolve the book.
 func TestResolveGivesEachReaderTheirOwnWork(t *testing.T) {
 	f := newFolderFixture(t)
 	bookID, _ := f.publish(t, "shared", []byte("a shared book"))

--- a/internal/api/cover.go
+++ b/internal/api/cover.go
@@ -38,7 +38,7 @@ func (s *Server) HandleBookCover(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
-	s.ServeBookCover(w, r, r.PathValue("id"))
+	s.ServeBookCover(w, r, readerID(r), r.PathValue("id"))
 }
 
 // ServeBookCover is the cover itself, without the token, so the web UI
@@ -51,7 +51,7 @@ func (s *Server) HandleBookCover(w http.ResponseWriter, r *http.Request) {
 // server doing work for books nobody looks at, and a cache that has to
 // be kept in step with a folder somebody else edits.
 func (s *Server) ServeBookCover(
-	w http.ResponseWriter, r *http.Request, bookID string,
+	w http.ResponseWriter, r *http.Request, viewerID, bookID string,
 ) {
 	if s.Files == nil {
 		writeError(w, http.StatusServiceUnavailable, "content storage is unavailable")
@@ -62,7 +62,7 @@ func (s *Server) ServeBookCover(
 		writeError(w, http.StatusBadRequest, "unknown cover size")
 		return
 	}
-	book, err := s.St.CatalogBookByID(r.Context(), bookID)
+	book, err := s.St.CatalogBookByID(r.Context(), viewerID, bookID)
 	if err != nil {
 		writeCatalogError(w, err, "book not found")
 		return

--- a/internal/api/delete.go
+++ b/internal/api/delete.go
@@ -56,14 +56,14 @@ func (s *Server) DeleteBook(
 		return DeleteOutcome{}, deleteErr(http.StatusServiceUnavailable,
 			"this server is running without a folder watcher")
 	}
-	book, err := s.St.CatalogBookByID(ctx, bookID)
+	book, err := s.St.CatalogBookByID(ctx, userID, bookID)
 	if errors.Is(err, store.ErrNotFound) {
 		return DeleteOutcome{}, deleteErr(http.StatusNotFound, "no such book")
 	}
 	if err != nil {
 		return DeleteOutcome{}, err
 	}
-	folder, err := s.St.FolderByID(ctx, book.FolderID)
+	folder, err := s.St.FolderByID(ctx, userID, book.FolderID)
 	if errors.Is(err, store.ErrNotFound) {
 		return DeleteOutcome{}, deleteErr(http.StatusNotFound, "no such book")
 	}

--- a/internal/api/delete_test.go
+++ b/internal/api/delete_test.go
@@ -53,7 +53,7 @@ func TestDeleteBookRemovesTheFileAndTheRow(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(f.root, "gone.epub")); !os.IsNotExist(err) {
 		t.Errorf("the file survived: %v", err)
 	}
-	if _, err := f.st.CatalogBookByID(t.Context(), bookID); err == nil {
+	if _, err := f.st.CatalogBookByID(t.Context(), "", bookID); err == nil {
 		t.Error("the catalog row survived")
 	}
 }
@@ -71,7 +71,7 @@ func TestDeleteBookRefusesAFolderThatDoesNotAcceptUploads(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(f.root, "kept.epub")); err != nil {
 		t.Errorf("the file was deleted from a folder nobody marked: %v", err)
 	}
-	if _, err := f.st.CatalogBookByID(t.Context(), bookID); err != nil {
+	if _, err := f.st.CatalogBookByID(t.Context(), "", bookID); err != nil {
 		t.Errorf("the row went even though the file stayed: %v", err)
 	}
 }
@@ -103,6 +103,23 @@ func TestDeleteBookAnswers404ForABookThatIsNotThere(t *testing.T) {
 
 	if resp := f.deleteBook(t, token, "no-such-book", ""); resp.StatusCode != http.StatusNotFound {
 		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestDeleteBookAnswers404WithoutAFolderGrant(t *testing.T) {
+	f := newFolderFixture(t)
+	f.allowUploads(t)
+	bookID, _ := f.publishAs(t, "private", "Private", []byte("bytes"))
+	if err := f.st.UnassignUserFolder(t.Context(), f.user.ID, f.folder.ID); err != nil {
+		t.Fatal(err)
+	}
+	token := f.mintToken(t, f.user.ID, store.ScopeLibraryDelete)
+
+	if resp := f.deleteBook(t, token, bookID, ""); resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	if _, err := os.Stat(filepath.Join(f.root, "private.epub")); err != nil {
+		t.Fatalf("the inaccessible file was changed: %v", err)
 	}
 }
 

--- a/internal/api/fixture_test.go
+++ b/internal/api/fixture_test.go
@@ -39,10 +39,8 @@ type folderFixture struct {
 	srv   *Server
 	cache *content.Cache
 
-	// user and other are two distinct accounts. The catalog is shared
-	// (ADR-0017), so most tests need only user; the ones asserting that
-	// sharing is real, and that reading state stays private, need other
-	// too.
+	// user and other are two distinct accounts. The fixture grants its
+	// default folder to both; isolation tests explicitly revoke one grant.
 	user  store.User
 	other store.User
 	// token is user's everyday credential: library-read and sync, the
@@ -108,6 +106,11 @@ func newFolderFixture(t *testing.T) *folderFixture {
 	if err := st.CreateFolder(t.Context(), f.folder); err != nil {
 		t.Fatal(err)
 	}
+	for _, user := range []store.User{f.user, f.other} {
+		if err := st.AssignUserFolder(t.Context(), user.ID, f.folder.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
 	f.rec = content.NewReconciler(st, content.ScanLimits{}, epub.DefaultLimits(),
 		slog.New(slog.DiscardHandler))
 	// The upload route hands its bytes to the same reconciler the tests
@@ -131,6 +134,22 @@ func (f *folderFixture) createUser(t *testing.T, name string) store.User {
 	}
 	if err := f.st.CreateUser(t.Context(), u); err != nil {
 		t.Fatal(err)
+	}
+	var after string
+	for {
+		folders, err := f.st.ListFolders(t.Context(), "", after, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, folder := range folders {
+			if err := f.st.AssignUserFolder(t.Context(), u.ID, folder.ID); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if len(folders) < 100 {
+			break
+		}
+		after = store.FolderCursor(folders[len(folders)-1])
 	}
 	return u
 }
@@ -162,6 +181,11 @@ func (f *folderFixture) reconcile(t *testing.T) store.ReconcileResult {
 // the plain folder every other test uses.
 func (f *folderFixture) reconcileFolder(t *testing.T, folder store.Folder) store.ReconcileResult {
 	t.Helper()
+	for _, user := range []store.User{f.user, f.other} {
+		if err := f.st.AssignUserFolder(t.Context(), user.ID, folder.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
 	result, err := f.rec.Reconcile(t.Context(), folder)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/api/opds.go
+++ b/internal/api/opds.go
@@ -79,12 +79,12 @@ type opdsText struct {
 // folders this server watches, which is all a reader needs to reach
 // every book: there is no other entry point.
 func (s *Server) HandleOPDSRoot(w http.ResponseWriter, r *http.Request) {
-	_, ok := auth.TokenFrom(r)
+	tok, ok := auth.TokenFrom(r)
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
-	folders, err := s.St.ListFolders(r.Context(), "", maxCatalogPageSize)
+	folders, err := s.St.ListFolders(r.Context(), tok.UserID, "", maxCatalogPageSize)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "folder lookup failed")
 		return
@@ -117,7 +117,8 @@ func (s *Server) HandleOPDSRoot(w http.ResponseWriter, r *http.Request) {
 // paginated with the same cursor as the native catalog, exposed to the
 // reader only as an opaque `next` link.
 func (s *Server) HandleOPDSFolder(w http.ResponseWriter, r *http.Request) {
-	if _, ok := auth.TokenFrom(r); !ok {
+	tok, ok := auth.TokenFrom(r)
+	if !ok {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -132,7 +133,7 @@ func (s *Server) HandleOPDSFolder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	limit := defaultCatalogPageSize
-	books, err := s.St.ListCatalogBooks(r.Context(), folderID, after, limit)
+	books, err := s.St.ListCatalogBooks(r.Context(), tok.UserID, folderID, after, limit)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "folder not found")

--- a/internal/api/opdsbrowse.go
+++ b/internal/api/opdsbrowse.go
@@ -39,7 +39,8 @@ type opdsSearchURL struct {
 // The folder is checked before the document is written, so a document
 // never confirms a folder that does not exist.
 func (s *Server) HandleOPDSSearchDescription(w http.ResponseWriter, r *http.Request) {
-	if _, ok := auth.TokenFrom(r); !ok {
+	tok, ok := auth.TokenFrom(r)
+	if !ok {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -48,7 +49,7 @@ func (s *Server) HandleOPDSSearchDescription(w http.ResponseWriter, r *http.Requ
 		writeError(w, http.StatusNotFound, "folder not found")
 		return
 	}
-	folder, err := s.St.FolderByID(r.Context(), folderID)
+	folder, err := s.St.FolderByID(r.Context(), tok.UserID, folderID)
 	if err != nil {
 		writeCatalogError(w, err, "folder not found")
 		return
@@ -89,7 +90,8 @@ func (s *Server) HandleOPDSSearchDescription(w http.ResponseWriter, r *http.Requ
 // link: a reader that reaches the end of this feed has seen the best
 // matches, and the answer to wanting more is a better query.
 func (s *Server) HandleOPDSSearch(w http.ResponseWriter, r *http.Request) {
-	if _, ok := auth.TokenFrom(r); !ok {
+	tok, ok := auth.TokenFrom(r)
+	if !ok {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -105,6 +107,7 @@ func (s *Server) HandleOPDSSearch(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := s.St.SearchCatalogBooks(r.Context(), store.SearchQuery{
 		FolderID: folderID,
+		UserID:   tok.UserID,
 		Text:     text,
 		Limit:    defaultCatalogPageSize,
 	})
@@ -269,7 +272,8 @@ func plainPlural(n int, noun string) string {
 // from the folder's own feed rather than the root, because "recent" only
 // means anything inside one folder.
 func (s *Server) HandleOPDSRecent(w http.ResponseWriter, r *http.Request) {
-	if _, ok := auth.TokenFrom(r); !ok {
+	tok, ok := auth.TokenFrom(r)
+	if !ok {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
@@ -284,7 +288,7 @@ func (s *Server) HandleOPDSRecent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	limit := defaultCatalogPageSize
-	books, err := s.St.ListRecentCatalogBooks(r.Context(), folderID, before, limit)
+	books, err := s.St.ListRecentCatalogBooks(r.Context(), tok.UserID, folderID, before, limit)
 	if err != nil {
 		writeCatalogError(w, err, "folder not found")
 		return

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -339,9 +339,9 @@ func (s *Server) Routes() *http.ServeMux {
 	mux.Handle("GET /v1/insights/works/{id}", insH(s.HandleInsightsWork))
 	mux.Handle("GET /v1/insights/calendar", insH(s.HandleInsightsCalendar))
 
-	// library-read scope: the catalog. Every signed-in reader sees every
-	// folder's books — the catalog is deliberately shared (ADR-0017) —
-	// while reading state stays strictly per user.
+	// library-read scope: the catalog. Folder grants select the shared
+	// catalog rows this account may see (ADR-0027), while reading state
+	// stays strictly per user.
 	//
 	// There is no metadata-editing scope beyond series claims: with
 	// uploads gone, nothing else writes to the catalog but a reconcile

--- a/internal/api/token_scope_test.go
+++ b/internal/api/token_scope_test.go
@@ -265,14 +265,11 @@ func concretePath(pattern string) string {
 	})
 }
 
-// TestScopeMatrixCoversEveryRegisteredRoute is the ADR-0017 obligation
-// that replaces the old library-manage scope: with folder management
-// gone from the API entirely and the catalog shared by every reader,
-// the only scope boundary left worth policing by hand is "does this
-// route ask for the credential routes.go says it asks for" — and this
-// test is honest about that boundary by reading routes.go rather than
-// guessing at it, so a route added without a matching gate here fails
-// loudly instead of shipping unchecked.
+// TestScopeMatrixCoversEveryRegisteredRoute checks the capability half of
+// access control. Folder grants are enforced inside catalog operations;
+// this matrix asks whether each route requires the token scope routes.go
+// declares for it. It reads routes.go rather than guessing, so a route
+// added without a matching gate here fails loudly.
 func TestScopeMatrixCoversEveryRegisteredRoute(t *testing.T) {
 	found := registeredRoutes(t)
 	seen := map[string]bool{}

--- a/internal/api/upload.go
+++ b/internal/api/upload.go
@@ -51,7 +51,7 @@ func (s *Server) HandleUploadBook(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusUnauthorized, "authentication required")
 		return
 	}
-	folder, err := s.uploadFolder(r.Context(), r.PathValue("folder"))
+	folder, err := s.uploadFolder(r.Context(), tok.UserID, r.PathValue("folder"))
 	if err != nil {
 		writeUploadError(w, err)
 		return
@@ -138,12 +138,12 @@ func writeWriteError(w http.ResponseWriter, err error, fallback string) {
 
 // uploadFolder resolves a folder and satisfies itself that somebody
 // asked for it to be writable.
-func (s *Server) uploadFolder(ctx context.Context, id string) (store.Folder, error) {
+func (s *Server) uploadFolder(ctx context.Context, viewerID, id string) (store.Folder, error) {
 	if s.Ingest == nil {
 		return store.Folder{}, uploadErr(http.StatusServiceUnavailable,
 			"this server is running without a folder watcher")
 	}
-	folder, err := s.St.FolderByID(ctx, id)
+	folder, err := s.St.FolderByID(ctx, viewerID, id)
 	if errors.Is(err, store.ErrNotFound) {
 		return store.Folder{}, uploadErr(http.StatusNotFound, "no such folder")
 	}
@@ -174,7 +174,7 @@ func (s *Server) uploadFolder(ctx context.Context, id string) (store.Folder, err
 func (s *Server) ReceiveUpload(
 	w http.ResponseWriter, r *http.Request, folder store.Folder, userID string,
 ) (UploadResult, error) {
-	result, err := s.receiveUpload(w, r, folder)
+	result, err := s.receiveUpload(w, r, folder, userID)
 	// Both answers that carry a book — the one just written and the one
 	// the catalog already held — are joined here, so a retry over a bad
 	// connection settles the work as surely as the first attempt did.
@@ -216,7 +216,7 @@ func (s *Server) nameUploadedWork(ctx context.Context, userID, bookID string) {
 }
 
 func (s *Server) receiveUpload(
-	w http.ResponseWriter, r *http.Request, folder store.Folder,
+	w http.ResponseWriter, r *http.Request, folder store.Folder, userID string,
 ) (UploadResult, error) {
 	if s.Ingest == nil {
 		return UploadResult{}, uploadErr(http.StatusServiceUnavailable,
@@ -236,7 +236,7 @@ func (s *Server) receiveUpload(
 
 	// The catalog may already hold these bytes, in this folder or
 	// another. Either way the upload is done and this is the book.
-	existing, err := s.St.CatalogBookByDigest(r.Context(), spooled.sha)
+	existing, err := s.St.CatalogBookByDigest(r.Context(), userID, spooled.sha)
 	if err == nil {
 		return UploadResult{
 			BookID:        existing.ID,
@@ -288,7 +288,7 @@ func (s *Server) receiveUpload(
 		RelativePath:  relative,
 		ContentSHA256: spooled.sha,
 	}
-	if book, err := s.St.CatalogBookByDigest(r.Context(), spooled.sha); err == nil {
+	if book, err := s.St.CatalogBookByDigest(r.Context(), userID, spooled.sha); err == nil {
 		result.BookID = book.ID
 		result.RelativePath = book.RelativePath
 	}

--- a/internal/api/upload_test.go
+++ b/internal/api/upload_test.go
@@ -116,7 +116,7 @@ func TestUploadCataloguesTheBook(t *testing.T) {
 		t.Fatalf("the book is not on the disk: %v", err)
 	}
 
-	book, err := f.st.CatalogBookByID(t.Context(), got["book_id"].(string))
+	book, err := f.st.CatalogBookByID(t.Context(), "", got["book_id"].(string))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,6 +220,64 @@ func TestUploadTwiceMakesOneBook(t *testing.T) {
 	}
 	if len(books) != 1 {
 		t.Fatalf("folder holds %d books, want 1", len(books))
+	}
+}
+
+func TestUploadDoesNotDeduplicateAgainstAnInaccessibleBook(t *testing.T) {
+	f := newFolderFixture(t)
+	body := makeEPUB(t, "Private Copy", "A Reader", []byte("same bytes"))
+	hiddenBookID, _ := f.writeBook(t, "hidden.epub", body)
+	if err := f.st.UnassignUserFolder(t.Context(), f.user.ID, f.folder.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	targetRoot := t.TempDir()
+	target := store.Folder{
+		ID: store.NewID(), Name: "Uploads", RootPath: targetRoot,
+		Kind: store.FolderPlain,
+	}
+	if err := f.st.CreateFolder(t.Context(), target); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.st.AssignUserFolder(t.Context(), f.user.ID, target.ID); err != nil {
+		t.Fatal(err)
+	}
+	f.folder, f.root = target, targetRoot
+	f.allowUploads(t)
+	token := f.mintToken(t, f.user.ID, store.ScopeLibraryUpload)
+
+	resp, got := f.upload(t, token, "copy.epub", body)
+	if resp.StatusCode != http.StatusCreated || got["duplicate"] != false {
+		t.Fatalf("upload = %d %v, want a new visible copy", resp.StatusCode, got)
+	}
+	if got["book_id"] == hiddenBookID {
+		t.Fatal("upload exposed the inaccessible book through digest deduplication")
+	}
+	books, err := f.st.BooksInFolder(t.Context(), target.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(books) != 1 || books[0].ID != got["book_id"] {
+		t.Fatalf("target books = %+v, response = %v", books, got)
+	}
+}
+
+func TestUploadAnswers404WithoutAFolderGrant(t *testing.T) {
+	f := newFolderFixture(t)
+	f.allowUploads(t)
+	if err := f.st.UnassignUserFolder(t.Context(), f.user.ID, f.folder.ID); err != nil {
+		t.Fatal(err)
+	}
+	token := f.mintToken(t, f.user.ID, store.ScopeLibraryUpload)
+
+	resp, got := f.upload(t, token, "private.epub",
+		makeEPUB(t, "Private", "", []byte("bytes")))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("upload = %d %v, want 404", resp.StatusCode, got)
+	}
+	entries, err := os.ReadDir(f.root)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("inaccessible upload changed the folder: %+v, %v", entries, err)
 	}
 }
 
@@ -379,6 +437,9 @@ func TestUploadIntoACalibreFolderAddsACalibreBook(t *testing.T) {
 	if err := f.st.CreateFolder(t.Context(), library); err != nil {
 		t.Fatal(err)
 	}
+	if err := f.st.AssignUserFolder(t.Context(), f.user.ID, library.ID); err != nil {
+		t.Fatal(err)
+	}
 	token := f.mintToken(t, f.user.ID, store.ScopeLibraryUpload)
 	saved := f.folder
 	f.folder = library
@@ -423,6 +484,9 @@ func TestUploadingTheSameBookIntoCalibreTwiceMakesOneBook(t *testing.T) {
 		Kind: store.FolderCalibre, AcceptsUploads: true,
 	}
 	if err := f.st.CreateFolder(t.Context(), library); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.st.AssignUserFolder(t.Context(), f.user.ID, library.ID); err != nil {
 		t.Fatal(err)
 	}
 	token := f.mintToken(t, f.user.ID, store.ScopeLibraryUpload)

--- a/internal/content/files_linux.go
+++ b/internal/content/files_linux.go
@@ -46,7 +46,7 @@ func (f *Files) OpenBookCover(
 }
 
 func (f *Files) root(ctx context.Context, book store.CatalogBook) (string, error) {
-	folder, err := f.folders.FolderByID(ctx, book.FolderID)
+	folder, err := f.folders.FolderByID(ctx, "", book.FolderID)
 	if err != nil {
 		// A book whose folder has gone is a book whose bytes are not
 		// this server's to serve, which is what ErrRootMissing means to

--- a/internal/content/pass_linux_test.go
+++ b/internal/content/pass_linux_test.go
@@ -97,7 +97,7 @@ func (c *fakeCatalog) snapshot() (int, []store.ObservedBook, bool) {
 // ListFolders and FolderByID make the fake a FolderSource too, so a
 // watcher test does not need a second double.
 func (c *fakeCatalog) ListFolders(
-	_ context.Context, after string, limit int,
+	_ context.Context, _ string, after string, limit int,
 ) ([]store.Folder, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -115,7 +115,7 @@ func (c *fakeCatalog) ListFolders(
 }
 
 func (c *fakeCatalog) FolderByID(
-	_ context.Context, folderID string,
+	_ context.Context, _ string, folderID string,
 ) (store.Folder, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/content/watch_linux.go
+++ b/internal/content/watch_linux.go
@@ -37,8 +37,8 @@ const (
 // reconciling one folder are different concerns and a test usually wants
 // only one of them.
 type FolderSource interface {
-	ListFolders(ctx context.Context, after string, limit int) ([]store.Folder, error)
-	FolderByID(ctx context.Context, folderID string) (store.Folder, error)
+	ListFolders(ctx context.Context, viewerID, after string, limit int) ([]store.Folder, error)
+	FolderByID(ctx context.Context, viewerID, folderID string) (store.Folder, error)
 }
 
 // Watcher keeps the catalog reflecting the disk.
@@ -334,7 +334,7 @@ func (w *Watcher) allFolders(ctx context.Context) ([]store.Folder, error) {
 	var all []store.Folder
 	cursor := ""
 	for {
-		page, err := w.folders.ListFolders(ctx, cursor, 200)
+		page, err := w.folders.ListFolders(ctx, "", cursor, 200)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/store/postgres/catalog.go
+++ b/internal/store/postgres/catalog.go
@@ -64,9 +64,15 @@ func utcPtr(t *time.Time) {
 	}
 }
 
-func (s *Store) CatalogBookByID(ctx context.Context, bookID string) (store.CatalogBook, error) {
-	row := s.db.QueryRowContext(ctx,
-		q(`SELECT `+bookColumns+` FROM books b WHERE b.id = ?`), bookID)
+func (s *Store) CatalogBookByID(ctx context.Context, viewerID, bookID string) (store.CatalogBook, error) {
+	query := `SELECT ` + bookColumns + ` FROM books b WHERE b.id = ?`
+	args := []any{bookID}
+	if viewerID != "" {
+		query += ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+	}
+	row := s.db.QueryRowContext(ctx, q(query), args...)
 	book, err := scanCatalogBook(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.CatalogBook{}, store.ErrNotFound
@@ -78,13 +84,21 @@ func (s *Store) CatalogBookByID(ctx context.Context, bookID string) (store.Catal
 // folders may hold the same bytes; the oldest row wins, so the answer
 // does not change as the catalog grows.
 func (s *Store) CatalogBookByDigest(
-	ctx context.Context, sha string,
+	ctx context.Context, viewerID, sha string,
 ) (store.CatalogBook, error) {
-	row := s.db.QueryRowContext(ctx, q(`SELECT `+bookColumns+`
+	query := `SELECT ` + bookColumns + `
 		   FROM books b
-		  WHERE b.content_sha256 = ? AND b.status = 'active'
+		  WHERE b.content_sha256 = ? AND b.status = 'active'`
+	args := []any{sha}
+	if viewerID != "" {
+		query += ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+	}
+	query += `
 		  ORDER BY b.created_at, b.id
-		  LIMIT 1`), sha)
+		  LIMIT 1`
+	row := s.db.QueryRowContext(ctx, q(query), args...)
 	book, err := scanCatalogBook(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.CatalogBook{}, store.ErrNotFound
@@ -93,15 +107,15 @@ func (s *Store) CatalogBookByDigest(
 }
 
 func (s *Store) ListCatalogBooks(
-	ctx context.Context, folderID string, after *store.CatalogBookCursor, limit int,
+	ctx context.Context, viewerID, folderID string, after *store.CatalogBookCursor, limit int,
 ) ([]store.CatalogBook, error) {
-	return s.listCatalogBooks(ctx, folderID, after, limit, true)
+	return s.listCatalogBooks(ctx, viewerID, folderID, after, limit, true)
 }
 
 func (s *Store) ListRecentCatalogBooks(
-	ctx context.Context, folderID string, before *store.CatalogBookCursor, limit int,
+	ctx context.Context, viewerID, folderID string, before *store.CatalogBookCursor, limit int,
 ) ([]store.CatalogBook, error) {
-	return s.listCatalogBooks(ctx, folderID, before, limit, false)
+	return s.listCatalogBooks(ctx, viewerID, folderID, before, limit, false)
 }
 
 // listCatalogBooks pages a folder's books in either direction. Only
@@ -111,9 +125,12 @@ func (s *Store) ListRecentCatalogBooks(
 // readers' work mappings, and it returns to the listing whole the moment
 // a complete pass sees its file again.
 func (s *Store) listCatalogBooks(
-	ctx context.Context, folderID string, cursor *store.CatalogBookCursor,
+	ctx context.Context, viewerID, folderID string, cursor *store.CatalogBookCursor,
 	limit int, ascending bool,
 ) ([]store.CatalogBook, error) {
+	if _, err := s.FolderByID(ctx, viewerID, folderID); err != nil {
+		return nil, err
+	}
 	if limit <= 0 {
 		limit = 50
 	}
@@ -166,6 +183,11 @@ func (s *Store) CatalogBookRelationsForBooks(
 	}
 	if len(bookIDs) == 0 {
 		return out, nil
+	}
+	var err error
+	bookIDs, err = s.visibleBookIDs(ctx, userID, bookIDs)
+	if err != nil || len(bookIDs) == 0 {
+		return out, err
 	}
 	placeholders, args := inArgs(bookIDs)
 	readerScope := userID
@@ -273,6 +295,14 @@ func (s *Store) CatalogSeriesVolumesForBooks(
 	if len(bookIDs) == 0 {
 		return []store.CatalogSeriesVolume{}, nil
 	}
+	if _, err := s.FolderByID(ctx, userID, folderID); err != nil {
+		return nil, err
+	}
+	var err error
+	bookIDs, err = s.visibleBookIDs(ctx, userID, bookIDs)
+	if err != nil || len(bookIDs) == 0 {
+		return []store.CatalogSeriesVolume{}, err
+	}
 	placeholders, ids := inArgs(bookIDs)
 	args := seriesReadArgs(userID, append([]any{folderID}, ids...)...)
 	args = append(args, folderID)
@@ -332,7 +362,7 @@ SELECT p.series_id, p.name, p.position,
 // catalog book to a sync work, which needs a title and its authors and
 // nothing else.
 func (s *Store) CatalogAuthorsForBooks(
-	ctx context.Context, bookIDs []string,
+	ctx context.Context, viewerID string, bookIDs []string,
 ) (map[string][]string, error) {
 	out := map[string][]string{}
 	if len(bookIDs) == 0 {
@@ -340,13 +370,19 @@ func (s *Store) CatalogAuthorsForBooks(
 	}
 	placeholders, args := inArgs(bookIDs)
 	args = append(args, store.ContributorRoleAuthor)
-	rows, err := s.db.QueryContext(ctx, q(
+	query :=
 		`SELECT bc.book_id, c.name
 		 FROM book_contributors bc
 		 JOIN contributors c ON c.id = bc.contributor_id
-		 WHERE bc.book_id IN (`+placeholders+`) AND bc.role = ?
-		 ORDER BY bc.book_id, bc.position, c.normalized_name`),
-		args...)
+		 JOIN books b ON b.id = bc.book_id
+		 WHERE bc.book_id IN (` + placeholders + `) AND bc.role = ?`
+	if viewerID != "" {
+		query += ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+	}
+	query += ` ORDER BY bc.book_id, bc.position, c.normalized_name`
+	rows, err := s.db.QueryContext(ctx, q(query), args...)
 	if err != nil {
 		return nil, err
 	}
@@ -363,7 +399,10 @@ func (s *Store) CatalogAuthorsForBooks(
 	return out, nil
 }
 
-func (s *Store) AvailableBookMediaTypes(ctx context.Context, folderID string) ([]string, error) {
+func (s *Store) AvailableBookMediaTypes(ctx context.Context, viewerID, folderID string) ([]string, error) {
+	if _, err := s.FolderByID(ctx, viewerID, folderID); err != nil {
+		return nil, err
+	}
 	rows, err := s.db.QueryContext(ctx, q(
 		`SELECT DISTINCT media_type FROM books
 		 WHERE folder_id = ? AND status = 'active' AND media_type <> ''
@@ -411,7 +450,9 @@ func (s *Store) ResolveCatalogBookWork(
 		return store.WorkResolution{}, err
 	}
 	var folderID string
-	err = tx.QueryRowContext(ctx, q(`SELECT folder_id FROM books WHERE id = ?`), bookID).Scan(&folderID)
+	err = tx.QueryRowContext(ctx, q(`SELECT b.folder_id FROM books b
+		WHERE b.id = ? AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`), bookID, userID).Scan(&folderID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.WorkResolution{}, store.ErrNotFound
 	}
@@ -452,7 +493,9 @@ func (s *Store) UserBookWork(
 ) (store.UserBookWork, error) {
 	row := s.db.QueryRowContext(ctx, q(
 		`SELECT user_id, folder_id, book_id, work_id, created_at
-		 FROM user_book_works WHERE user_id = ? AND book_id = ?`), userID, bookID)
+		 FROM user_book_works ubw WHERE user_id = ? AND book_id = ?
+		 AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = ubw.folder_id AND uf.user_id = ?)`), userID, bookID, userID)
 	out, err := scanUserBookWork(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.UserBookWork{}, store.ErrNotFound
@@ -472,8 +515,11 @@ func scanUserBookWork(row interface{ Scan(...any) error }) (store.UserBookWork, 
 
 func (s *Store) WorkBookIDs(ctx context.Context, userID, workID string) ([]string, error) {
 	rows, err := s.db.QueryContext(ctx, q(
-		`SELECT book_id FROM user_book_works
-		 WHERE user_id = ? AND work_id = ? ORDER BY book_id`), userID, workID)
+		`SELECT ubw.book_id FROM user_book_works ubw
+		 WHERE ubw.user_id = ? AND ubw.work_id = ?
+		 AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = ubw.folder_id AND uf.user_id = ?)
+		 ORDER BY ubw.book_id`), userID, workID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -501,6 +547,31 @@ func inArgs(ids []string) (string, []any) {
 	return strings.Join(placeholders, ","), args
 }
 
+func (s *Store) visibleBookIDs(ctx context.Context, viewerID string, ids []string) ([]string, error) {
+	if viewerID == "" || len(ids) == 0 {
+		return ids, nil
+	}
+	placeholders, args := inArgs(ids)
+	args = append(args, viewerID)
+	rows, err := s.db.QueryContext(ctx, q(`SELECT b.id FROM books b
+		WHERE b.id IN (`+placeholders+`)
+		AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
 func eachRow(rows *sql.Rows, each func(scan func(...any) error) error) error {
 	defer rows.Close()
 	for rows.Next() {
@@ -516,8 +587,11 @@ func eachRow(rows *sql.Rows, each func(scan func(...any) error) error) error {
 // They are the strongest evidence for joining a catalog book to a work
 // that is not the file's own digest.
 func (s *Store) CatalogBookIdentifiers(
-	ctx context.Context, bookID string,
+	ctx context.Context, viewerID, bookID string,
 ) ([]store.BookIdentifier, error) {
+	if _, err := s.CatalogBookByID(ctx, viewerID, bookID); err != nil {
+		return nil, err
+	}
 	rows, err := s.db.QueryContext(ctx, q(
 		`SELECT scheme, value FROM book_identifiers
 		 WHERE book_id = ? ORDER BY scheme, value`), bookID)

--- a/internal/store/postgres/catalog_schema_test.go
+++ b/internal/store/postgres/catalog_schema_test.go
@@ -45,6 +45,9 @@ func splitMovesMissingCatalogMapping(t *testing.T, s *Store) {
 	if err := s.CreateFolder(ctx, folder); err != nil {
 		t.Fatal(err)
 	}
+	if err := s.AssignUserFolder(ctx, user.ID, folder.ID); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := s.ReconcileFolder(ctx, folder.ID, []store.ObservedBook{{
 		RelativePath:     "missing.epub",
 		SizeBytes:        1,

--- a/internal/store/postgres/entities.go
+++ b/internal/store/postgres/entities.go
@@ -65,7 +65,36 @@ func (t entityTables) nameColumns(
 // whose page turns out to be blank.
 const entityCountExpr = `(SELECT COUNT(*) FROM %s m
 	         JOIN books b ON b.id = m.book_id
-	         WHERE m.%s = e.id AND b.status = 'active')`
+	         WHERE m.%s = e.id AND b.status = 'active'%s)`
+
+func scopedEntityCount(membership, column, userID string) (string, []any) {
+	access := ""
+	var args []any
+	if userID != "" {
+		access = ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, userID)
+	}
+	return fmt.Sprintf(entityCountExpr, membership, column, access), args
+}
+
+func scopedEntityBacking(tables entityTables, membership, userID string) (string, []any) {
+	if userID == "" {
+		return "", nil
+	}
+	backing := tables.membership
+	if backing == "book_series" {
+		// A series may be supported by what the folder observed, by an
+		// effective claim, or both. Preserve an emptied observed series
+		// while also admitting one created only by a claim.
+		backing = `(SELECT book_id, series_id FROM book_series
+			UNION SELECT book_id, series_id FROM ` + membership + `)`
+	}
+	return ` AND EXISTS (SELECT 1 FROM ` + backing + ` backing
+		JOIN books visible_book ON visible_book.id = backing.book_id
+		JOIN user_folders uf ON uf.folder_id = visible_book.folder_id
+		WHERE backing.` + tables.column + ` = e.id AND uf.user_id = ?)`, []any{userID}
+}
 
 func (s *Store) ListCatalogEntities(
 	ctx context.Context, userID string, kind store.EntityKind,
@@ -80,15 +109,20 @@ func (s *Store) ListCatalogEntities(
 	}
 	prefix, membership, args := tables.membershipFor(kind, userID)
 	nameJoin, name, normalized, scanned, source := tables.nameColumns(kind)
-	args = append(args, after, limit)
+	count, countArgs := scopedEntityCount(membership, tables.column, userID)
+	args = append(args, countArgs...)
+	backing, backingArgs := scopedEntityBacking(tables, membership, userID)
+	args = append(args, after)
+	args = append(args, backingArgs...)
+	args = append(args, limit)
 	// Paging is by the name the reader sees, not the one the scan wrote.
 	rows, err := s.db.QueryContext(ctx, q(
 		prefix+
 			`SELECT e.id, `+name+`, `+normalized+`, `+scanned+`, `+source+`,
 			        e.created_at,
-			        `+fmt.Sprintf(entityCountExpr, membership, tables.column)+`
+			        `+count+`
 			 FROM `+tables.entity+` e`+nameJoin+`
-			 WHERE `+normalized+` > ?
+			 WHERE `+normalized+` > ?`+backing+`
 			 ORDER BY `+normalized+` LIMIT ?`),
 		args...)
 	if err != nil {
@@ -118,15 +152,19 @@ func (s *Store) CatalogEntityByID(
 	}
 	prefix, membership, args := tables.membershipFor(kind, userID)
 	nameJoin, name, normalized, scanned, source := tables.nameColumns(kind)
+	count, countArgs := scopedEntityCount(membership, tables.column, userID)
+	args = append(args, countArgs...)
+	backing, backingArgs := scopedEntityBacking(tables, membership, userID)
 	args = append(args, entityID)
+	args = append(args, backingArgs...)
 	entity := store.CatalogEntity{Kind: kind}
 	err = s.db.QueryRowContext(ctx, q(
 		prefix+
 			`SELECT e.id, `+name+`, `+normalized+`, `+scanned+`, `+source+`,
 			        e.created_at,
-			        `+fmt.Sprintf(entityCountExpr, membership, tables.column)+`
+			        `+count+`
 			 FROM `+tables.entity+` e`+nameJoin+`
-			 WHERE e.id = ?`),
+			 WHERE e.id = ?`+backing),
 		args...).
 		Scan(&entity.ID, &entity.Name, &entity.NormalizedName,
 			&entity.ScannedName, &entity.NameSource,
@@ -178,6 +216,12 @@ func (s *Store) ListBooksByEntity(
 	order := "b.created_at, b.id"
 	cursor := ""
 	args = append(args, entityID)
+	access := ""
+	if userID != "" {
+		access = ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, userID)
+	}
 	if series {
 		order = sortKey + ", b.created_at, b.id"
 		if after != nil {
@@ -196,7 +240,7 @@ func (s *Store) ListBooksByEntity(
 			 FROM books b
 			 JOIN `+membership+` m ON m.book_id = b.id
 			 WHERE m.`+tables.column+` = ?
-			   AND b.status = 'active'`+
+			   AND b.status = 'active'`+access+
 			cursor+` ORDER BY `+order+` LIMIT ?`), args...)
 	if err != nil {
 		return nil, nil, err

--- a/internal/store/postgres/folders.go
+++ b/internal/store/postgres/folders.go
@@ -10,9 +10,8 @@ import (
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
-// A folder has no owner and no access list, so none of these queries
-// take a user id. That is ADR-0017's deliberate carve-out from the
-// user-scoping rule: the catalog is shared, reading state is not.
+// A folder has no owner. An empty viewer id is the trusted internal
+// view; every real viewer must have a user_folders grant.
 
 const folderColumns = `id, name, root_path, kind, accepts_uploads,
 	created_at, updated_at`
@@ -70,9 +69,15 @@ func (s *Store) SetFolderUploads(
 	return nil
 }
 
-func (s *Store) FolderByID(ctx context.Context, folderID string) (store.Folder, error) {
-	row := s.db.QueryRowContext(ctx,
-		q(`SELECT `+folderColumns+` FROM folders WHERE id = ?`), folderID)
+func (s *Store) FolderByID(ctx context.Context, viewerID, folderID string) (store.Folder, error) {
+	query := `SELECT ` + folderColumns + ` FROM folders WHERE id = ?`
+	args := []any{folderID}
+	if viewerID != "" {
+		query += ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = folders.id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+	}
+	row := s.db.QueryRowContext(ctx, q(query), args...)
 	folder, err := scanFolder(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Folder{}, store.ErrNotFound
@@ -80,15 +85,27 @@ func (s *Store) FolderByID(ctx context.Context, folderID string) (store.Folder, 
 	return folder, err
 }
 
-func (s *Store) ListFolders(ctx context.Context, after string, limit int) ([]store.Folder, error) {
+func (s *Store) ListFolders(ctx context.Context, viewerID, after string, limit int) ([]store.Folder, error) {
 	if limit <= 0 {
 		limit = 100
 	}
 	query := `SELECT ` + folderColumns + ` FROM folders`
 	args := []any{}
+	where := false
+	if viewerID != "" {
+		query += ` WHERE EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = folders.id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+		where = true
+	}
 	if after != "" {
 		name, id := store.SplitFolderCursor(after)
-		query += ` WHERE (name COLLATE "C", id) > (?, ?)`
+		if where {
+			query += ` AND`
+		} else {
+			query += ` WHERE`
+		}
+		query += ` (name COLLATE "C", id) > (?, ?)`
 		args = append(args, name, id)
 	}
 	// COLLATE "C" is byte order, which is what SQLite gives with no
@@ -114,6 +131,80 @@ func (s *Store) ListFolders(ctx context.Context, after string, limit int) ([]sto
 		folders = append(folders, folder)
 	}
 	return folders, rows.Err()
+}
+
+func (s *Store) AssignUserFolder(ctx context.Context, userID, folderID string) error {
+	return s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := validateGrantTargets(ctx, tx, userID, []string{folderID}); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT INTO user_folders (user_id, folder_id)
+			VALUES ($1, $2) ON CONFLICT DO NOTHING`, userID, folderID)
+		return err
+	})
+}
+
+func (s *Store) UnassignUserFolder(ctx context.Context, userID, folderID string) error {
+	return s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := validateGrantTargets(ctx, tx, userID, []string{folderID}); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx,
+			`DELETE FROM user_folders WHERE user_id = $1 AND folder_id = $2`, userID, folderID)
+		return err
+	})
+}
+
+func (s *Store) ListUserFolders(ctx context.Context, userID, after string, limit int) ([]store.Folder, error) {
+	if _, err := s.UserByID(ctx, userID); err != nil {
+		return nil, err
+	}
+	return s.ListFolders(ctx, userID, after, limit)
+}
+
+func (s *Store) ReplaceUserFolders(ctx context.Context, userID string, folderIDs []string) error {
+	unique := make([]string, 0, len(folderIDs))
+	seen := make(map[string]struct{}, len(folderIDs))
+	for _, id := range folderIDs {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			unique = append(unique, id)
+		}
+	}
+	return s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := validateGrantTargets(ctx, tx, userID, unique); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM user_folders WHERE user_id = $1`, userID); err != nil {
+			return err
+		}
+		for _, folderID := range unique {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO user_folders
+				(user_id, folder_id) VALUES ($1, $2)`, userID, folderID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func validateGrantTargets(ctx context.Context, tx *sql.Tx, userID string, folderIDs []string) error {
+	var one int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM users WHERE id = $1`, userID).Scan(&one); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return store.ErrNotFound
+		}
+		return err
+	}
+	for _, folderID := range folderIDs {
+		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM folders WHERE id = $1`, folderID).Scan(&one); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return store.ErrNotFound
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 // DeleteFolder removes the folder row. Everything catalog-side hangs off

--- a/internal/store/postgres/migrate_test.go
+++ b/internal/store/postgres/migrate_test.go
@@ -35,6 +35,16 @@ func TestMigrateUpgradesAnOlderDatabase(t *testing.T) {
 		time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
+	created := time.Now().UTC()
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO users
+		(id, name, argon2_hash, created_at) VALUES ('old-user', 'old-user', 'x', $1)`, created); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO folders
+		(id, name, root_path, kind, created_at, updated_at)
+		VALUES ('old-folder', 'Old', '/old', 'plain', $1, $1)`, created); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Migrate(ctx); err != nil {
 		t.Fatalf("migrating an older database: %v", err)
@@ -51,6 +61,13 @@ func TestMigrateUpgradesAnOlderDatabase(t *testing.T) {
 		if count != 1 {
 			t.Errorf("book_series_overrides.%s is missing after the upgrade", column)
 		}
+	}
+	var grants int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM user_folders`).Scan(&grants); err != nil {
+		t.Fatal(err)
+	}
+	if grants != 0 {
+		t.Fatalf("migration granted existing accounts %d folders, want none", grants)
 	}
 
 	// Idempotent: a second start must not try to add the columns again.

--- a/internal/store/postgres/schema.go
+++ b/internal/store/postgres/schema.go
@@ -467,5 +467,17 @@ const folderUploads = `
 ALTER TABLE folders ADD COLUMN accepts_uploads BOOLEAN NOT NULL DEFAULT FALSE;
 `
 
+// folderAccess is migration 4. Grants are explicit and deliberately
+// empty for both existing and newly created accounts and folders.
+const folderAccess = `
+CREATE TABLE user_folders (
+    user_id   TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    folder_id TEXT NOT NULL REFERENCES folders(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, folder_id)
+);
+
+CREATE INDEX user_folders_folder ON user_folders(folder_id);
+`
+
 // migrations is append-only, for the reason the SQLite copy gives.
-var migrations = []string{schema, claimRevisions, folderUploads}
+var migrations = []string{schema, claimRevisions, folderUploads, folderAccess}

--- a/internal/store/postgres/search.go
+++ b/internal/store/postgres/search.go
@@ -116,6 +116,9 @@ func (s *Store) SearchCatalogBooks(
 		return store.SearchResult{}, fmt.Errorf(
 			"%w: search limit %d", store.ErrInvalidInput, query.Limit)
 	}
+	if _, err := s.FolderByID(ctx, query.UserID, query.FolderID); err != nil {
+		return store.SearchResult{}, err
+	}
 	terms := store.SearchTerms(query.Text)
 	scored := len(terms) > 0
 	if !scored && len(query.Entities) == 0 {

--- a/internal/store/postgres/seriesmerge.go
+++ b/internal/store/postgres/seriesmerge.go
@@ -16,6 +16,12 @@ import (
 func (s *Store) MergeSeries(
 	ctx context.Context, userID, seriesID, intoID string, at time.Time,
 ) (string, error) {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return "", err
+	}
+	if _, err := s.CatalogEntityByID(ctx, userID, intoID, store.EntitySeries); err != nil {
+		return "", err
+	}
 	if seriesID == intoID {
 		return "", fmt.Errorf("%w: a series cannot be merged into itself",
 			store.ErrInvalidInput)
@@ -106,6 +112,12 @@ func (s *Store) MergeSeries(
 func (s *Store) SplitSeriesFolder(
 	ctx context.Context, userID, seriesID, folderID, name string, at time.Time,
 ) (string, error) {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return "", err
+	}
+	if _, err := s.FolderByID(ctx, userID, folderID); err != nil {
+		return "", err
+	}
 	if userID == "" {
 		return "", fmt.Errorf("%w: a split needs a writer", store.ErrInvalidInput)
 	}

--- a/internal/store/postgres/seriesname.go
+++ b/internal/store/postgres/seriesname.go
@@ -19,6 +19,9 @@ func (s *Store) SetSeriesName(
 	ctx context.Context, userID, seriesID string, scope store.SeriesSource,
 	name string, at time.Time,
 ) error {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return err
+	}
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
 		return err
@@ -70,6 +73,9 @@ func (s *Store) SetSeriesName(
 func (s *Store) ClearSeriesName(
 	ctx context.Context, userID, seriesID string, scope store.SeriesSource,
 ) error {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return err
+	}
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
 		return err

--- a/internal/store/postgres/seriesoverride.go
+++ b/internal/store/postgres/seriesoverride.go
@@ -89,6 +89,9 @@ func (s *Store) SetBookSeriesOverride(
 	ctx context.Context, userID, bookID string, scope store.SeriesSource,
 	items []store.SeriesClaimItem, mutation store.SeriesClaimMutation,
 ) (store.SeriesClaimOutcome, error) {
+	if _, err := s.CatalogBookByID(ctx, userID, bookID); err != nil {
+		return "", err
+	}
 	clientTS, ifUpdatedAt, at := mutation.ClientTS, mutation.IfUpdatedAt, store.ClaimRevision(mutation.At)
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
@@ -227,6 +230,9 @@ func (s *Store) ClearBookSeriesOverride(
 	ctx context.Context, userID, bookID string, scope store.SeriesSource,
 	mutation store.SeriesClaimMutation,
 ) (store.SeriesClaimOutcome, error) {
+	if _, err := s.CatalogBookByID(ctx, userID, bookID); err != nil {
+		return "", err
+	}
 	clientTS, ifUpdatedAt, at := mutation.ClientTS, mutation.IfUpdatedAt, store.ClaimRevision(mutation.At)
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
@@ -291,6 +297,14 @@ func (s *Store) ReorderSeries(
 	ctx context.Context, userID, seriesID string,
 	scope store.SeriesSource, order []store.SeriesPlacement, at time.Time,
 ) error {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return err
+	}
+	for _, placement := range order {
+		if _, err := s.CatalogBookByID(ctx, userID, placement.BookID); err != nil {
+			return err
+		}
+	}
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
 		return err
@@ -354,6 +368,9 @@ func (s *Store) BookSeriesLayers(
 	ctx context.Context, userID, bookID string,
 ) (store.BookSeriesLayers, error) {
 	var out store.BookSeriesLayers
+	if _, err := s.CatalogBookByID(ctx, userID, bookID); err != nil {
+		return out, err
+	}
 	var folderID string
 	err := s.db.QueryRowContext(ctx, q(
 		`SELECT folder_id FROM books WHERE id = ?`), bookID).Scan(&folderID)

--- a/internal/store/postgres/store_test.go
+++ b/internal/store/postgres/store_test.go
@@ -41,7 +41,7 @@ func reset(t *testing.T, s *Store) {
 		"book_contributors", "contributors",
 		"book_series_override_items", "book_series_overrides",
 		"series_name_overrides", "series_bindings", "book_series", "series",
-		"book_identifiers", "user_book_works",
+		"book_identifiers", "user_book_works", "user_folders",
 		"books", "folders",
 		"session_supersessions", "session_tombstones", "session_rollups", "sessions", "ops", "aliases", "editions",
 		"works", "seq_counters", "compaction_state", "kosync_devices",

--- a/internal/store/sqlite/catalog.go
+++ b/internal/store/sqlite/catalog.go
@@ -71,9 +71,15 @@ func scanCatalogBook(row interface{ Scan(...any) error }) (store.CatalogBook, er
 	return b, nil
 }
 
-func (s *Store) CatalogBookByID(ctx context.Context, bookID string) (store.CatalogBook, error) {
-	row := s.db.QueryRowContext(ctx,
-		`SELECT `+bookColumns+` FROM books b WHERE b.id = ?`, bookID)
+func (s *Store) CatalogBookByID(ctx context.Context, viewerID, bookID string) (store.CatalogBook, error) {
+	query := `SELECT ` + bookColumns + ` FROM books b WHERE b.id = ?`
+	args := []any{bookID}
+	if viewerID != "" {
+		query += ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+	}
+	row := s.db.QueryRowContext(ctx, query, args...)
 	book, err := scanCatalogBook(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.CatalogBook{}, store.ErrNotFound
@@ -85,13 +91,21 @@ func (s *Store) CatalogBookByID(ctx context.Context, bookID string) (store.Catal
 // folders may hold the same bytes; the oldest row wins, so the answer
 // does not change as the catalog grows.
 func (s *Store) CatalogBookByDigest(
-	ctx context.Context, sha string,
+	ctx context.Context, viewerID, sha string,
 ) (store.CatalogBook, error) {
-	row := s.db.QueryRowContext(ctx, `SELECT `+bookColumns+`
+	query := `SELECT ` + bookColumns + `
 		   FROM books b
-		  WHERE b.content_sha256 = ? AND b.status = 'active'
+		  WHERE b.content_sha256 = ? AND b.status = 'active'`
+	args := []any{sha}
+	if viewerID != "" {
+		query += ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+	}
+	query += `
 		  ORDER BY b.created_at, b.id
-		  LIMIT 1`, sha)
+		  LIMIT 1`
+	row := s.db.QueryRowContext(ctx, query, args...)
 	book, err := scanCatalogBook(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.CatalogBook{}, store.ErrNotFound
@@ -100,15 +114,15 @@ func (s *Store) CatalogBookByDigest(
 }
 
 func (s *Store) ListCatalogBooks(
-	ctx context.Context, folderID string, after *store.CatalogBookCursor, limit int,
+	ctx context.Context, viewerID, folderID string, after *store.CatalogBookCursor, limit int,
 ) ([]store.CatalogBook, error) {
-	return s.listCatalogBooks(ctx, folderID, after, limit, true)
+	return s.listCatalogBooks(ctx, viewerID, folderID, after, limit, true)
 }
 
 func (s *Store) ListRecentCatalogBooks(
-	ctx context.Context, folderID string, before *store.CatalogBookCursor, limit int,
+	ctx context.Context, viewerID, folderID string, before *store.CatalogBookCursor, limit int,
 ) ([]store.CatalogBook, error) {
-	return s.listCatalogBooks(ctx, folderID, before, limit, false)
+	return s.listCatalogBooks(ctx, viewerID, folderID, before, limit, false)
 }
 
 // listCatalogBooks pages a folder's books in either direction. Only
@@ -118,8 +132,11 @@ func (s *Store) ListRecentCatalogBooks(
 // readers' work mappings, and it returns to the listing whole the moment
 // a complete pass sees its file again.
 func (s *Store) listCatalogBooks(
-	ctx context.Context, folderID string, cursor *store.CatalogBookCursor, limit int, ascending bool,
+	ctx context.Context, viewerID, folderID string, cursor *store.CatalogBookCursor, limit int, ascending bool,
 ) ([]store.CatalogBook, error) {
+	if _, err := s.FolderByID(ctx, viewerID, folderID); err != nil {
+		return nil, err
+	}
 	if limit <= 0 {
 		limit = 50
 	}
@@ -172,6 +189,11 @@ func (s *Store) CatalogBookRelationsForBooks(
 	}
 	if len(bookIDs) == 0 {
 		return out, nil
+	}
+	var err error
+	bookIDs, err = s.visibleBookIDs(ctx, userID, bookIDs)
+	if err != nil || len(bookIDs) == 0 {
+		return out, err
 	}
 	placeholders, args := inArgs(bookIDs)
 	readerScope := userID
@@ -285,6 +307,14 @@ func (s *Store) CatalogSeriesVolumesForBooks(
 	if len(bookIDs) == 0 {
 		return []store.CatalogSeriesVolume{}, nil
 	}
+	if _, err := s.FolderByID(ctx, userID, folderID); err != nil {
+		return nil, err
+	}
+	var err error
+	bookIDs, err = s.visibleBookIDs(ctx, userID, bookIDs)
+	if err != nil || len(bookIDs) == 0 {
+		return []store.CatalogSeriesVolume{}, err
+	}
 	placeholders, ids := inArgs(bookIDs)
 	args := seriesReadArgs(userID, append([]any{folderID}, ids...)...)
 	args = append(args, folderID)
@@ -347,7 +377,7 @@ SELECT p.series_id, p.name, p.position,
 // catalog book to a sync work, which needs a title and its authors and
 // nothing else.
 func (s *Store) CatalogAuthorsForBooks(
-	ctx context.Context, bookIDs []string,
+	ctx context.Context, viewerID string, bookIDs []string,
 ) (map[string][]string, error) {
 	out := map[string][]string{}
 	if len(bookIDs) == 0 {
@@ -355,13 +385,19 @@ func (s *Store) CatalogAuthorsForBooks(
 	}
 	placeholders, args := inArgs(bookIDs)
 	args = append(args, store.ContributorRoleAuthor)
-	rows, err := s.db.QueryContext(ctx,
+	query :=
 		`SELECT bc.book_id, c.name
 		 FROM book_contributors bc
 		 JOIN contributors c ON c.id = bc.contributor_id
-		 WHERE bc.book_id IN (`+placeholders+`) AND bc.role = ?
-		 ORDER BY bc.book_id, bc.position, c.normalized_name`,
-		args...)
+		 JOIN books b ON b.id = bc.book_id
+		 WHERE bc.book_id IN (` + placeholders + `) AND bc.role = ?`
+	if viewerID != "" {
+		query += ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+	}
+	query += ` ORDER BY bc.book_id, bc.position, c.normalized_name`
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -378,7 +414,10 @@ func (s *Store) CatalogAuthorsForBooks(
 	return out, nil
 }
 
-func (s *Store) AvailableBookMediaTypes(ctx context.Context, folderID string) ([]string, error) {
+func (s *Store) AvailableBookMediaTypes(ctx context.Context, viewerID, folderID string) ([]string, error) {
+	if _, err := s.FolderByID(ctx, viewerID, folderID); err != nil {
+		return nil, err
+	}
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT DISTINCT media_type FROM books
 		 WHERE folder_id = ? AND status = 'active' AND media_type <> ''
@@ -426,7 +465,9 @@ func (s *Store) ResolveCatalogBookWork(
 		return store.WorkResolution{}, err
 	}
 	var folderID string
-	err = tx.QueryRowContext(ctx, `SELECT folder_id FROM books WHERE id = ?`, bookID).Scan(&folderID)
+	err = tx.QueryRowContext(ctx, `SELECT b.folder_id FROM books b
+		WHERE b.id = ? AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`, bookID, userID).Scan(&folderID)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.WorkResolution{}, store.ErrNotFound
 	}
@@ -465,7 +506,9 @@ func (s *Store) ResolveCatalogBookWork(
 func (s *Store) UserBookWork(ctx context.Context, userID, bookID string) (store.UserBookWork, error) {
 	row := s.db.QueryRowContext(ctx,
 		`SELECT user_id, folder_id, book_id, work_id, created_at
-		 FROM user_book_works WHERE user_id = ? AND book_id = ?`, userID, bookID)
+		 FROM user_book_works ubw WHERE user_id = ? AND book_id = ?
+		 AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = ubw.folder_id AND uf.user_id = ?)`, userID, bookID, userID)
 	out, err := scanUserBookWork(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.UserBookWork{}, store.ErrNotFound
@@ -489,8 +532,11 @@ func scanUserBookWork(row interface{ Scan(...any) error }) (store.UserBookWork, 
 
 func (s *Store) WorkBookIDs(ctx context.Context, userID, workID string) ([]string, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT book_id FROM user_book_works
-		 WHERE user_id = ? AND work_id = ? ORDER BY book_id`, userID, workID)
+		`SELECT ubw.book_id FROM user_book_works ubw
+		 WHERE ubw.user_id = ? AND ubw.work_id = ?
+		 AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = ubw.folder_id AND uf.user_id = ?)
+		 ORDER BY ubw.book_id`, userID, workID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -517,6 +563,31 @@ func inArgs(ids []string) (string, []any) {
 	return strings.Join(placeholders, ","), args
 }
 
+func (s *Store) visibleBookIDs(ctx context.Context, viewerID string, ids []string) ([]string, error) {
+	if viewerID == "" || len(ids) == 0 {
+		return ids, nil
+	}
+	placeholders, args := inArgs(ids)
+	args = append(args, viewerID)
+	rows, err := s.db.QueryContext(ctx, `SELECT b.id FROM books b
+		WHERE b.id IN (`+placeholders+`)
+		AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out = append(out, id)
+	}
+	return out, rows.Err()
+}
+
 func eachRow(rows *sql.Rows, each func(scan func(...any) error) error) error {
 	defer rows.Close()
 	for rows.Next() {
@@ -532,8 +603,11 @@ func eachRow(rows *sql.Rows, each func(scan func(...any) error) error) error {
 // They are the strongest evidence for joining a catalog book to a work
 // that is not the file's own digest.
 func (s *Store) CatalogBookIdentifiers(
-	ctx context.Context, bookID string,
+	ctx context.Context, viewerID, bookID string,
 ) ([]store.BookIdentifier, error) {
+	if _, err := s.CatalogBookByID(ctx, viewerID, bookID); err != nil {
+		return nil, err
+	}
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT scheme, value FROM book_identifiers
 		 WHERE book_id = ? ORDER BY scheme, value`, bookID)

--- a/internal/store/sqlite/catalog_schema_test.go
+++ b/internal/store/sqlite/catalog_schema_test.go
@@ -40,6 +40,9 @@ func splitMovesMissingCatalogMapping(t *testing.T, s *Store) {
 	if err := s.CreateFolder(ctx, folder); err != nil {
 		t.Fatal(err)
 	}
+	if err := s.AssignUserFolder(ctx, user.ID, folder.ID); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := s.ReconcileFolder(ctx, folder.ID, []store.ObservedBook{{
 		RelativePath:     "missing.epub",
 		SizeBytes:        1,

--- a/internal/store/sqlite/entities.go
+++ b/internal/store/sqlite/entities.go
@@ -66,7 +66,36 @@ func (t entityTables) nameColumns(
 // whose page turns out to be blank.
 const entityCountExpr = `(SELECT COUNT(*) FROM %s m
 	         JOIN books b ON b.id = m.book_id
-	         WHERE m.%s = e.id AND b.status = 'active')`
+	         WHERE m.%s = e.id AND b.status = 'active'%s)`
+
+func scopedEntityCount(membership, column, userID string) (string, []any) {
+	access := ""
+	var args []any
+	if userID != "" {
+		access = ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, userID)
+	}
+	return fmt.Sprintf(entityCountExpr, membership, column, access), args
+}
+
+func scopedEntityBacking(tables entityTables, membership, userID string) (string, []any) {
+	if userID == "" {
+		return "", nil
+	}
+	backing := tables.membership
+	if backing == "book_series" {
+		// A series may be supported by what the folder observed, by an
+		// effective claim, or both. Preserve an emptied observed series
+		// while also admitting one created only by a claim.
+		backing = `(SELECT book_id, series_id FROM book_series
+			UNION SELECT book_id, series_id FROM ` + membership + `)`
+	}
+	return ` AND EXISTS (SELECT 1 FROM ` + backing + ` backing
+		JOIN books visible_book ON visible_book.id = backing.book_id
+		JOIN user_folders uf ON uf.folder_id = visible_book.folder_id
+		WHERE backing.` + tables.column + ` = e.id AND uf.user_id = ?)`, []any{userID}
+}
 
 func (s *Store) ListCatalogEntities(
 	ctx context.Context, userID string, kind store.EntityKind,
@@ -81,7 +110,12 @@ func (s *Store) ListCatalogEntities(
 	}
 	prefix, membership, args := tables.membershipFor(kind, userID)
 	nameJoin, name, normalized, scanned, source := tables.nameColumns(kind)
-	args = append(args, after, limit)
+	count, countArgs := scopedEntityCount(membership, tables.column, userID)
+	args = append(args, countArgs...)
+	backing, backingArgs := scopedEntityBacking(tables, membership, userID)
+	args = append(args, after)
+	args = append(args, backingArgs...)
+	args = append(args, limit)
 	// Paging is by the name the reader sees, not the one the scan wrote,
 	// or a renamed series would be listed in one place and paged past in
 	// another.
@@ -89,9 +123,9 @@ func (s *Store) ListCatalogEntities(
 		prefix+
 			`SELECT e.id, `+name+`, `+normalized+`, `+scanned+`, `+source+`,
 			        e.created_at,
-			        `+fmt.Sprintf(entityCountExpr, membership, tables.column)+`
+			        `+count+`
 			 FROM `+tables.entity+` e`+nameJoin+`
-			 WHERE `+normalized+` > ?
+			 WHERE `+normalized+` > ?`+backing+`
 			 ORDER BY `+normalized+` LIMIT ?`,
 		args...)
 	if err != nil {
@@ -124,16 +158,20 @@ func (s *Store) CatalogEntityByID(
 	}
 	prefix, membership, args := tables.membershipFor(kind, userID)
 	nameJoin, name, normalized, scanned, source := tables.nameColumns(kind)
+	count, countArgs := scopedEntityCount(membership, tables.column, userID)
+	args = append(args, countArgs...)
+	backing, backingArgs := scopedEntityBacking(tables, membership, userID)
 	args = append(args, entityID)
+	args = append(args, backingArgs...)
 	entity := store.CatalogEntity{Kind: kind}
 	var created string
 	err = s.db.QueryRowContext(ctx,
 		prefix+
 			`SELECT e.id, `+name+`, `+normalized+`, `+scanned+`, `+source+`,
 			        e.created_at,
-			        `+fmt.Sprintf(entityCountExpr, membership, tables.column)+`
+			        `+count+`
 			 FROM `+tables.entity+` e`+nameJoin+`
-			 WHERE e.id = ?`,
+			 WHERE e.id = ?`+backing,
 		args...).
 		Scan(&entity.ID, &entity.Name, &entity.NormalizedName,
 			&entity.ScannedName, &entity.NameSource,
@@ -185,6 +223,12 @@ func (s *Store) ListBooksByEntity(
 	order := "b.created_at, b.id"
 	cursor := ""
 	args = append(args, entityID)
+	access := ""
+	if userID != "" {
+		access = ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = b.folder_id AND uf.user_id = ?)`
+		args = append(args, userID)
+	}
 	if series {
 		order = sortKey + ", b.created_at, b.id"
 		if after != nil {
@@ -203,7 +247,7 @@ func (s *Store) ListBooksByEntity(
 			 FROM books b
 			 JOIN `+membership+` m ON m.book_id = b.id
 			 WHERE m.`+tables.column+` = ?
-			   AND b.status = 'active'`+
+			   AND b.status = 'active'`+access+
 			cursor+` ORDER BY `+order+` LIMIT ?`, args...)
 	if err != nil {
 		return nil, nil, err

--- a/internal/store/sqlite/folders.go
+++ b/internal/store/sqlite/folders.go
@@ -10,9 +10,8 @@ import (
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
-// A folder has no owner and no access list, so none of these queries
-// take a user id. That is ADR-0017's deliberate carve-out from the
-// user-scoping rule: the catalog is shared, reading state is not.
+// A folder has no owner. An empty viewer id is the trusted internal
+// view; every real viewer must have a user_folders grant.
 
 func (s *Store) CreateFolder(ctx context.Context, folder store.Folder) error {
 	if !folder.Kind.Valid() {
@@ -76,9 +75,15 @@ func (s *Store) SetFolderUploads(
 	return nil
 }
 
-func (s *Store) FolderByID(ctx context.Context, folderID string) (store.Folder, error) {
-	row := s.db.QueryRowContext(ctx,
-		`SELECT `+folderColumns+` FROM folders WHERE id = ?`, folderID)
+func (s *Store) FolderByID(ctx context.Context, viewerID, folderID string) (store.Folder, error) {
+	query := `SELECT ` + folderColumns + ` FROM folders WHERE id = ?`
+	args := []any{folderID}
+	if viewerID != "" {
+		query += ` AND EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = folders.id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+	}
+	row := s.db.QueryRowContext(ctx, query, args...)
 	folder, err := scanFolder(row)
 	if errors.Is(err, sql.ErrNoRows) {
 		return store.Folder{}, store.ErrNotFound
@@ -86,15 +91,27 @@ func (s *Store) FolderByID(ctx context.Context, folderID string) (store.Folder, 
 	return folder, err
 }
 
-func (s *Store) ListFolders(ctx context.Context, after string, limit int) ([]store.Folder, error) {
+func (s *Store) ListFolders(ctx context.Context, viewerID, after string, limit int) ([]store.Folder, error) {
 	if limit <= 0 {
 		limit = 100
 	}
 	query := `SELECT ` + folderColumns + ` FROM folders`
 	args := []any{}
+	where := false
+	if viewerID != "" {
+		query += ` WHERE EXISTS (SELECT 1 FROM user_folders uf
+			WHERE uf.folder_id = folders.id AND uf.user_id = ?)`
+		args = append(args, viewerID)
+		where = true
+	}
 	if after != "" {
 		name, id := store.SplitFolderCursor(after)
-		query += ` WHERE (name, id) > (?, ?)`
+		if where {
+			query += ` AND`
+		} else {
+			query += ` WHERE`
+		}
+		query += ` (name, id) > (?, ?)`
 		args = append(args, name, id)
 	}
 	query += ` ORDER BY name, id LIMIT ?`
@@ -114,6 +131,80 @@ func (s *Store) ListFolders(ctx context.Context, after string, limit int) ([]sto
 		folders = append(folders, folder)
 	}
 	return folders, rows.Err()
+}
+
+func (s *Store) AssignUserFolder(ctx context.Context, userID, folderID string) error {
+	return s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := validateGrantTargets(ctx, tx, userID, []string{folderID}); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `INSERT OR IGNORE INTO user_folders
+			(user_id, folder_id) VALUES (?, ?)`, userID, folderID)
+		return err
+	})
+}
+
+func (s *Store) UnassignUserFolder(ctx context.Context, userID, folderID string) error {
+	return s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := validateGrantTargets(ctx, tx, userID, []string{folderID}); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx,
+			`DELETE FROM user_folders WHERE user_id = ? AND folder_id = ?`, userID, folderID)
+		return err
+	})
+}
+
+func (s *Store) ListUserFolders(ctx context.Context, userID, after string, limit int) ([]store.Folder, error) {
+	if _, err := s.UserByID(ctx, userID); err != nil {
+		return nil, err
+	}
+	return s.ListFolders(ctx, userID, after, limit)
+}
+
+func (s *Store) ReplaceUserFolders(ctx context.Context, userID string, folderIDs []string) error {
+	unique := make([]string, 0, len(folderIDs))
+	seen := make(map[string]struct{}, len(folderIDs))
+	for _, id := range folderIDs {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			unique = append(unique, id)
+		}
+	}
+	return s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := validateGrantTargets(ctx, tx, userID, unique); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM user_folders WHERE user_id = ?`, userID); err != nil {
+			return err
+		}
+		for _, folderID := range unique {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO user_folders
+				(user_id, folder_id) VALUES (?, ?)`, userID, folderID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+func validateGrantTargets(ctx context.Context, tx *sql.Tx, userID string, folderIDs []string) error {
+	var one int
+	if err := tx.QueryRowContext(ctx, `SELECT 1 FROM users WHERE id = ?`, userID).Scan(&one); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return store.ErrNotFound
+		}
+		return err
+	}
+	for _, folderID := range folderIDs {
+		if err := tx.QueryRowContext(ctx, `SELECT 1 FROM folders WHERE id = ?`, folderID).Scan(&one); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return store.ErrNotFound
+			}
+			return err
+		}
+	}
+	return nil
 }
 
 // DeleteFolder removes the folder row. Everything catalog-side hangs off

--- a/internal/store/sqlite/migrate_test.go
+++ b/internal/store/sqlite/migrate_test.go
@@ -36,6 +36,16 @@ func TestMigrateUpgradesAnOlderDatabase(t *testing.T) {
 		time.Now().UTC().Format(time.RFC3339Nano)); err != nil {
 		t.Fatal(err)
 	}
+	created := time.Now().UTC().Format(time.RFC3339Nano)
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO users
+		(id, name, argon2_hash, created_at) VALUES ('old-user', 'old-user', 'x', ?)`, created); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx, `INSERT INTO folders
+		(id, name, root_path, kind, created_at, updated_at)
+		VALUES ('old-folder', 'Old', '/old', 'plain', ?, ?)`, created, created); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := s.Migrate(ctx); err != nil {
 		t.Fatalf("migrating an older database: %v", err)
@@ -60,6 +70,13 @@ func TestMigrateUpgradesAnOlderDatabase(t *testing.T) {
 	}
 	if applied != len(migrations) {
 		t.Errorf("applied migration %d, want %d", applied, len(migrations))
+	}
+	var grants int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM user_folders`).Scan(&grants); err != nil {
+		t.Fatal(err)
+	}
+	if grants != 0 {
+		t.Fatalf("migration granted existing accounts %d folders, want none", grants)
 	}
 
 	// Idempotent: a second start must not try to add the columns again.

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -541,7 +541,19 @@ const folderUploads = `
 ALTER TABLE folders ADD COLUMN accepts_uploads BOOLEAN NOT NULL DEFAULT 0;
 `
 
+// folderAccess is migration 4. Grants are explicit and deliberately
+// empty for both existing and newly created accounts and folders.
+const folderAccess = `
+CREATE TABLE user_folders (
+    user_id   TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    folder_id TEXT NOT NULL REFERENCES folders(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, folder_id)
+);
+
+CREATE INDEX user_folders_folder ON user_folders(folder_id);
+`
+
 // migrations is append-only: entry n is applied to a database that has
 // applied n-1 of them, so an entry that has shipped is never edited
 // again — the baseline included.
-var migrations = []string{schema, claimRevisions, folderUploads}
+var migrations = []string{schema, claimRevisions, folderUploads, folderAccess}

--- a/internal/store/sqlite/search.go
+++ b/internal/store/sqlite/search.go
@@ -121,6 +121,9 @@ func (s *Store) SearchCatalogBooks(
 		return store.SearchResult{}, fmt.Errorf(
 			"%w: search limit %d", store.ErrInvalidInput, query.Limit)
 	}
+	if _, err := s.FolderByID(ctx, query.UserID, query.FolderID); err != nil {
+		return store.SearchResult{}, err
+	}
 	terms := store.SearchTerms(query.Text)
 	scored := len(terms) > 0
 	if !scored && len(query.Entities) == 0 {

--- a/internal/store/sqlite/seriesmerge.go
+++ b/internal/store/sqlite/seriesmerge.go
@@ -21,6 +21,12 @@ import (
 func (s *Store) MergeSeries(
 	ctx context.Context, userID, seriesID, intoID string, at time.Time,
 ) (string, error) {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return "", err
+	}
+	if _, err := s.CatalogEntityByID(ctx, userID, intoID, store.EntitySeries); err != nil {
+		return "", err
+	}
 	if seriesID == intoID {
 		return "", fmt.Errorf("%w: a series cannot be merged into itself",
 			store.ErrInvalidInput)
@@ -111,6 +117,12 @@ func (s *Store) MergeSeries(
 func (s *Store) SplitSeriesFolder(
 	ctx context.Context, userID, seriesID, folderID, name string, at time.Time,
 ) (string, error) {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return "", err
+	}
+	if _, err := s.FolderByID(ctx, userID, folderID); err != nil {
+		return "", err
+	}
 	if userID == "" {
 		return "", fmt.Errorf("%w: a split needs a writer", store.ErrInvalidInput)
 	}

--- a/internal/store/sqlite/seriesname.go
+++ b/internal/store/sqlite/seriesname.go
@@ -21,6 +21,9 @@ func (s *Store) SetSeriesName(
 	ctx context.Context, userID, seriesID string, scope store.SeriesSource,
 	name string, at time.Time,
 ) error {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return err
+	}
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
 		return err
@@ -72,6 +75,9 @@ func (s *Store) SetSeriesName(
 func (s *Store) ClearSeriesName(
 	ctx context.Context, userID, seriesID string, scope store.SeriesSource,
 ) error {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return err
+	}
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
 		return err

--- a/internal/store/sqlite/seriesoverride.go
+++ b/internal/store/sqlite/seriesoverride.go
@@ -117,6 +117,9 @@ func (s *Store) SetBookSeriesOverride(
 	ctx context.Context, userID, bookID string, scope store.SeriesSource,
 	items []store.SeriesClaimItem, mutation store.SeriesClaimMutation,
 ) (store.SeriesClaimOutcome, error) {
+	if _, err := s.CatalogBookByID(ctx, userID, bookID); err != nil {
+		return "", err
+	}
 	clientTS, ifUpdatedAt, at := mutation.ClientTS, mutation.IfUpdatedAt, store.ClaimRevision(mutation.At)
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
@@ -266,6 +269,9 @@ func (s *Store) ClearBookSeriesOverride(
 	ctx context.Context, userID, bookID string, scope store.SeriesSource,
 	mutation store.SeriesClaimMutation,
 ) (store.SeriesClaimOutcome, error) {
+	if _, err := s.CatalogBookByID(ctx, userID, bookID); err != nil {
+		return "", err
+	}
 	clientTS, ifUpdatedAt, at := mutation.ClientTS, mutation.IfUpdatedAt, store.ClaimRevision(mutation.At)
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
@@ -332,6 +338,14 @@ func (s *Store) ReorderSeries(
 	ctx context.Context, userID, seriesID string,
 	scope store.SeriesSource, order []store.SeriesPlacement, at time.Time,
 ) error {
+	if _, err := s.CatalogEntityByID(ctx, userID, seriesID, store.EntitySeries); err != nil {
+		return err
+	}
+	for _, placement := range order {
+		if _, err := s.CatalogBookByID(ctx, userID, placement.BookID); err != nil {
+			return err
+		}
+	}
 	scopeUser, err := scope.ScopeUser(userID)
 	if err != nil {
 		return err
@@ -395,6 +409,9 @@ func (s *Store) BookSeriesLayers(
 	ctx context.Context, userID, bookID string,
 ) (store.BookSeriesLayers, error) {
 	var out store.BookSeriesLayers
+	if _, err := s.CatalogBookByID(ctx, userID, bookID); err != nil {
+		return out, err
+	}
 	var folderID string
 	err := s.db.QueryRowContext(ctx,
 		`SELECT folder_id FROM books WHERE id = ?`, bookID).Scan(&folderID)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,10 +3,10 @@
 //
 // Per-user reading state — ops, sessions, works, editions, aliases and
 // the user_book_works bridge — is scoped by user_id in every query, and
-// no caller constructs a cross-user one. The catalog is deliberately
-// not: ADR-0017 makes every folder's books visible to every signed-in
-// account, so catalog reads take a folder id and no principal. What
-// stays private is what somebody read, never what the server holds.
+// no caller constructs a cross-user one. Catalog rows are shared, but
+// catalog visibility is filtered through explicit per-user folder
+// grants. An empty viewer id is reserved for trusted internal and
+// administrative work.
 package store
 
 import (
@@ -248,11 +248,10 @@ func (k FolderKind) Valid() bool {
 
 // Folder is a directory this server reflects.
 //
-// It has no owner, no quota principal and no access list. Every
-// signed-in account sees every folder's books; only an administrator
-// sees RootPath, which is a filesystem oracle and not a reader's
-// business. Nothing beneath RootPath is written unless AcceptsUploads
-// says somebody asked for it.
+// It has no owner or quota principal. Readers see it through explicit
+// folder grants; only an administrator sees RootPath, which is a
+// filesystem oracle and not a reader's business. Nothing beneath
+// RootPath is written unless AcceptsUploads says somebody asked for it.
 type Folder struct {
 	ID       string
 	Name     string
@@ -708,7 +707,9 @@ const MaxEntityListLimit = 500
 // catalog's search to have no vocabulary for it.
 type SearchQuery struct {
 	FolderID string
-	// UserID is who is asking. Series filters and series facets resolve
+	// UserID is the catalog viewer. Empty is reserved for trusted
+	// internal work; a real user sees only explicitly granted folders.
+	// Series filters and series facets resolve
 	// through that reader's override layers (ADR-0018); the full-text
 	// index is deliberately shared and keeps indexing what the folder
 	// observed.
@@ -1186,20 +1187,23 @@ type Store interface {
 	// -----------------------------------------------------------------
 	// Folders.
 	//
-	// A folder has no owner and no access list, so none of these take a
-	// user id: every signed-in account sees every folder's books. Only
-	// an administrator is shown RootPath, and that is enforced at the
-	// handler edge, not here.
+	// A folder has no owner. Catalog-facing reads take a viewer id and
+	// require an explicit grant. The empty viewer id is the trusted path
+	// used by reconciliation, watchers and folder administration.
 	// -----------------------------------------------------------------
 
 	CreateFolder(ctx context.Context, folder Folder) error
-	FolderByID(ctx context.Context, folderID string) (Folder, error)
+	FolderByID(ctx context.Context, viewerID, folderID string) (Folder, error)
 	// SetFolderUploads turns a folder's upload permission on or off
 	// (ADR-0023). Returns ErrNotFound if the folder is gone.
 	SetFolderUploads(ctx context.Context, folderID string, accepts bool, at time.Time) error
 	// ListFolders pages folders ordered by name then id. after is a
 	// FolderCursor, empty for the first page.
-	ListFolders(ctx context.Context, after string, limit int) ([]Folder, error)
+	ListFolders(ctx context.Context, viewerID, after string, limit int) ([]Folder, error)
+	AssignUserFolder(ctx context.Context, userID, folderID string) error
+	UnassignUserFolder(ctx context.Context, userID, folderID string) error
+	ListUserFolders(ctx context.Context, userID, after string, limit int) ([]Folder, error)
+	ReplaceUserFolders(ctx context.Context, userID string, folderIDs []string) error
 	// DeleteFolder removes a folder and, by cascade, every catalog row
 	// that hung off it. Nothing beneath its root path is touched: the
 	// files were never this server's to delete.
@@ -1275,7 +1279,7 @@ type Store interface {
 	// Catalog reads.
 	// -----------------------------------------------------------------
 
-	CatalogBookByID(ctx context.Context, bookID string) (CatalogBook, error)
+	CatalogBookByID(ctx context.Context, viewerID, bookID string) (CatalogBook, error)
 	// CatalogBookByDigest finds an active book by its content digest.
 	//
 	// It is what makes an upload idempotent (ADR-0023): the bytes are
@@ -1284,12 +1288,12 @@ type Store interface {
 	// book its own reconcile pass just made, which is why it does not
 	// take a folder id — the same file may already be somewhere else,
 	// and that copy is the answer.
-	CatalogBookByDigest(ctx context.Context, sha string) (CatalogBook, error)
+	CatalogBookByDigest(ctx context.Context, viewerID, sha string) (CatalogBook, error)
 	// ListCatalogBooks pages one folder's books, oldest first.
-	ListCatalogBooks(ctx context.Context, folderID string, after *CatalogBookCursor, limit int) ([]CatalogBook, error)
+	ListCatalogBooks(ctx context.Context, viewerID, folderID string, after *CatalogBookCursor, limit int) ([]CatalogBook, error)
 	// ListRecentCatalogBooks pages the same books newest first, for the
 	// "recently added" shelf and the OPDS feed of the same name.
-	ListRecentCatalogBooks(ctx context.Context, folderID string, before *CatalogBookCursor, limit int) ([]CatalogBook, error)
+	ListRecentCatalogBooks(ctx context.Context, viewerID, folderID string, before *CatalogBookCursor, limit int) ([]CatalogBook, error)
 	// CatalogBookRelationsForBooks reads the contributors and series of a
 	// whole page of books at once, so that rendering a shelf costs one
 	// query rather than one per book (ADR-0015).
@@ -1323,13 +1327,13 @@ type Store interface {
 	SearchCatalogBooks(ctx context.Context, query SearchQuery) (SearchResult, error)
 	// AvailableBookMediaTypes reports the distinct media types a folder's
 	// books carry, so a feed can advertise what it actually holds.
-	AvailableBookMediaTypes(ctx context.Context, folderID string) ([]string, error)
+	AvailableBookMediaTypes(ctx context.Context, viewerID, folderID string) ([]string, error)
 	// CatalogBookIdentifiers reads one book's publication identifiers,
 	// which are the evidence a work resolution runs on.
-	CatalogBookIdentifiers(ctx context.Context, bookID string) ([]BookIdentifier, error)
+	CatalogBookIdentifiers(ctx context.Context, viewerID, bookID string) ([]BookIdentifier, error)
 	// CatalogAuthorsForBooks maps book id to author display names, for
 	// the identity backfill that links a catalog book to a sync work.
-	CatalogAuthorsForBooks(ctx context.Context, bookIDs []string) (map[string][]string, error)
+	CatalogAuthorsForBooks(ctx context.Context, viewerID string, bookIDs []string) (map[string][]string, error)
 
 	// -----------------------------------------------------------------
 	// Series claims (ADR-0018).

--- a/internal/store/storetest/catalog.go
+++ b/internal/store/storetest/catalog.go
@@ -37,11 +37,11 @@ func testFolders(t *testing.T, open OpenFunc) {
 		t.Fatalf("invalid folder kind: want ErrInvalidInput, got %v", err)
 	}
 
-	got, err := s.FolderByID(ctx, "folders-a")
+	got, err := s.FolderByID(ctx, "", "folders-a")
 	if err != nil || got.RootPath != "/srv/dup" {
 		t.Fatalf("FolderByID: %+v %v", got, err)
 	}
-	if _, err := s.FolderByID(ctx, "no-such-folder"); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.FolderByID(ctx, "", "no-such-folder"); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("missing folder: want ErrNotFound, got %v", err)
 	}
 
@@ -57,7 +57,7 @@ func testFolders(t *testing.T, open OpenFunc) {
 	var names []string
 	cursor := ""
 	for {
-		page, err := s.ListFolders(ctx, cursor, 2)
+		page, err := s.ListFolders(ctx, "", cursor, 2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -90,7 +90,7 @@ func testFolders(t *testing.T, open OpenFunc) {
 	if err := s.DeleteFolder(ctx, "folders-a"); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("double delete: want ErrNotFound, got %v", err)
 	}
-	if _, err := s.CatalogBookByID(ctx, bookID); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.CatalogBookByID(ctx, "", bookID); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("book survived its folder's deletion: %v", err)
 	}
 }
@@ -144,7 +144,7 @@ func testCatalogListingsPageAndIsolate(t *testing.T, open OpenFunc) {
 	var got []string
 	var cursor *store.CatalogBookCursor
 	for {
-		page, err := s.ListCatalogBooks(ctx, folder.ID, cursor, 2)
+		page, err := s.ListCatalogBooks(ctx, "", folder.ID, cursor, 2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -176,7 +176,7 @@ func testCatalogListingsPageAndIsolate(t *testing.T, open OpenFunc) {
 
 	// Hidden, not deleted: the row is still there to be read by id, so a
 	// reader's work mapping still has something to point at.
-	away, err := s.CatalogBookByID(ctx, awayID)
+	away, err := s.CatalogBookByID(ctx, "", awayID)
 	if err != nil {
 		t.Fatalf("a missing book was deleted rather than hidden: %v", err)
 	}
@@ -188,7 +188,7 @@ func testCatalogListingsPageAndIsolate(t *testing.T, open OpenFunc) {
 	var recent []string
 	cursor = nil
 	for {
-		page, err := s.ListRecentCatalogBooks(ctx, folder.ID, cursor, 2)
+		page, err := s.ListRecentCatalogBooks(ctx, "", folder.ID, cursor, 2)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -212,7 +212,7 @@ func testCatalogListingsPageAndIsolate(t *testing.T, open OpenFunc) {
 		t.Fatalf("recent books: got %v want %v", recent, reversed)
 	}
 
-	if _, err := s.CatalogBookByID(ctx, "no-such-book"); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.CatalogBookByID(ctx, "", "no-such-book"); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("missing book id: want ErrNotFound, got %v", err)
 	}
 }
@@ -247,7 +247,7 @@ func testAvailableBookMediaTypes(t *testing.T, open OpenFunc) {
 			Title: "C", MediaType: "application/vnd.comicbook+zip"},
 	}, true, now)
 
-	got, err := s.AvailableBookMediaTypes(ctx, folder.ID)
+	got, err := s.AvailableBookMediaTypes(ctx, "", folder.ID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +294,7 @@ func testCatalogAuthorsForBooks(t *testing.T, open OpenFunc) {
 		known["pair.epub"].ID, known["translated.epub"].ID,
 		known["anonymous.epub"].ID, "no-such-book",
 	}
-	got, err := s.CatalogAuthorsForBooks(ctx, ids)
+	got, err := s.CatalogAuthorsForBooks(ctx, "", ids)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -311,7 +311,7 @@ func testCatalogAuthorsForBooks(t *testing.T, open OpenFunc) {
 		t.Fatalf("an unknown book id resolved to something: %v", got["no-such-book"])
 	}
 
-	empty, err := s.CatalogAuthorsForBooks(ctx, nil)
+	empty, err := s.CatalogAuthorsForBooks(ctx, "", nil)
 	if err != nil || len(empty) != 0 {
 		t.Fatalf("empty request: %v %v", empty, err)
 	}
@@ -559,7 +559,7 @@ func testUserBookWorkIsPerUser(t *testing.T, open OpenFunc) {
 	bookID := knownByPath(t, s, folder.ID)["shared.epub"].ID
 
 	// Both accounts can read the one shared catalog row.
-	if _, err := s.CatalogBookByID(ctx, bookID); err != nil {
+	if _, err := s.CatalogBookByID(ctx, "", bookID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/store/storetest/delete.go
+++ b/internal/store/storetest/delete.go
@@ -218,7 +218,7 @@ func testDeleteMissingBook(t *testing.T, open OpenFunc) {
 	if err := s.DeleteMissingBook(ctx, unreadID); err != nil {
 		t.Fatalf("DeleteMissingBook: %v", err)
 	}
-	if _, err := s.CatalogBookByID(ctx, readID); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.CatalogBookByID(ctx, "", readID); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("a deleted book is still in the catalog: %v", err)
 	}
 
@@ -298,7 +298,7 @@ func testDeleteCatalogBook(t *testing.T, open OpenFunc) {
 		t.Fatalf("deleting out of a folder that takes no uploads: "+
 			"want ErrInvalidInput, got %v", err)
 	}
-	if _, err := s.CatalogBookByID(ctx, theirsID); err != nil {
+	if _, err := s.CatalogBookByID(ctx, "", theirsID); err != nil {
 		t.Fatalf("a refused delete took the book anyway: %v", err)
 	}
 
@@ -307,7 +307,7 @@ func testDeleteCatalogBook(t *testing.T, open OpenFunc) {
 	); err != nil {
 		t.Fatalf("DeleteCatalogBook: %v", err)
 	}
-	if _, err := s.CatalogBookByID(ctx, sentID); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.CatalogBookByID(ctx, "", sentID); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("the book survived its own deletion: %v", err)
 	}
 	if _, err := s.DeleteCatalogBook(

--- a/internal/store/storetest/folderaccess.go
+++ b/internal/store/storetest/folderaccess.go
@@ -1,0 +1,180 @@
+package storetest
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func testFolderAccess(t *testing.T, open OpenFunc) {
+	t.Helper()
+	s := open(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	reader := store.User{
+		ID: "grant-reader", Name: "grant-reader", Argon2Hash: "x",
+		Timezone: "UTC", CreatedAt: now,
+	}
+	admin := store.User{
+		ID: "grant-admin", Name: "grant-admin", Argon2Hash: "x",
+		Timezone: "UTC", IsAdmin: true, CreatedAt: now,
+	}
+	for _, user := range []store.User{reader, admin} {
+		if err := s.CreateUser(ctx, user); err != nil {
+			t.Fatal(err)
+		}
+	}
+	folders := []store.Folder{
+		{ID: "grant-a", Name: "A", RootPath: "/a", Kind: store.FolderPlain, CreatedAt: now, UpdatedAt: now},
+		{ID: "grant-b", Name: "B", RootPath: "/b", Kind: store.FolderPlain, CreatedAt: now, UpdatedAt: now},
+	}
+	for _, folder := range folders {
+		if err := s.CreateFolder(ctx, folder); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, userID := range []string{reader.ID, admin.ID} {
+		got, err := s.ListFolders(ctx, userID, "", 10)
+		if err != nil || len(got) != 0 {
+			t.Fatalf("new account %s folders = %+v, %v", userID, got, err)
+		}
+	}
+	if got, err := s.ListFolders(ctx, "", "", 10); err != nil || len(got) != 2 {
+		t.Fatalf("trusted folder list = %+v, %v", got, err)
+	}
+
+	if err := s.AssignUserFolder(ctx, reader.ID, folders[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AssignUserFolder(ctx, reader.ID, folders[0].ID); err != nil {
+		t.Fatalf("duplicate assignment: %v", err)
+	}
+	if _, err := s.FolderByID(ctx, reader.ID, folders[1].ID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("ungranted folder lookup = %v", err)
+	}
+
+	observed := func(path, sha, title, author string) store.ObservedBook {
+		return store.ObservedBook{
+			RelativePath: path, SizeBytes: 1, MTime: now,
+			ContentSHA256: sha, OriginalFilename: path,
+			MediaType: "application/epub+zip", Title: title,
+			Contributors: []store.ObservedContributor{{Name: author, Role: store.ContributorRoleAuthor}},
+			Tags:         []string{"Visible Tag"},
+			Series:       []store.ObservedSeries{{Name: "Visible Series"}},
+		}
+	}
+	if _, err := s.ReconcileFolder(ctx, folders[0].ID,
+		[]store.ObservedBook{observed("a.epub", "sha-a", "A", "Author Z")}, true, now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ReconcileFolder(ctx, folders[1].ID,
+		[]store.ObservedBook{observed("b.epub", "sha-b", "B", "Author A")}, true, now); err != nil {
+		t.Fatal(err)
+	}
+	aBooks, err := s.ListCatalogBooks(ctx, reader.ID, folders[0].ID, nil, 10)
+	if err != nil || len(aBooks) != 1 {
+		t.Fatalf("granted books = %+v, %v", aBooks, err)
+	}
+	if _, err := s.ListCatalogBooks(ctx, reader.ID, folders[1].ID, nil, 10); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("ungranted book list = %v", err)
+	}
+	if _, err := s.CatalogBookByDigest(ctx, reader.ID, "sha-b"); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("hidden digest = %v", err)
+	}
+	result, err := s.SearchCatalogBooks(ctx, store.SearchQuery{
+		UserID: reader.ID, FolderID: folders[0].ID, Text: "A", Limit: 10,
+	})
+	if err != nil || len(result.Books) != 1 {
+		t.Fatalf("granted search = %+v, %v", result, err)
+	}
+	for _, kind := range []store.EntityKind{store.EntitySeries, store.EntityContributor, store.EntityTag} {
+		entities, err := s.ListCatalogEntities(ctx, reader.ID, kind, "", 10)
+		if err != nil || len(entities) != 1 || entities[0].BookCount != 1 {
+			t.Fatalf("%s entities = %+v, %v", kind, entities, err)
+		}
+	}
+	contributors, err := s.ListCatalogEntities(ctx, reader.ID, store.EntityContributor, "", 1)
+	if err != nil || len(contributors) != 1 || contributors[0].Name != "Author Z" {
+		t.Fatalf("hidden entity consumed the first page: %+v, %v", contributors, err)
+	}
+	allContributors, err := s.ListCatalogEntities(ctx, "", store.EntityContributor, "", 10)
+	if err != nil || len(allContributors) != 2 {
+		t.Fatalf("trusted contributors = %+v, %v", allContributors, err)
+	}
+	if _, err := s.CatalogEntityByID(ctx, reader.ID, allContributors[0].ID,
+		store.EntityContributor); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("hidden entity lookup = %v", err)
+	}
+
+	work := store.Work{ID: "grant-work", UserID: reader.ID, Title: "A", CreatedAt: now}
+	resolved, err := s.ResolveCatalogBookWork(ctx, reader.ID, aBooks[0].ID, work, nil, nil, true, now)
+	if err != nil || resolved.WorkID != work.ID {
+		t.Fatalf("resolve = %+v, %v", resolved, err)
+	}
+	if _, err := s.AppendOps(ctx, reader.ID, "grant-device", []store.Op{{
+		OpID: "grant-op", WorkID: work.ID, ClientTS: now,
+		Progression: 0.5, Origin: store.OriginNative,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendSessions(ctx, reader.ID, []store.Session{{
+		SessionID: "grant-session", WorkID: work.ID, DeviceID: "grant-device",
+		StartedAt: now.Add(-time.Minute), EndedAt: now,
+		StartProg: 0.4, EndProg: 0.5, Origin: store.OriginNative,
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UnassignUserFolder(ctx, reader.ID, folders[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UserBookWork(ctx, reader.ID, aBooks[0].ID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("revoked mapping was visible: %v", err)
+	}
+	if _, err := s.WorkByID(ctx, reader.ID, work.ID); err != nil {
+		t.Fatalf("revocation removed reading history: %v", err)
+	}
+	if positions, err := s.Positions(ctx, reader.ID, work.ID, 10); err != nil || len(positions) != 1 {
+		t.Fatalf("revocation removed positions: %+v, %v", positions, err)
+	}
+	if sessions, err := s.SessionsForWork(ctx, reader.ID, work.ID, 10); err != nil || len(sessions) != 1 {
+		t.Fatalf("revocation removed sessions: %+v, %v", sessions, err)
+	}
+	if workIDs, err := s.WorkIDsWithInsights(ctx, reader.ID); err != nil || len(workIDs) != 1 || workIDs[0] != work.ID {
+		t.Fatalf("revocation removed statistics: %+v, %v", workIDs, err)
+	}
+	if err := s.AssignUserFolder(ctx, reader.ID, folders[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if link, err := s.UserBookWork(ctx, reader.ID, aBooks[0].ID); err != nil || link.WorkID != work.ID {
+		t.Fatalf("restored mapping = %+v, %v", link, err)
+	}
+
+	if err := s.ReplaceUserFolders(ctx, reader.ID, []string{folders[0].ID, folders[0].ID}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ReplaceUserFolders(ctx, reader.ID, []string{folders[1].ID, "missing"}); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("invalid replacement = %v", err)
+	}
+	grants, err := s.ListUserFolders(ctx, reader.ID, "", 10)
+	if err != nil || len(grants) != 1 || grants[0].ID != folders[0].ID {
+		t.Fatalf("invalid replacement changed grants: %+v, %v", grants, err)
+	}
+	if err := s.ReplaceUserFolders(ctx, reader.ID, nil); err != nil {
+		t.Fatal(err)
+	}
+	if grants, err := s.ListUserFolders(ctx, reader.ID, "", 10); err != nil || len(grants) != 0 {
+		t.Fatalf("empty replacement = %+v, %v", grants, err)
+	}
+	if err := s.AssignUserFolder(ctx, reader.ID, folders[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DeleteFolder(ctx, folders[0].ID); err != nil {
+		t.Fatal(err)
+	}
+	if grants, err := s.ListUserFolders(ctx, reader.ID, "", 10); err != nil || len(grants) != 0 {
+		t.Fatalf("folder cascade = %+v, %v", grants, err)
+	}
+}

--- a/internal/store/storetest/reconcile.go
+++ b/internal/store/storetest/reconcile.go
@@ -22,6 +22,15 @@ func MkFolder(t *testing.T, s store.Store, name string, kind store.FolderKind) s
 	if err := s.CreateFolder(context.Background(), f); err != nil {
 		t.Fatal(err)
 	}
+	users, err := s.ListUsers(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, user := range users {
+		if err := s.AssignUserFolder(context.Background(), user.ID, f.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
 	return f
 }
 
@@ -88,7 +97,7 @@ func testReconcileIdempotency(t *testing.T, open OpenFunc) {
 		t.Fatalf("first pass: %+v", first)
 	}
 
-	books, err := s.ListCatalogBooks(context.Background(), folder.ID, nil, 50)
+	books, err := s.ListCatalogBooks(context.Background(), "", folder.ID, nil, 50)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +116,7 @@ func testReconcileIdempotency(t *testing.T, open OpenFunc) {
 		t.Fatalf("second identical pass reported a change: %+v", second)
 	}
 
-	books, err = s.ListCatalogBooks(context.Background(), folder.ID, nil, 50)
+	books, err = s.ListCatalogBooks(context.Background(), "", folder.ID, nil, 50)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +156,7 @@ func testReconcileMissingAndReturning(t *testing.T, open OpenFunc) {
 	if result.Missing != 1 {
 		t.Fatalf("want one missing book, got %+v", result)
 	}
-	got, err := s.CatalogBookByID(ctx, bookID)
+	got, err := s.CatalogBookByID(ctx, "", bookID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +176,7 @@ func testReconcileMissingAndReturning(t *testing.T, open OpenFunc) {
 	if result.Returned != 1 {
 		t.Fatalf("want one returned book, got %+v", result)
 	}
-	got, err = s.CatalogBookByID(ctx, bookID)
+	got, err = s.CatalogBookByID(ctx, "", bookID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +210,7 @@ func testReconcileIncompletePassMarksNothingMissing(t *testing.T, open OpenFunc)
 	if result.Missing != 0 {
 		t.Fatalf("an incomplete pass marked books missing: %+v", result)
 	}
-	got, err := s.CatalogBookByID(ctx, bID)
+	got, err := s.CatalogBookByID(ctx, "", bID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +240,7 @@ func testReconcileZeroObservationPassMarksNothingMissing(t *testing.T, open Open
 	if result.Missing != 0 {
 		t.Fatalf("a zero-observation complete pass marked books missing: %+v", result)
 	}
-	got, err := s.CatalogBookByID(ctx, bookID)
+	got, err := s.CatalogBookByID(ctx, "", bookID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,13 +290,13 @@ func testReconcileReplacementDropsReadingMapping(t *testing.T, open OpenFunc) {
 	if newBookID == oldBookID {
 		t.Fatalf("replacement kept the old book id")
 	}
-	if _, err := s.CatalogBookByID(ctx, oldBookID); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.CatalogBookByID(ctx, "", oldBookID); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("old book row survived a replacement: %v", err)
 	}
 	if _, err := s.UserBookWork(ctx, user.ID, oldBookID); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("reading mapping survived a content replacement: %v", err)
 	}
-	newBook, err := s.CatalogBookByID(ctx, newBookID)
+	newBook, err := s.CatalogBookByID(ctx, "", newBookID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +330,7 @@ func testReconcileUnchangedKeepsMetadata(t *testing.T, open OpenFunc) {
 	}
 	doReconcile(t, s, folder.ID, []store.ObservedBook{unchanged}, true, now.Add(time.Hour))
 
-	got, err := s.CatalogBookByID(ctx, bookID)
+	got, err := s.CatalogBookByID(ctx, "", bookID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +390,7 @@ func testReconcileCalibrePathMoveKeepsIdentity(t *testing.T, open OpenFunc) {
 	if stillSameID.RelativePath != "New Title (7)/book.epub" {
 		t.Fatalf("book did not follow its new path: %+v", stillSameID)
 	}
-	got, err := s.CatalogBookByID(ctx, bookID)
+	got, err := s.CatalogBookByID(ctx, "", bookID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -492,7 +501,7 @@ func testReconcileCalibrePurgesDeletedBooks(t *testing.T, open OpenFunc) {
 	if len(after) != 1 {
 		t.Fatalf("want one book left after the purge, got %d", len(after))
 	}
-	if _, err := s.CatalogBookByID(ctx, droppedID); !errors.Is(err, store.ErrNotFound) {
+	if _, err := s.CatalogBookByID(ctx, "", droppedID); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("a book gone from metadata.db survived the pass: %v", err)
 	}
 	if _, err := s.WorkByID(ctx, user.ID, emptyWork.ID); !errors.Is(err, store.ErrNotFound) {
@@ -557,7 +566,7 @@ func testReconcileCalibreUnservableBookIsKept(t *testing.T, open OpenFunc) {
 	if known.RelativePath != "Converted (11)/book.epub" {
 		t.Fatalf("an unservable observation overwrote what the catalog knew: %+v", known)
 	}
-	stored, err := s.CatalogBookByID(ctx, bookID)
+	stored, err := s.CatalogBookByID(ctx, "", bookID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/storetest/seriesname.go
+++ b/internal/store/storetest/seriesname.go
@@ -336,7 +336,7 @@ func testSeriesRenameDiesWithItsSeries(t *testing.T, open OpenFunc) {
 // folderIDOf finds a folder by the name a test gave it.
 func folderIDOf(t *testing.T, s store.Store, name string) string {
 	t.Helper()
-	folders, err := s.ListFolders(context.Background(), "", 100)
+	folders, err := s.ListFolders(context.Background(), "", "", 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/storetest/seriesoverride.go
+++ b/internal/store/storetest/seriesoverride.go
@@ -40,7 +40,7 @@ func bookIDByPath(
 	t *testing.T, s store.Store, folderID, path string,
 ) string {
 	t.Helper()
-	books, err := s.ListCatalogBooks(context.Background(), folderID, nil, 100)
+	books, err := s.ListCatalogBooks(context.Background(), "", folderID, nil, 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -43,6 +43,7 @@ func Run(t *testing.T, open OpenFunc) {
 	t.Run("DisabledUser", func(t *testing.T) { testDisabledUser(t, open) })
 	t.Run("Tokens", func(t *testing.T) { testTokens(t, open) })
 	t.Run("Folders", func(t *testing.T) { testFolders(t, open) })
+	t.Run("FolderAccess", func(t *testing.T) { testFolderAccess(t, open) })
 	t.Run("CatalogListingsPageAndIsolate", func(t *testing.T) {
 		testCatalogListingsPageAndIsolate(t, open)
 	})
@@ -254,6 +255,25 @@ func MkUser(t *testing.T, s store.Store, name string) store.User {
 	}
 	if err := s.CreateUser(context.Background(), u); err != nil {
 		t.Fatal(err)
+	}
+	// Most shared-store tests predate explicit folder grants and use
+	// MkUser/MkFolder when catalog access is incidental. Keep those
+	// fixtures readable while grant-specific tests use raw creation.
+	var after string
+	for {
+		folders, err := s.ListFolders(context.Background(), "", after, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, folder := range folders {
+			if err := s.AssignUserFolder(context.Background(), u.ID, folder.ID); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if len(folders) < 100 {
+			break
+		}
+		after = store.FolderCursor(folders[len(folders)-1])
 	}
 	return u
 }

--- a/internal/webui/adminexpanded_test.go
+++ b/internal/webui/adminexpanded_test.go
@@ -62,7 +62,7 @@ func TestAdminWatchesAndForgetsAFolder(t *testing.T) {
 	if strings.Contains(body, "Watching Nowhere") {
 		t.Fatalf("a missing directory was accepted: %s", body)
 	}
-	if folders, _ := st.ListFolders(ctx, "", 10); len(folders) != 0 {
+	if folders, _ := st.ListFolders(ctx, "", "", 10); len(folders) != 0 {
 		t.Fatalf("a refused add created %d folders", len(folders))
 	}
 
@@ -72,7 +72,7 @@ func TestAdminWatchesAndForgetsAFolder(t *testing.T) {
 	if !strings.Contains(body, "Watching Shelf") {
 		t.Fatalf("add: %s", body)
 	}
-	folders, err := st.ListFolders(ctx, "", 10)
+	folders, err := st.ListFolders(ctx, "", "", 10)
 	if err != nil || len(folders) != 1 {
 		t.Fatalf("folders = %d, %v", len(folders), err)
 	}
@@ -99,7 +99,7 @@ func TestAdminWatchesAndForgetsAFolder(t *testing.T) {
 	if !strings.Contains(body, "Stopped watching Shelf") {
 		t.Fatalf("delete: %s", body)
 	}
-	if folders, _ := st.ListFolders(ctx, "", 10); len(folders) != 0 {
+	if folders, _ := st.ListFolders(ctx, "", "", 10); len(folders) != 0 {
 		t.Fatalf("a removed folder is still listed: %v", folders)
 	}
 	if _, err := os.Stat(root); err != nil {
@@ -137,7 +137,7 @@ func TestAdminFolderHonoursTheAllowlist(t *testing.T) {
 	if !strings.Contains(body, "not below any of the roots") {
 		t.Fatalf("a root outside the allowlist was accepted: %s", body)
 	}
-	if folders, _ := st.ListFolders(t.Context(), "", 10); len(folders) != 0 {
+	if folders, _ := st.ListFolders(t.Context(), "", "", 10); len(folders) != 0 {
 		t.Fatalf("a refused root still created %d folders", len(folders))
 	}
 	// A directory below an allowed root is allowed.
@@ -180,7 +180,7 @@ func TestAdminFolderMutationsNeedTheSessionsToken(t *testing.T) {
 			t.Errorf("%s without a token: %d, want 403", path, code)
 		}
 	}
-	if folders, _ := st.ListFolders(ctx, "", 10); len(folders) != 1 {
+	if folders, _ := st.ListFolders(ctx, "", "", 10); len(folders) != 1 {
 		t.Fatalf("a forged request changed the folder list: %v", folders)
 	}
 }

--- a/internal/webui/adminfolders.go
+++ b/internal/webui/adminfolders.go
@@ -12,9 +12,8 @@ import (
 // The folders page (ADR-0013, ADR-0017).
 //
 // It is the one page in the whole UI that renders a root path. A folder
-// has no owner and no access list — every signed-in account sees every
-// folder's books — so what is administered here is not who may read
-// what, but which directories on this machine the server reflects. That
+// has no owner. This page administers which directories the server
+// reflects; each user page separately administers who may read them. That
 // is a privilege beyond administering the application, which is why the
 // form is bounded by content.folder_roots when an operator has set it.
 //
@@ -94,7 +93,7 @@ func (s *Server) handleAdminScanFolder(
 		return
 	}
 	folderID := r.PathValue("id")
-	folder, err := s.St.FolderByID(r.Context(), folderID)
+	folder, err := s.St.FolderByID(r.Context(), "", folderID)
 	logAdminAction(r, u, "scan-folder", folderID, err)
 	if err != nil {
 		s.renderAdminFolders(w, r, a, u, Flash{Error: "no such folder"})
@@ -126,7 +125,7 @@ func (s *Server) handleAdminDeleteFolder(
 		return
 	}
 	folderID := r.PathValue("id")
-	folder, err := s.St.FolderByID(r.Context(), folderID)
+	folder, err := s.St.FolderByID(r.Context(), "", folderID)
 	if err != nil {
 		logAdminAction(r, u, "remove-folder", folderID, err)
 		s.renderAdminFolders(w, r, a, u, Flash{Error: "no such folder"})
@@ -162,7 +161,7 @@ func (s *Server) handleAdminSetFolderUploads(
 		return
 	}
 	folderID := r.PathValue("id")
-	folder, err := s.St.FolderByID(r.Context(), folderID)
+	folder, err := s.St.FolderByID(r.Context(), "", folderID)
 	if err != nil {
 		logAdminAction(r, u, "folder-uploads", folderID, err)
 		s.renderAdminFolders(w, r, a, u, Flash{Error: "no such folder"})

--- a/internal/webui/adminfolders_watch_test.go
+++ b/internal/webui/adminfolders_watch_test.go
@@ -84,7 +84,7 @@ func TestAddingAFolderTellsTheWatcher(t *testing.T) {
 		t.Fatalf("a refused folder was announced: %d calls", count)
 	}
 
-	folders, err := st.ListFolders(t.Context(), "", 10)
+	folders, err := st.ListFolders(t.Context(), "", "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +143,7 @@ func TestScanNowAsksTheWatcher(t *testing.T) {
 	if !strings.Contains(body, "Watching Books") {
 		t.Fatalf("the folder was not added: %s", body)
 	}
-	folders, err := st.ListFolders(t.Context(), "", 10)
+	folders, err := st.ListFolders(t.Context(), "", "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +192,7 @@ func TestScanNowWithoutAWatcherSaysSo(t *testing.T) {
 	if !strings.Contains(body, "Watching Books") {
 		t.Fatal("the folder was not added")
 	}
-	folders, err := st.ListFolders(t.Context(), "", 10)
+	folders, err := st.ListFolders(t.Context(), "", "", 10)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/webui/adminusers.go
+++ b/internal/webui/adminusers.go
@@ -31,6 +31,21 @@ const adminUsersPerPage = 50
 // the slice (ADR-0013).
 const adminListCap = 200
 
+// adminUserFoldersMax bounds what the per-user grant form will render.
+// The form submits the complete grant set, so a truncated list would
+// revoke every folder past the cut the moment somebody saved it. Past
+// this many folders the page declines to offer the form at all and the
+// admin CLI does the assigning.
+const adminUserFoldersMax = 500
+
+// errTooManyFolders is what the grant form answers once the instance
+// watches more folders than one page may safely replace.
+var errTooManyFolders = errors.New(
+	"this instance watches too many folders for the web form to replace the " +
+		"whole grant set safely: use the admin CLI (assign-folder, " +
+		"unassign-folder) instead",
+)
+
 // adminUserView is one account as the per-user page shows it.
 type adminUserView struct {
 	User     store.User
@@ -53,6 +68,19 @@ type adminUserView struct {
 	// for the addresses an operator has to read out to whoever owns the
 	// device being paired.
 	Base string
+	// Folders is every watched folder, not one page. The checkbox form
+	// replaces the complete grant set, so rendering a partial list would
+	// revoke everything on a later page when it was submitted.
+	Folders []adminUserFolderView
+	// FoldersUnmanageable says the instance watches more folders than
+	// adminUserFoldersMax, so Folders is empty on purpose and the page
+	// offers no form rather than a lossy one.
+	FoldersUnmanageable bool
+}
+
+type adminUserFolderView struct {
+	Folder  store.Folder
+	Granted bool
 }
 
 // reauth is the shared gate in front of every high-impact mutation: the
@@ -222,6 +250,25 @@ func (s *Server) handleAdminSetDisabled(
 		}
 		return target.Name + " is enabled again. Their tokens and devices work; " +
 			"their web sessions do not, so they sign in again.", nil
+	})
+}
+
+func (s *Server) handleAdminSetFolders(
+	w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User,
+) {
+	s.withTargetNoReauth(w, r, a, u, "set-folder-access", func(target store.User) (string, error) {
+		if _, tooMany, err := allFolders(r.Context(), s.St, "", adminUserFoldersMax); err != nil {
+			return "", err
+		} else if tooMany {
+			return "", errTooManyFolders
+		}
+		// PostForm, not Form: Form merges the URL query into the body, so
+		// reading it would let a crafted link decide which folders a saved
+		// form grants.
+		if err := s.St.ReplaceUserFolders(r.Context(), target.ID, r.PostForm["folders"]); err != nil {
+			return "", err
+		}
+		return "Folder access updated for " + target.Name + ".", nil
 	})
 }
 

--- a/internal/webui/adminusers.templ
+++ b/internal/webui/adminusers.templ
@@ -117,6 +117,36 @@ templ adminUserBody(prefix string, csrf string, v adminUserView, flash Flash) {
 	</p>
 	@adminFlash(flash)
 	<section class="card">
+		<h2>Folder access</h2>
+		<p class="muted">
+			Choose which folders appear in this account's library. Administrator
+			rights do not grant reading access; administrators may assign folders
+			to themselves here.
+		</p>
+		<form method="post" action={ prefix + "admin/users/" + v.User.ID + "/folders" }>
+			<input type="hidden" name="csrf" value={ csrf }/>
+			if v.FoldersUnmanageable {
+				<p class="muted">
+					This instance watches too many folders to list here. Assign
+					them with the admin CLI: <code>assign-folder</code>,
+					<code>unassign-folder</code> and <code>list-user-folders</code>.
+				</p>
+			} else if len(v.Folders) == 0 {
+				<p class="muted">No folders are watched.</p>
+			} else {
+				for _, f := range v.Folders {
+					<label class="check">
+						<input type="checkbox" name="folders" value={ f.Folder.ID } checked?={ f.Granted }/>
+						{ f.Folder.Name }
+					</label>
+				}
+			}
+			if !v.FoldersUnmanageable {
+				<button type="submit" class="primary">Save folder access</button>
+			}
+		</form>
+	</section>
+	<section class="card">
 		<h2>API tokens</h2>
 		if len(v.Tokens) == 0 {
 			<p class="muted">None.</p>

--- a/internal/webui/adminusers_test.go
+++ b/internal/webui/adminusers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -27,6 +28,147 @@ func mkTarget(t *testing.T, st store.Store, name string) store.User {
 		t.Fatal(err)
 	}
 	return u
+}
+
+func TestAdminAssignsFolderAccessIncludingSelf(t *testing.T) {
+	ts, st := testServer(t)
+	if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
+		t.Fatal(err)
+	}
+	bob := mkTarget(t, st, "bob")
+	folder := store.Folder{
+		ID: "folder-access", Name: "Private Shelf", RootPath: t.TempDir(),
+		Kind: store.FolderPlain, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	if err := st.CreateFolder(t.Context(), folder); err != nil {
+		t.Fatal(err)
+	}
+	for i := range adminFoldersPerPage {
+		paged := store.Folder{
+			ID: store.NewID(), Name: fmt.Sprintf("Paged Shelf %02d", i),
+			RootPath: t.TempDir(), Kind: store.FolderPlain,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}
+		if err := st.CreateFolder(t.Context(), paged); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cookie := loginCookie(t, ts)
+	path := "/ui/settings?section=admin&view=user&user=" + bob.ID
+	_, body := page(t, ts, cookie, path)
+	if !strings.Contains(body, "Private Shelf") ||
+		!strings.Contains(body, "Paged Shelf 49") ||
+		!strings.Contains(body, "Folder access") {
+		t.Fatalf("folder access form missing: %s", body)
+	}
+	csrf := extractCSRF(t, body)
+	postPath := "/ui/admin/users/" + bob.ID + "/folders"
+	if code, _ := postForm(t, ts, cookie, postPath,
+		url.Values{"folders": {folder.ID}}); code != http.StatusForbidden {
+		t.Fatalf("assignment without CSRF = %d", code)
+	}
+	if code, _ := postForm(t, ts, cookie, postPath,
+		url.Values{"csrf": {csrf}, "folders": {folder.ID}}); code != http.StatusOK {
+		t.Fatalf("assignment = %d", code)
+	}
+	if _, err := st.FolderByID(t.Context(), bob.ID, folder.ID); err != nil {
+		t.Fatalf("bob did not receive the folder: %v", err)
+	}
+
+	selfPath := "/ui/settings?section=admin&view=user&user=u1"
+	_, body = page(t, ts, cookie, selfPath)
+	csrf = extractCSRF(t, body)
+	if code, _ := postForm(t, ts, cookie, "/ui/admin/users/u1/folders",
+		url.Values{"csrf": {csrf}, "folders": {folder.ID}}); code != http.StatusOK {
+		t.Fatalf("self-assignment = %d", code)
+	}
+	if _, err := st.FolderByID(t.Context(), "u1", folder.ID); err != nil {
+		t.Fatalf("admin did not receive their self-grant: %v", err)
+	}
+	if code, _ := postForm(t, ts, cookie, postPath,
+		url.Values{"csrf": {csrf}}); code != http.StatusOK {
+		t.Fatalf("empty replacement = %d", code)
+	}
+	if _, err := st.FolderByID(t.Context(), bob.ID, folder.ID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("empty replacement left access: %v", err)
+	}
+}
+
+// TestAdminFolderGrantIgnoresQueryStringFolders pins the grant form to
+// the request body. r.Form merges the URL query into the parsed body, so
+// reading it would let a crafted link decide which folders a submitted
+// form grants — the admin sees their own checkboxes and saves something
+// else.
+func TestAdminFolderGrantIgnoresQueryStringFolders(t *testing.T) {
+	ts, st := testServer(t)
+	if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
+		t.Fatal(err)
+	}
+	bob := mkTarget(t, st, "bob")
+	shown := store.Folder{
+		ID: "shown", Name: "Shown Shelf", RootPath: t.TempDir(),
+		Kind: store.FolderPlain, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	smuggled := store.Folder{
+		ID: "smuggled", Name: "Smuggled Shelf", RootPath: t.TempDir(),
+		Kind: store.FolderPlain, CreatedAt: time.Now(), UpdatedAt: time.Now(),
+	}
+	for _, f := range []store.Folder{shown, smuggled} {
+		if err := st.CreateFolder(t.Context(), f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cookie := loginCookie(t, ts)
+	_, body := page(t, ts, cookie,
+		"/ui/settings?section=admin&view=user&user="+bob.ID)
+	csrf := extractCSRF(t, body)
+	postPath := "/ui/admin/users/" + bob.ID + "/folders?folders=" + smuggled.ID
+	if code, _ := postForm(t, ts, cookie, postPath,
+		url.Values{"csrf": {csrf}, "folders": {shown.ID}}); code != http.StatusOK {
+		t.Fatalf("assignment = %d", code)
+	}
+	if _, err := st.FolderByID(t.Context(), bob.ID, shown.ID); err != nil {
+		t.Fatalf("the submitted folder was not granted: %v", err)
+	}
+	if _, err := st.FolderByID(t.Context(), bob.ID, smuggled.ID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("a query-string folder was granted: %v", err)
+	}
+}
+
+// TestAllFoldersReportsOverflowRatherThanAPrefix covers the bound on the
+// grant form's folder list. A prefix would be worse than an error: the
+// form replaces the whole grant set, so saving a truncated page would
+// revoke every folder past the cut.
+func TestAllFoldersReportsOverflowRatherThanAPrefix(t *testing.T) {
+	_, st := testServer(t)
+	total := adminFoldersPerPage + 5
+	for i := range total {
+		f := store.Folder{
+			ID: store.NewID(), Name: fmt.Sprintf("Shelf %03d", i),
+			RootPath: t.TempDir(), Kind: store.FolderPlain,
+			CreatedAt: time.Now(), UpdatedAt: time.Now(),
+		}
+		if err := st.CreateFolder(t.Context(), f); err != nil {
+			t.Fatal(err)
+		}
+	}
+	all, tooMany, err := allFolders(t.Context(), st, "", adminUserFoldersMax)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tooMany || len(all) != total {
+		t.Fatalf("under the cap: tooMany=%v len=%d want %d", tooMany, len(all), total)
+	}
+	all, tooMany, err = allFolders(t.Context(), st, "", adminFoldersPerPage-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !tooMany {
+		t.Fatalf("over the cap returned %d folders instead of an overflow", len(all))
+	}
+	if all != nil {
+		t.Fatalf("overflow returned a prefix of %d folders", len(all))
+	}
 }
 
 // TestAdminUserPageAndCredentialRevocation walks the per-user page: it

--- a/internal/webui/books.go
+++ b/internal/webui/books.go
@@ -26,10 +26,10 @@ import (
 // way than by a token — here, by a session cookie. Reusing it keeps the
 // media-type allowlist and filename sanitizing in one place.
 //
-// There is no user id, because the catalog is shared: every signed-in
-// account may download every folder's books (ADR-0017).
+// The user id is part of the call because shared catalog rows are
+// visible only through that reader's folder grants (ADR-0027).
 type Downloader interface {
-	ServeBookDownload(w http.ResponseWriter, r *http.Request, bookID string)
+	ServeBookDownload(w http.ResponseWriter, r *http.Request, viewerID, bookID string)
 }
 
 // booksPageSize keeps the page short enough to read. The UI paginates
@@ -49,7 +49,7 @@ func isHTMXRequest(r *http.Request) bool {
 // sortDirAsc pages oldest first, anything else (the default) newest
 // first.
 func (s *Server) listBooksPage(
-	r *http.Request, folderID, dir string,
+	r *http.Request, userID, folderID, dir string,
 ) ([]store.CatalogBook, string, error) {
 	after, err := decodeBooksCursor(r.URL.Query().Get("cursor"))
 	if err != nil {
@@ -62,7 +62,7 @@ func (s *Server) listBooksPage(
 	if dir == sortDirAsc {
 		list = s.St.ListCatalogBooks
 	}
-	books, err := list(r.Context(), folderID, after, booksPageSize)
+	books, err := list(r.Context(), userID, folderID, after, booksPageSize)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			return nil, "", nil
@@ -84,7 +84,7 @@ func (s *Server) listBooksPage(
 // there is nothing left to batch. The callers are the reading shelves,
 // which are bounded by construction; a catalog page already holds the
 // rows it needs.
-func (s *Server) booksByID(ctx context.Context, ids []string) map[string]store.CatalogBook {
+func (s *Server) booksByID(ctx context.Context, userID string, ids []string) map[string]store.CatalogBook {
 	out := make(map[string]store.CatalogBook, len(ids))
 	for _, id := range ids {
 		if id == "" {
@@ -93,7 +93,7 @@ func (s *Server) booksByID(ctx context.Context, ids []string) map[string]store.C
 		if _, done := out[id]; done {
 			continue
 		}
-		book, err := s.St.CatalogBookByID(ctx, id)
+		book, err := s.St.CatalogBookByID(ctx, userID, id)
 		if err != nil {
 			continue
 		}
@@ -115,10 +115,9 @@ func (s *Server) handleBook(w http.ResponseWriter, r *http.Request, a store.Auth
 }
 
 // bookView assembles the book page from one catalog row and its
-// relations. Every signed-in account sees the same page: the catalog is
-// shared, and nothing on it is anybody's to edit (ADR-0017).
+// relations. The row must be visible through this reader's folder grant.
 func (s *Server) bookView(r *http.Request, u *store.User, bookID string) (BookView, bool) {
-	book, err := s.St.CatalogBookByID(r.Context(), bookID)
+	book, err := s.St.CatalogBookByID(r.Context(), u.ID, bookID)
 	if err != nil {
 		return BookView{}, false
 	}
@@ -153,7 +152,7 @@ func (s *Server) bookView(r *http.Request, u *store.User, bookID string) (BookVi
 	// rather than a scope, because a browser session carries no scopes
 	// — the account carries the role.
 	if isAdmin(r) {
-		if folder, err := s.St.FolderByID(r.Context(), book.FolderID); err == nil {
+		if folder, err := s.St.FolderByID(r.Context(), u.ID, book.FolderID); err == nil {
 			if !v.Present {
 				v.Retirable = folder.Kind != store.FolderCalibre
 			}
@@ -226,7 +225,7 @@ func (s *Server) handleBookDownload(w http.ResponseWriter, r *http.Request, a st
 		http.Error(w, "content storage is unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	s.Downloads.ServeBookDownload(w, r, r.PathValue("id"))
+	s.Downloads.ServeBookDownload(w, r, u.ID, r.PathValue("id"))
 }
 
 func encodeBooksCursor(c store.CatalogBookCursor) string {

--- a/internal/webui/books_ext_test.go
+++ b/internal/webui/books_ext_test.go
@@ -86,6 +86,11 @@ func newBooksFixture(t *testing.T) *booksFixture {
 	if err := st.CreateFolder(t.Context(), folder); err != nil {
 		t.Fatal(err)
 	}
+	for _, userID := range []string{"u1", "u2"} {
+		if err := st.AssignUserFolder(t.Context(), userID, folder.ID); err != nil {
+			t.Fatal(err)
+		}
+	}
 
 	cfg := config.Default()
 	cfg.InsecureHTTP = true
@@ -169,7 +174,7 @@ func bookWithMetadata(t *testing.T, f *booksFixture, name string) string {
 // watcher does.
 func (f *booksFixture) reconcile(t *testing.T) {
 	t.Helper()
-	folder, err := f.st.FolderByID(t.Context(), f.folder)
+	folder, err := f.st.FolderByID(t.Context(), "", f.folder)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +188,7 @@ func (f *booksFixture) reconcile(t *testing.T) {
 // a guess.
 func (f *booksFixture) bookAt(t *testing.T, relative string) string {
 	t.Helper()
-	books, err := f.st.ListCatalogBooks(t.Context(), f.folder, nil, 200)
+	books, err := f.st.ListCatalogBooks(t.Context(), "", f.folder, nil, 200)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -232,8 +237,8 @@ func (f *booksFixture) loginTo(
 	return nil
 }
 
-// readerCookie signs in a second account. It needs no grant: every
-// signed-in account reads every folder (ADR-0017).
+// readerCookie signs in the second account, which the fixture explicitly
+// grants access to its folder.
 func (f *booksFixture) readerCookie(t *testing.T) *http.Cookie {
 	t.Helper()
 	return f.login(t, "bob")
@@ -386,10 +391,9 @@ func TestBookPageIsANotFoundForAnUnknownID(t *testing.T) {
 	}
 }
 
-// TestBooksUIIsSharedByEverySignedInAccount pins ADR-0017's decision:
-// the catalog is the server's, not an account's. There is no owner and
-// no grant, so bob sees the same shelf alice does.
-func TestBooksUIIsSharedByEverySignedInAccount(t *testing.T) {
+// TestBooksUIAllowsTheSameFolderForTwoAssignedAccounts checks that grants
+// are many-to-many rather than folder ownership.
+func TestBooksUIAllowsTheSameFolderForTwoAssignedAccounts(t *testing.T) {
 	f := newBooksFixture(t)
 	bookID := f.addBook(t, "shared", []byte(strings.Repeat("shared-bytes", 40)))
 
@@ -408,6 +412,57 @@ func TestBooksUIIsSharedByEverySignedInAccount(t *testing.T) {
 	resp, _ = f.get(t, "/ui/books/"+bookID+"/download", bob)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("bob's download: %d", resp.StatusCode)
+	}
+}
+
+func TestBooksUIHidesDirectURLsWithoutAFolderGrant(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := bookWithMetadata(t, f, "private")
+	if err := f.st.UnassignUserFolder(t.Context(), "u2", f.folder); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.st.SetUserAdmin(t.Context(), "u2", true); err != nil {
+		t.Fatal(err)
+	}
+	bob := f.login(t, "bob")
+
+	resp, page := f.get(t, "/ui/library?folder="+f.folder, bob)
+	if resp.StatusCode != http.StatusNotFound || strings.Contains(page, bookID) {
+		t.Fatalf("hidden library = %d, contains book = %v, want 404", resp.StatusCode, strings.Contains(page, bookID))
+	}
+	resp, page = f.get(t, "/ui/entities/contributors", bob)
+	if resp.StatusCode != http.StatusOK || strings.Contains(page, "Ann Author") {
+		t.Fatalf("hidden contributor leaked: status=%d page=%s", resp.StatusCode, page)
+	}
+
+	for _, path := range []string{
+		"/ui/folders/" + f.folder + "/search?q=private",
+		"/ui/books/" + bookID,
+		"/ui/books/" + bookID + "/download",
+		"/ui/books/" + bookID + "/cover",
+		"/ui/books/" + bookID + "/read",
+	} {
+		resp, _ := f.get(t, path, bob)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("GET %s = %d, want 404", path, resp.StatusCode)
+		}
+	}
+	_, emptyLibrary := f.get(t, "/ui/library", bob)
+	csrf := csrfFrom(t, emptyLibrary)
+	for path, form := range map[string]url.Values{
+		"/ui/books/" + bookID + "/reading-status": {
+			"csrf": {csrf}, "status": {"read"},
+		},
+		"/ui/books/" + bookID + "/series": {
+			"csrf": {csrf}, "name": {"Leaked Series"},
+		},
+		"/ui/books/" + bookID + "/destroy": {
+			"csrf": {csrf},
+		},
+	} {
+		if resp := f.postForm(t, path, bob, form); resp.StatusCode != http.StatusNotFound {
+			t.Errorf("POST %s = %d, want 404", path, resp.StatusCode)
+		}
 	}
 }
 
@@ -448,7 +503,7 @@ func TestBooksUIDropsAMissingBooksDownload(t *testing.T) {
 	}
 	f.reconcile(t)
 
-	book, err := f.st.CatalogBookByID(t.Context(), bookID)
+	book, err := f.st.CatalogBookByID(t.Context(), "", bookID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/webui/cover.go
+++ b/internal/webui/cover.go
@@ -18,11 +18,11 @@ import (
 // be served live on the other side of this interface and are not repeated
 // here.
 //
-// There is no user id: the catalog is shared, so every signed-in account
-// may see every folder's covers (ADR-0017). Who is asking decides
+// The user id applies the same folder grant as every other catalog
+// surface (ADR-0027). Who is asking also decides
 // whether the request happens at all, not what it may see.
 type CoverServer interface {
-	ServeBookCover(w http.ResponseWriter, r *http.Request, bookID string)
+	ServeBookCover(w http.ResponseWriter, r *http.Request, viewerID, bookID string)
 }
 
 // handleBookCover shows a cover, or a placeholder when there is none.
@@ -36,12 +36,19 @@ type CoverServer interface {
 func (s *Server) handleBookCover(
 	w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User,
 ) {
+	// A missing cover gets a placeholder, but a missing or inaccessible
+	// book must stay a 404. Check the scoped catalog row before the
+	// fallback writer deliberately turns later cover errors into images.
+	if _, err := s.St.CatalogBookByID(r.Context(), u.ID, r.PathValue("id")); err != nil {
+		http.NotFound(w, r)
+		return
+	}
 	if s.Covers == nil {
 		servePlaceholderCover(w, r)
 		return
 	}
 	intercept := &coverFallbackWriter{ResponseWriter: w, request: r}
-	s.Covers.ServeBookCover(intercept, r, r.PathValue("id"))
+	s.Covers.ServeBookCover(intercept, r, u.ID, r.PathValue("id"))
 	intercept.finish()
 }
 

--- a/internal/webui/delete.go
+++ b/internal/webui/delete.go
@@ -81,13 +81,13 @@ func (s *Server) handleDeleteMissingBook(
 		return
 	}
 	bookID := r.PathValue("id")
-	book, err := s.St.CatalogBookByID(r.Context(), bookID)
+	book, err := s.St.CatalogBookByID(r.Context(), u.ID, bookID)
 	if err != nil {
 		http.NotFound(w, r)
 		return
 	}
 	back := relPrefix(r.URL.Path) + "library?folder=" + url.QueryEscape(book.FolderID)
-	folder, err := s.St.FolderByID(r.Context(), book.FolderID)
+	folder, err := s.St.FolderByID(r.Context(), u.ID, book.FolderID)
 	if err != nil {
 		http.Error(w, "internal", http.StatusInternalServerError)
 		return

--- a/internal/webui/delete_ext_test.go
+++ b/internal/webui/delete_ext_test.go
@@ -177,7 +177,7 @@ func TestDeleteMissingBookIsAdminWork(t *testing.T) {
 		"&notice=removed+from+the+catalog" {
 		t.Fatalf("the catalog delete sent the browser to %q", got)
 	}
-	if _, err := f.st.CatalogBookByID(t.Context(), ids["vanished"]); err == nil {
+	if _, err := f.st.CatalogBookByID(t.Context(), "", ids["vanished"]); err == nil {
 		t.Fatal("the missing book is still in the catalog")
 	}
 	// The reader keeps the reading, now as a work they may delete.
@@ -205,6 +205,9 @@ func TestDeleteMissingBookRefusedInACalibreFolder(t *testing.T) {
 		Kind: store.FolderCalibre, CreatedAt: time.Now().UTC(),
 	}
 	if err := f.st.CreateFolder(t.Context(), calibre); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.st.AssignUserFolder(t.Context(), "u1", calibre.ID); err != nil {
 		t.Fatal(err)
 	}
 	// Catalogued first, then observed as unservable — a format this
@@ -243,7 +246,7 @@ func TestDeleteMissingBookRefusedInACalibreFolder(t *testing.T) {
 	if got := resp.Header.Get("Location"); !strings.Contains(got, "problem=") {
 		t.Fatalf("the route allowed a Calibre delete: %d %q", resp.StatusCode, got)
 	}
-	if _, err := f.st.CatalogBookByID(t.Context(), bookID); err != nil {
+	if _, err := f.st.CatalogBookByID(t.Context(), "", bookID); err != nil {
 		t.Fatalf("the Calibre book was deleted anyway: %v", err)
 	}
 }

--- a/internal/webui/entities.go
+++ b/internal/webui/entities.go
@@ -34,12 +34,11 @@ func entityKindFrom(r *http.Request) (store.EntityKind, bool) {
 	return kind, ok
 }
 
-// handleEntities lists the library's entities of one kind (ADR-0019).
-// There is nothing to gate: the catalog is shared, and browsing by
-// author or tag is reading it (ADR-0017).
+// handleEntities lists the library's entities of one kind (ADR-0019),
+// with counts and rows limited to books visible through folder grants.
 // readerID is who a catalog read is answered for. Series memberships
-// resolve through that reader's override layers (ADR-0018); every other
-// part of the catalog is shared and does not depend on who is asking.
+// resolve through that reader's override layers (ADR-0018), while folder
+// grants decide which backing books are visible (ADR-0027).
 func readerID(u *store.User) string {
 	if u == nil {
 		return ""
@@ -128,7 +127,7 @@ func (s *Server) handleEntityBooks(
 	for _, b := range books {
 		bookIDs = append(bookIDs, b.ID)
 	}
-	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), bookIDs)
+	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), u.ID, bookIDs)
 	loc := userLoc(u)
 	v := EntityBooksView{
 		Kind:     r.PathValue("kind"),

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -86,14 +86,14 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request, a store
 		links := s.workBookIDs(r.Context(), u.ID, works)
 		dashboard(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a),
 			sum, heat, recent,
-			s.markReadable(r, continueReading(works, links.active, loc))).
+			s.markReadable(r, u.ID, continueReading(works, links.active, loc))).
 			Render(r.Context(), w)
 		return
 	}
 	links := s.workBookIDs(r.Context(), u.ID, works)
 	dashboard(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a),
 		sum, nil, nil,
-		s.markReadable(r, continueReading(works, links.active, loc))).
+		s.markReadable(r, u.ID, continueReading(works, links.active, loc))).
 		Render(r.Context(), w)
 }
 
@@ -169,14 +169,14 @@ func streakFrom(dayMin map[string]float64, u *store.User, now time.Time) int {
 // open. The shelf it answers for is bounded (continueReadingLimit), so
 // it is a handful of book lookups rather than the wall of them a whole
 // catalog page would be.
-func (s *Server) markReadable(r *http.Request, rows []WorkRow) []WorkRow {
+func (s *Server) markReadable(r *http.Request, userID string, rows []WorkRow) []WorkRow {
 	ids := make([]string, 0, len(rows))
 	for _, row := range rows {
 		if row.BookID != "" {
 			ids = append(ids, row.BookID)
 		}
 	}
-	books := s.booksByID(r.Context(), ids)
+	books := s.booksByID(r.Context(), userID, ids)
 	for i := range rows {
 		book, ok := books[rows[i].BookID]
 		rows[i].CanRead = ok && bookReadable(book)
@@ -233,7 +233,7 @@ func (s *Server) handleWork(w http.ResponseWriter, r *http.Request, a store.Auth
 		d.BookID = ids[0]
 	}
 	if d.BookID != "" {
-		if book, err := s.St.CatalogBookByID(r.Context(), d.BookID); err == nil {
+		if book, err := s.St.CatalogBookByID(r.Context(), u.ID, d.BookID); err == nil {
 			d.CanRead = bookReadable(book)
 		}
 	}

--- a/internal/webui/library.go
+++ b/internal/webui/library.go
@@ -186,7 +186,7 @@ type LibraryView struct {
 }
 
 func (s *Server) handleLibrary(w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User) {
-	folders, err := s.St.ListFolders(r.Context(), "", folderPickerLimit)
+	folders, err := s.St.ListFolders(r.Context(), u.ID, "", folderPickerLimit)
 	if err != nil {
 		http.Error(w, "internal", http.StatusInternalServerError)
 		return
@@ -202,6 +202,26 @@ func (s *Server) handleLibrary(w http.ResponseWriter, r *http.Request, a store.A
 		Dir:         normalizeDir(r.URL.Query().Get("dir")),
 	}
 	selected := r.URL.Query().Get("folder")
+	if selected != "" {
+		folder, err := s.St.FolderByID(r.Context(), u.ID, selected)
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		found := false
+		for _, listed := range folders {
+			if listed.ID == folder.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			// A directly selected granted folder may sit beyond the
+			// bounded picker page. Keep direct access correct and include
+			// that selection in the control.
+			folders = append(folders, folder)
+		}
+	}
 	if selected == "" && len(folders) > 0 {
 		selected = folders[0].ID
 	}
@@ -220,17 +240,6 @@ func (s *Server) handleLibrary(w http.ResponseWriter, r *http.Request, a store.A
 	// natural order is not the other field's reversal.
 	v.SortURL = libraryURL(v.Selected, v.Filter, otherSort(v.Sort), "", "")
 	v.DirURL = libraryURL(v.Selected, v.Filter, v.Sort, otherDir(v.Dir), "")
-
-	// A folder id from the query string that no longer exists is
-	// treated as no selection at all, rather than as an error: it is
-	// most often a stale bookmark. The reading half of the page does
-	// not depend on a folder, but the catalog half is all there is to
-	// show once there is no folder to show it from.
-	if v.Selected == "" && len(folders) > 0 {
-		libraryPage(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a), v).
-			Render(r.Context(), w)
-		return
-	}
 
 	loc := userLoc(u)
 	works, err := s.St.ListWorks(r.Context(), u.ID)
@@ -256,7 +265,7 @@ func (s *Server) handleLibrary(w http.ResponseWriter, r *http.Request, a store.A
 	if next != "" {
 		v.NextURL = libraryURL(v.Selected, v.Filter, v.Sort, v.Dir, next)
 	}
-	v.Hero = s.libraryHero(r, works, links, loc)
+	v.Hero = s.libraryHero(r, u.ID, works, links, loc)
 
 	// An htmx continuation asks for more of one list, not for the page
 	// around it: answering with the whole document would append a second
@@ -306,7 +315,7 @@ func (s *Server) workBookIDs(
 		candidates[ws.Work.ID] = ids
 		all = append(all, ids...)
 	}
-	books := s.booksByID(ctx, all)
+	books := s.booksByID(ctx, userID, all)
 	links := bookLinks{
 		active: make(map[string]string, len(candidates)),
 		mapped: make(map[string]bool, len(candidates)),
@@ -350,7 +359,7 @@ func (s *Server) libraryRows(
 	byBook map[string]store.WorkSummary, loc *time.Location,
 ) ([]LibraryRow, []LibraryEntry, string, error) {
 	if v.Filter == filterReading || v.Filter == filterFinished || v.Sort == sortLastRead {
-		rows := s.readingRows(r, v, works, links, loc)
+		rows := s.readingRows(r, userID, v, works, links, loc)
 		if !v.groupedGrid() {
 			return rows, nil, "", nil
 		}
@@ -359,7 +368,7 @@ func (s *Server) libraryRows(
 		return rows, entries, "", err
 	}
 
-	books, next, err := s.listBooksPage(r, v.Selected, v.Dir)
+	books, next, err := s.listBooksPage(r, userID, v.Selected, v.Dir)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -367,7 +376,7 @@ func (s *Server) libraryRows(
 	for _, b := range books {
 		bookIDs = append(bookIDs, b.ID)
 	}
-	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), bookIDs)
+	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), userID, bookIDs)
 
 	raw := make([]LibraryRow, 0, len(books))
 	for _, b := range books {
@@ -435,7 +444,7 @@ func (v LibraryView) groupedGrid() bool {
 // the union: every work, whether or not this server holds its file,
 // newest read first.
 func (s *Server) readingRows(
-	r *http.Request, v LibraryView,
+	r *http.Request, userID string, v LibraryView,
 	works []store.WorkSummary, links bookLinks, loc *time.Location,
 ) []LibraryRow {
 	rows := make([]LibraryRow, 0, len(works))
@@ -447,7 +456,7 @@ func (s *Server) readingRows(
 		}
 		rows = append(rows, row)
 	}
-	rows = s.markLibraryReadable(r, rows)
+	rows = s.markLibraryReadable(r, userID, rows)
 	// A filter about the catalog, answered from reading data, still has
 	// to mean what it says on the chip.
 	if v.Filter == filterHere {
@@ -527,7 +536,7 @@ func keepRow(row LibraryRow, filter string) bool {
 // because it is a shortcut back to what you were doing rather than a
 // view of the list below it.
 func (s *Server) libraryHero(
-	r *http.Request,
+	r *http.Request, userID string,
 	works []store.WorkSummary, links bookLinks, loc *time.Location,
 ) *LibraryRow {
 	best := LibraryRow{}
@@ -550,7 +559,7 @@ func (s *Server) libraryHero(
 	}
 	// A hero with no Read button is a picture of a book and a dead end,
 	// so it only exists when the file is here and openable.
-	rows := s.markLibraryReadable(r, []LibraryRow{best})
+	rows := s.markLibraryReadable(r, userID, []LibraryRow{best})
 	if !rows[0].CanRead {
 		return nil
 	}
@@ -561,14 +570,14 @@ func (s *Server) libraryHero(
 // from a catalog listing already know — the book is in hand there — so
 // this is for the rows that came from the reading half of the union,
 // where all that is known is which book a work was resolved from.
-func (s *Server) markLibraryReadable(r *http.Request, rows []LibraryRow) []LibraryRow {
+func (s *Server) markLibraryReadable(r *http.Request, userID string, rows []LibraryRow) []LibraryRow {
 	ids := make([]string, 0, len(rows))
 	for _, row := range rows {
 		if row.BookID != "" {
 			ids = append(ids, row.BookID)
 		}
 	}
-	books := s.booksByID(r.Context(), ids)
+	books := s.booksByID(r.Context(), userID, ids)
 	for i := range rows {
 		book, ok := books[rows[i].BookID]
 		if !ok {

--- a/internal/webui/librarydelete.go
+++ b/internal/webui/librarydelete.go
@@ -45,9 +45,12 @@ func (s *Server) handleDeleteBookFile(
 	}
 	bookID := r.PathValue("id")
 	back := relPrefix(r.URL.Path) + "library"
-	if book, err := s.St.CatalogBookByID(r.Context(), bookID); err == nil {
-		back += "?folder=" + url.QueryEscape(book.FolderID)
+	book, err := s.St.CatalogBookByID(r.Context(), u.ID, bookID)
+	if err != nil {
+		http.NotFound(w, r)
+		return
 	}
+	back += "?folder=" + url.QueryEscape(book.FolderID)
 	if s.Deletes == nil {
 		s.deleteDone(w, back, "", "this server cannot delete books")
 		return

--- a/internal/webui/librarydelete_ext_test.go
+++ b/internal/webui/librarydelete_ext_test.go
@@ -82,7 +82,7 @@ func TestDeleteBookFileTakesTheFileAndTheRow(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(f.root, "doomed.epub")); !os.IsNotExist(err) {
 		t.Errorf("the file survived: %v", err)
 	}
-	if _, err := f.st.CatalogBookByID(t.Context(), bookID); err == nil {
+	if _, err := f.st.CatalogBookByID(t.Context(), "", bookID); err == nil {
 		t.Error("the catalog row survived")
 	}
 }

--- a/internal/webui/libraryseries.go
+++ b/internal/webui/libraryseries.go
@@ -164,7 +164,7 @@ func (s *Server) librarySeriesForRows(
 	for _, volume := range volumes {
 		volumeIDs = append(volumeIDs, volume.BookID)
 	}
-	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), volumeIDs)
+	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), userID, volumeIDs)
 
 	groups := make(map[string]*LibrarySeries)
 	for _, volume := range volumes {

--- a/internal/webui/libraryupload.go
+++ b/internal/webui/libraryupload.go
@@ -56,9 +56,9 @@ func (s *Server) handleLibraryUpload(
 		s.uploadDone(w, back, "", "this server cannot receive uploads")
 		return
 	}
-	folder, err := s.St.FolderByID(r.Context(), folderID)
+	folder, err := s.St.FolderByID(r.Context(), u.ID, folderID)
 	if err != nil {
-		s.uploadDone(w, back, "", "no such folder")
+		http.NotFound(w, r)
 		return
 	}
 	if !folder.AcceptsUploads {

--- a/internal/webui/libraryupload_ext_test.go
+++ b/internal/webui/libraryupload_ext_test.go
@@ -105,6 +105,25 @@ func TestSendingABookFromTheBrowserAddsIt(t *testing.T) {
 	}
 }
 
+func TestSendingABookAnswers404WithoutAFolderGrant(t *testing.T) {
+	f := newBooksFixture(t)
+	allowUploads(t, f)
+	csrf := csrfOnLibrary(t, f)
+	if err := f.st.UnassignUserFolder(t.Context(), "u1", f.folder); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := send(t, f, csrf, "private.epub",
+		browserEPUB(t, "Private", "Nobody"))
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", resp.StatusCode)
+	}
+	entries, err := os.ReadDir(f.root)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("inaccessible upload changed the folder: %+v, %v", entries, err)
+	}
+}
+
 // The same book twice is a success that has to read differently, or the
 // second send looks like it added a second copy.
 func TestSendingTheSameBookTwiceSaysSo(t *testing.T) {

--- a/internal/webui/reader.go
+++ b/internal/webui/reader.go
@@ -20,7 +20,7 @@ import (
 // contributes to how the book is rendered is the policy below.
 func (s *Server) handleReaderPage(w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User) {
 	bookID := r.PathValue("id")
-	book, err := s.St.CatalogBookByID(r.Context(), bookID)
+	book, err := s.St.CatalogBookByID(r.Context(), u.ID, bookID)
 	if err != nil {
 		http.NotFound(w, r)
 		return

--- a/internal/webui/readerorigin.go
+++ b/internal/webui/readerorigin.go
@@ -87,7 +87,7 @@ func (s *Server) handleReaderRoute(w http.ResponseWriter, r *http.Request) {
 // identity per user, a short expiry, and two scopes.
 func (s *Server) handleReaderHandoff(w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User) {
 	bookID := r.PathValue("id")
-	book, err := s.St.CatalogBookByID(r.Context(), bookID)
+	book, err := s.St.CatalogBookByID(r.Context(), u.ID, bookID)
 	if err != nil {
 		http.NotFound(w, r)
 		return

--- a/internal/webui/readingstatus.go
+++ b/internal/webui/readingstatus.go
@@ -22,7 +22,7 @@ func (s *Server) handleBookReadingStatus(
 	}
 
 	bookID := r.PathValue("id")
-	book, err := s.St.CatalogBookByID(r.Context(), bookID)
+	book, err := s.St.CatalogBookByID(r.Context(), u.ID, bookID)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			http.NotFound(w, r)
@@ -85,7 +85,7 @@ func (s *Server) markWorkForBook(
 		return "", err
 	}
 
-	bookIDs, author, err := workident.Evidence(r.Context(), s.St, book.ID)
+	bookIDs, author, err := workident.Evidence(r.Context(), s.St, userID, book.ID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/webui/search.go
+++ b/internal/webui/search.go
@@ -22,13 +22,12 @@ var entityKindSegments = map[store.EntityKind]string{
 // answer makes the facets the way to narrow rather than scrolling.
 const searchPageSize = 50
 
-// handleSearch answers a search over one folder. Being signed in is
-// enough: the catalog is shared, and finding a book is reading it.
+// handleSearch answers a search over one folder assigned to the reader.
 func (s *Server) handleSearch(
 	w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User,
 ) {
 	folderID := r.PathValue("folder")
-	folder, err := s.St.FolderByID(r.Context(), folderID)
+	folder, err := s.St.FolderByID(r.Context(), u.ID, folderID)
 	if err != nil {
 		http.NotFound(w, r)
 		return
@@ -75,7 +74,7 @@ func (s *Server) handleSearch(
 	for _, b := range result.Books {
 		bookIDs = append(bookIDs, b.ID)
 	}
-	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), bookIDs)
+	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), u.ID, bookIDs)
 
 	loc := userLoc(u)
 	for _, b := range result.Books {
@@ -157,7 +156,7 @@ func (v SearchView) searchURL(filters []string) string {
 func (s *Server) handleTopSearch(
 	w http.ResponseWriter, r *http.Request, _ store.AuthSession, u *store.User,
 ) {
-	folders, err := s.St.ListFolders(r.Context(), "", 1)
+	folders, err := s.St.ListFolders(r.Context(), u.ID, "", 1)
 	if err != nil {
 		http.Error(w, "internal", http.StatusInternalServerError)
 		return

--- a/internal/webui/search_ext_test.go
+++ b/internal/webui/search_ext_test.go
@@ -98,7 +98,7 @@ func TestSearchIsOfferedOnTheLibraryPageAndScopedToTheLibrary(t *testing.T) {
 		t.Fatalf("the library page still has a second, ambiguous top-bar search:\n%s", books)
 	}
 
-	// Every signed-in account may search every folder (ADR-0017); a
+	// The fixture explicitly assigns this folder to both accounts. A
 	// folder that does not exist is a 404 rather than an empty page.
 	resp, _ := f.get(t, "/ui/folders/"+f.folder+"/search?q=offered", f.readerCookie(t))
 	if resp.StatusCode != http.StatusOK {

--- a/internal/webui/series.go
+++ b/internal/webui/series.go
@@ -171,7 +171,7 @@ func (s *Server) handleSeriesShelf(
 	for _, b := range books {
 		bookIDs = append(bookIDs, b.ID)
 	}
-	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), bookIDs)
+	authors, _ := s.St.CatalogAuthorsForBooks(r.Context(), u.ID, bookIDs)
 	// Positions come from the same resolved relations the book payload
 	// uses, so the shelf and the book page never disagree about where a
 	// volume sits.
@@ -646,7 +646,7 @@ func (s *Server) handleSeriesAssignForm(
 func (s *Server) assignView(
 	r *http.Request, u *store.User, bookID string,
 ) (SeriesAssignView, bool) {
-	book, err := s.St.CatalogBookByID(r.Context(), bookID)
+	book, err := s.St.CatalogBookByID(r.Context(), u.ID, bookID)
 	if err != nil {
 		return SeriesAssignView{}, false
 	}

--- a/internal/webui/seriesmerge_ext_test.go
+++ b/internal/webui/seriesmerge_ext_test.go
@@ -36,10 +36,13 @@ func secondFolderSeries(t *testing.T, f *booksFixture, name, series string) {
 		ID: "folder-two", Name: "Shared Shelf", RootPath: f.root + "-two",
 		Kind: store.FolderPlain, CreatedAt: time.Now().UTC(),
 	}
-	if _, err := f.st.FolderByID(t.Context(), folder.ID); err != nil {
+	if _, err := f.st.FolderByID(t.Context(), "", folder.ID); err != nil {
 		if err := f.st.CreateFolder(t.Context(), folder); err != nil {
 			t.Fatal(err)
 		}
+	}
+	if err := f.st.AssignUserFolder(t.Context(), "u1", folder.ID); err != nil {
+		t.Fatal(err)
 	}
 	pos := 1.0
 	if _, err := f.st.ReconcileFolder(t.Context(), folder.ID,

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -327,6 +327,8 @@ func (s *Server) Mount(mux *http.ServeMux, secure func(http.Handler) http.Handle
 		sec(s.requireAdmin(s.handleAdminSetRole)))
 	mux.Handle("POST /ui/admin/users/{id}/disabled",
 		sec(s.requireAdmin(s.handleAdminSetDisabled)))
+	mux.Handle("POST /ui/admin/users/{id}/folders",
+		sec(s.requireAdmin(s.handleAdminSetFolders)))
 	mux.Handle("POST /ui/admin/users/{id}/credentials/revoke",
 		sec(s.requireAdmin(s.handleAdminRevokeCredentials)))
 	mux.Handle("POST /ui/admin/users/{id}/tokens/{tokenID}/revoke",

--- a/internal/webui/settingsview.go
+++ b/internal/webui/settingsview.go
@@ -1,6 +1,7 @@
 package webui
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/url"
@@ -211,7 +212,7 @@ func (s *Server) settingsAdmin(
 	switch view {
 	case settingsAdminFolders:
 		after := r.URL.Query().Get("after")
-		folders, err := s.St.ListFolders(r.Context(), after, adminFoldersPerPage+1)
+		folders, err := s.St.ListFolders(r.Context(), "", after, adminFoldersPerPage+1)
 		if err != nil {
 			return err
 		}
@@ -258,6 +259,28 @@ func (s *Server) settingsAdmin(
 		view.Koplugin, view.MoreKoplugin = capSlice(
 			listOrNil(s.St.ListKopluginDevices(r.Context(), target.ID)),
 		)
+		all, tooMany, err := allFolders(r.Context(), s.St, "", adminUserFoldersMax)
+		if err != nil {
+			return err
+		}
+		if tooMany {
+			view.FoldersUnmanageable = true
+		} else {
+			granted, _, err := allFolders(r.Context(), s.St, target.ID, adminUserFoldersMax)
+			if err != nil {
+				return err
+			}
+			grantSet := make(map[string]bool, len(granted))
+			for _, folder := range granted {
+				grantSet[folder.ID] = true
+			}
+			view.Folders = make([]adminUserFolderView, 0, len(all))
+			for _, folder := range all {
+				view.Folders = append(view.Folders, adminUserFolderView{
+					Folder: folder, Granted: grantSet[folder.ID],
+				})
+			}
+		}
 		v.User = view
 		v.HasUser = true
 	case settingsAdminMaintenance:
@@ -281,4 +304,28 @@ func (s *Server) settingsAdmin(
 		v.View = settingsAdminOverview
 	}
 	return nil
+}
+
+// allFolders walks the whole folder list a page at a time, up to max
+// folders. It stops and reports the overflow rather than returning a
+// prefix: every caller needs the complete set, and a silent prefix here
+// would become a silent revocation on the grant form.
+func allFolders(
+	ctx context.Context, st store.Store, viewerID string, limit int,
+) (folders []store.Folder, tooMany bool, err error) {
+	var after string
+	for {
+		page, err := st.ListFolders(ctx, viewerID, after, adminFoldersPerPage)
+		if err != nil {
+			return nil, false, err
+		}
+		folders = append(folders, page...)
+		if len(folders) > limit {
+			return nil, true, nil
+		}
+		if len(page) < adminFoldersPerPage {
+			return folders, false, nil
+		}
+		after = store.FolderCursor(page[len(page)-1])
+	}
 }

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -751,11 +751,20 @@ func seedFolderBook(
 	t.Helper()
 	ctx := t.Context()
 	now := time.Now().UTC()
-	if _, err := st.FolderByID(ctx, folderID); err != nil {
+	if _, err := st.FolderByID(ctx, "", folderID); err != nil {
 		if err := st.CreateFolder(ctx, store.Folder{
 			ID: folderID, Name: "Test Folder", RootPath: t.TempDir(),
 			Kind: store.FolderPlain, CreatedAt: now, UpdatedAt: now,
 		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	users, err := st.ListUsers(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, user := range users {
+		if err := st.AssignUserFolder(ctx, user.ID, folderID); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -767,7 +776,7 @@ func seedFolderBook(
 	}}, true, now); err != nil {
 		t.Fatal(err)
 	}
-	books, err := st.ListCatalogBooks(ctx, folderID, nil, 100)
+	books, err := st.ListCatalogBooks(ctx, "", folderID, nil, 100)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/workident/backfill.go
+++ b/internal/workident/backfill.go
@@ -60,7 +60,7 @@ func Backfill(
 	var report Report
 	var folderCursor string
 	for {
-		folders, err := st.ListFolders(ctx, folderCursor, backfillPage)
+		folders, err := st.ListFolders(ctx, userID, folderCursor, backfillPage)
 		if err != nil {
 			return report, fmt.Errorf("list folders: %w", err)
 		}
@@ -70,7 +70,7 @@ func Backfill(
 		for _, folder := range folders {
 			var cursor *store.CatalogBookCursor
 			for {
-				books, err := st.ListCatalogBooks(ctx, folder.ID, cursor, backfillPage)
+				books, err := st.ListCatalogBooks(ctx, userID, folder.ID, cursor, backfillPage)
 				if err != nil {
 					return report, fmt.Errorf("list books in %s: %w", folder.ID, err)
 				}
@@ -119,7 +119,7 @@ func backfillBook(
 	report *Report,
 ) error {
 	report.Books++
-	ids, author, err := Evidence(ctx, st, book.ID)
+	ids, author, err := Evidence(ctx, st, userID, book.ID)
 	if err != nil {
 		// Replaced or its folder removed since the page was read.
 		// Nothing to map.
@@ -182,13 +182,13 @@ func backfillBook(
 // first read could land on two different works, and the reader's
 // position would silently stop following them between devices.
 func Evidence(
-	ctx context.Context, st store.Store, bookID string,
+	ctx context.Context, st store.Store, viewerID, bookID string,
 ) ([]store.BookIdentifier, string, error) {
-	ids, err := st.CatalogBookIdentifiers(ctx, bookID)
+	ids, err := st.CatalogBookIdentifiers(ctx, viewerID, bookID)
 	if err != nil {
 		return nil, "", err
 	}
-	authors, err := st.CatalogAuthorsForBooks(ctx, []string{bookID})
+	authors, err := st.CatalogAuthorsForBooks(ctx, viewerID, []string{bookID})
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/workident/backfill_test.go
+++ b/internal/workident/backfill_test.go
@@ -55,6 +55,9 @@ func newBackfillFixture(t *testing.T) *backfillFixture {
 	if err := st.CreateFolder(ctx, folder); err != nil {
 		t.Fatal(err)
 	}
+	if err := st.AssignUserFolder(ctx, user.ID, folder.ID); err != nil {
+		t.Fatal(err)
+	}
 	return &backfillFixture{
 		st: st, user: user, folder: folder, now: now,
 		ids: map[string]string{},
@@ -287,10 +290,9 @@ func TestBackfillPagesPastOneQuery(t *testing.T) {
 	}
 }
 
-// TestBackfillMapsPerUser: the catalog is shared — every logged-in user
-// sees every folder — but a work mapping is not. Two users backfilling
-// the same folder each get their own works, which is what keeps a shared
-// shelf from also sharing what its readers read.
+// TestBackfillMapsPerUser: catalog rows are shared but a work mapping is
+// not. Two users granted the same folder each get their own works, which
+// keeps a shared shelf from also sharing what its readers read.
 func TestBackfillMapsPerUser(t *testing.T) {
 	f := newBackfillFixture(t)
 	f.book(t, "b1", "Dune", "Frank Herbert")
@@ -301,6 +303,9 @@ func TestBackfillMapsPerUser(t *testing.T) {
 		Timezone: "UTC", CreatedAt: f.now,
 	}
 	if err := f.st.CreateUser(ctx, reader); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.st.AssignUserFolder(ctx, reader.ID, f.folder.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -382,12 +387,12 @@ type vanishingStore struct {
 }
 
 func (v vanishingStore) CatalogBookIdentifiers(
-	ctx context.Context, bookID string,
+	ctx context.Context, viewerID, bookID string,
 ) ([]store.BookIdentifier, error) {
 	if bookID == v.gone {
 		return nil, store.ErrNotFound
 	}
-	return v.Store.CatalogBookIdentifiers(ctx, bookID)
+	return v.Store.CatalogBookIdentifiers(ctx, viewerID, bookID)
 }
 
 func TestBackfillContinuesPastABookThatVanished(t *testing.T) {
@@ -417,7 +422,7 @@ type failingStore struct {
 }
 
 func (fs failingStore) CatalogBookIdentifiers(
-	ctx context.Context, bookID string,
+	ctx context.Context, _, bookID string,
 ) ([]store.BookIdentifier, error) {
 	return nil, fs.err
 }
@@ -448,15 +453,15 @@ type stuckStore struct {
 }
 
 func (ss stuckStore) ListCatalogBooks(
-	ctx context.Context, folderID string, _ *store.CatalogBookCursor, limit int,
+	ctx context.Context, viewerID, folderID string, _ *store.CatalogBookCursor, limit int,
 ) ([]store.CatalogBook, error) {
-	return ss.Store.ListCatalogBooks(ctx, folderID, nil, limit)
+	return ss.Store.ListCatalogBooks(ctx, viewerID, folderID, nil, limit)
 }
 
 func (ss stuckStore) ListFolders(
-	ctx context.Context, _ string, limit int,
+	ctx context.Context, viewerID, _ string, limit int,
 ) ([]store.Folder, error) {
-	return ss.Store.ListFolders(ctx, "", limit)
+	return ss.Store.ListFolders(ctx, viewerID, "", limit)
 }
 
 // stuckFolderStore is the same bug one level up: a full page of folders
@@ -467,7 +472,7 @@ type stuckFolderStore struct {
 }
 
 func (ss stuckFolderStore) ListFolders(
-	ctx context.Context, _ string, _ int,
+	ctx context.Context, _, _ string, _ int,
 ) ([]store.Folder, error) {
 	folders := make([]store.Folder, backfillPage)
 	for i := range folders {
@@ -480,7 +485,7 @@ func (ss stuckFolderStore) ListFolders(
 }
 
 func (stuckFolderStore) ListCatalogBooks(
-	context.Context, string, *store.CatalogBookCursor, int,
+	context.Context, string, string, *store.CatalogBookCursor, int,
 ) ([]store.CatalogBook, error) {
 	return nil, nil
 }


### PR DESCRIPTION
## What

Catalog rows stay shared, but a real viewer now sees only the books supported by an explicit grant in a new `user_folders` table. Administrator status confers management authority and nothing else: an unassigned administrator has an empty library.

Recorded as [ADR-0027](docs/adr/0027-explicit-per-user-folder-access.md).

## How

**Schema.** Migration 4 in both backends adds `user_folders(user_id, folder_id)` with a composite primary key and a folder index, appended to the `migrations` slice rather than folded into the baseline. It leaves every existing account unassigned.

**Store.** Assign, unassign, list and atomic replacement of grants. Replacement deduplicates ids, accepts an empty list, and validates every target before it deletes anything, in one transaction.

**Scoping.** Catalog and folder reads take a viewer id. The empty id is a sentinel for trusted callers only — reconciliation, the folder watcher and folder administration. Everything user-facing threads the authenticated id through the native API, OPDS, the web library, reader, cover, search, entity and series surfaces, upload and deletion.

**Responses.** An inaccessible resource answers 404, indistinguishable from one that does not exist; 403 stays reserved for a missing token capability. Upload digest deduplication considers only books the uploader can already see, so it cannot be used to probe for a book in somebody else's folder.

**Reading state.** Revoking a grant hides catalog mappings and nothing more. Positions, sessions, insights and the `user_book_works` row survive, and re-granting restores the library as it was.

**Administration.** Per-account folder checkboxes plus four CLI commands: `assign-folder`, `unassign-folder`, `list-user-folders`, `assign-all-folders`. The form submits the complete grant set, so the page lists every watched folder rather than a page of them, and past 500 folders it declines to render the form at all — a list it had to truncate would revoke whatever fell off the end. The handler reads `PostForm`, not `Form`, so a crafted query string cannot decide what a submitted form grants.

## Tests

- Shared store suite: grants, replacement validation and rollback, migration, entity pagination, revocation and restoration, reading-history retention, folder cascade. Runs against SQLite and PostgreSQL.
- API: catalog, OPDS, search and entities, upload deduplication, upload and deletion grant failures, admin-without-grant.
- Web: admin assignment, self-assignment, CSRF, pagination, query-string parameter pollution, the folder-list bound, and grant isolation on direct URLs for reader, cover, reading status, series, upload and deletion.
- CLI: ordinary and administrator assignment.

## Docs

ADR-0027, plus the design doc, `docs/openapi.yaml`, `docs/integrating.md`, `docs/deployment.md`, the ADR index and `AGENTS.md`.

## Verification

`go tool templ generate`, `go build ./...`, `go vet ./...`, `go test -race ./...` (including live PostgreSQL via `LISEUR_PG_TEST_DSN`) and `make lint` (0 golangci issues; the OpenAPI step reports the repository's pre-existing Redocly warnings and exits 0).
