### PR TITLE
feat: answer insights over an explicit span of days

### DIFF
--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -316,8 +316,11 @@ Prefer `from`/`to`. A count of days is resolved against the server's
 clock; a pair of dates says exactly what was meant and comes back in the
 answer.
 
-Every answer names the span it covers: `range_days` always, plus `from`
-and `to` when the span is bounded. **Check it.** A server too old to
+The summary and the works endpoints name the span they covered:
+`range_days` always, plus `from` and `to` when the span is bounded. The
+calendar echoes `from`, `to` and `range_days` only when it honoured an
+explicit `from`/`to` pair; a `year=` request comes back with `year` and
+`days` alone. **Check it.** A server too old to
 understand the parameters ignores them and answers about some other
 span, and the aggregates give no sign of it: thirty days of reading and
 ten years of it are both just a number of minutes. An answer that does
@@ -332,7 +335,9 @@ given nothing it understands, falls back on thirty days.
 A span is optional on the works endpoints, where absent means everything
 on record — which is what they answered before spans existed. The
 summary defaults to `30d` instead, for the same reason. Say `range=all`
-rather than leaving it out if you mean a lifetime.
+rather than leaving it out if you mean a lifetime. A `range` that cannot
+be parsed is treated as absent, so a malformed span gets the endpoint's
+default rather than its whole history.
 
 Give the works endpoints the same span as the summary if the two are
 shown on one screen: a headline covering thirty days above rows covering

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -295,15 +295,76 @@ time (duration minus `idle_ms`). If you only know pages, convert through
 
 With a `read-insights` token:
 
-- `GET /v1/insights/summary?range=30d`: totals, streak, speed trend
-- `GET /v1/insights/works`: aggregates for every work with reading
-  history
-- `GET /v1/insights/works/{id}`: per-work time, pace, ETA
+- `GET /v1/insights/summary?from=2026-07-13&to=2026-08-11`: totals,
+  streak, speed trend
+- `GET /v1/insights/works?from=…&to=…`: aggregates for every work with
+  reading history
+- `GET /v1/insights/works/{id}?from=…&to=…`: per-work time, pace, ETA
 - `GET /v1/insights/calendar?year=2026`: daily minutes for heatmaps
+- `GET /v1/insights/calendar?from=2025-04-01&to=2026-03-31`: the same,
+  over an arbitrary span
+
+Every endpoint takes a span the same way: a `from`/`to` pair of
+`YYYY-MM-DD` days, **both inclusive**, resolved in the user's configured
+timezone. The older `range=Nd` (up to `3660d`) and `range=all` spellings
+still work, and `Nd` now means the last N *calendar* days ending today
+rather than N × 24 hours ending at the moment of the request — the
+difference is a partial extra day at the far end, which no client could
+reconcile against days it had counted for itself.
+
+Prefer `from`/`to`. A count of days is resolved against the server's
+clock; a pair of dates says exactly what was meant and comes back in the
+answer.
+
+Every answer names the span it covers: `range_days` always, plus `from`
+and `to` when the span is bounded. **Check it.** A server too old to
+understand the parameters ignores them and answers about some other
+span, and the aggregates give no sign of it: thirty days of reading and
+ten years of it are both just a number of minutes. An answer that does
+not name back the days you asked about is not an answer to your
+question.
+
+Check an unbounded request too, against `range_days == 0`. An older
+server answers `range=all` with the ten-year horizon it used to apply,
+and an older one still does not know the word at all — and the summary,
+given nothing it understands, falls back on thirty days.
+
+A span is optional on the works endpoints, where absent means everything
+on record — which is what they answered before spans existed. The
+summary defaults to `30d` instead, for the same reason. Say `range=all`
+rather than leaving it out if you mean a lifetime.
+
+Give the works endpoints the same span as the summary if the two are
+shown on one screen: a headline covering thirty days above rows covering
+a lifetime is a dashboard whose numbers cannot be added up.
+
+`streak_days` is deliberately **not** narrowed by the span. It counts
+consecutive days ending today or yesterday, looking back up to ten
+years, so asking about the last week does not report a hundred-day run
+as seven.
+
+`range_days` reports how many days the answer covers, and is `0` for an
+unbounded one.
+
+A sitting that straddles the first morning of the span counts, whole, on
+the day it *ended* — both in the summary and in the per-work rows, so
+the two cannot disagree. The calendar splits such a sitting across the
+midnight it crosses, because a day-by-day answer that did not would
+attribute an hour to a day it was not read on.
+
+The calendar additionally accepts `year`, and falls back to the current
+year when no usable span is given — which is what makes the echo the
+only way to tell an honoured request from an ignored one. A single
+calendar may not span more than 4000 days; a longer one is refused with
+`400` rather than served.
 
 All day boundaries are computed in the user's configured timezone.
 Rereading counts time but never negative pages. ETA is `null` until the
 user has enough speed history on the work.
+
+`current_progression` and `eta_seconds` are never narrowed by the span
+either. Where the reader is in a book is true now, whatever span the
+totals beside it cover.
 
 `total_pages` will be `0` unless the work has a page count on its
 edition, and nothing in the native API sets one. A reflowable EPUB has

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -818,9 +818,10 @@ paths:
         "200":
           description: |
             Days with activity; midnight-crossing sessions are split.
-            `from` and `to` are echoed back only when they were honoured,
-            so a client can tell this server from one that predates them,
-            ignored them, and answered with the current year.
+            `from`, `to` and `range_days` are echoed back only when
+            `from`/`to` were honoured, so a client can tell this server
+            from one that predates them, ignored them, and answered with
+            the current year.
           content:
             application/json:
               schema:
@@ -829,6 +830,9 @@ paths:
                   year: { type: integer }
                   from: { type: string, format: date }
                   to: { type: string, format: date }
+                  range_days:
+                    type: integer
+                    description: Calendar days the answer covers, present only when `from`/`to` were honoured.
                   days:
                     type: array
                     items:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -628,19 +628,48 @@ paths:
       summary: Reading totals, streak, speed over a range
       security: [{ deviceToken: [] }]  # requires read-insights scope
       parameters:
+        - name: from
+          in: query
+          description: |
+            First day of the span, inclusive, in the user's timezone.
+            Must be paired with `to`, and takes precedence over `range`.
+            Prefer this over `range`: a count of days is resolved against
+            the server's clock, a pair of dates says exactly what was
+            meant, and both are echoed back so a client can tell an
+            honoured span from one a server too old to understand it
+            ignored.
+          schema: { type: string, format: date }
+        - name: to
+          in: query
+          description: Last day of the span, inclusive. Must be paired with `from` and not fall before it.
+          schema: { type: string, format: date }
         - name: range
           in: query
-          description: A whole number of days from 1 through 3660, such as `30d`. Omitted or invalid values use `30d`.
+          description: |
+            The older spelling of a span: a whole number of *calendar*
+            days from 1 through 3660 ending today, such as `30d`, or
+            `all` for everything on record, which is genuinely unbounded.
+            Omitted or invalid values use `30d`. Ignored when a valid
+            `from`/`to` pair is given. `streak_days` is not narrowed by
+            any of this: it counts every consecutive day on record, so a
+            short span cannot truncate a long run.
           schema: { type: string, default: 30d }
       responses:
         "200":
-          description: Aggregates (rereads count time but zero pages)
+          description: |
+            Aggregates (rereads count time but zero pages). `from` and
+            `to` are echoed back whenever the span was bounded, and must
+            be checked: a server that did not understand the request
+            answers about a different span, and nothing in the totals
+            themselves would say so.
           content:
             application/json:
               schema:
                 type: object
                 properties:
-                  range_days: { type: integer }
+                  range_days: { type: integer, description: "Days covered; 0 when unbounded" }
+                  from: { type: string, format: date }
+                  to: { type: string, format: date }
                   total_active_minutes: { type: number }
                   total_pages: { type: number }
                   sessions: { type: integer }
@@ -654,14 +683,45 @@ paths:
       security: [{ deviceToken: [] }]  # requires read-insights scope
       parameters:
         - { name: id, in: path, required: true, schema: { type: string } }
+        - name: from
+          in: query
+          description: |
+            First day of the span, inclusive, in the user's timezone.
+            Must be paired with `to`, and takes precedence over `range`.
+            Prefer this over `range`: a count of days is resolved against
+            the server's clock, a pair of dates says exactly what was
+            meant, and both are echoed back so a client can tell an
+            honoured span from one a server too old to understand it
+            ignored.
+          schema: { type: string, format: date }
+        - name: to
+          in: query
+          description: Last day of the span, inclusive. Must be paired with `from` and not fall before it.
+          schema: { type: string, format: date }
+        - name: range
+          in: query
+          description: |
+            The older spelling of a span: a whole number of calendar days
+            from 1 through 3660, or `all`. Omitted, the aggregate covers
+            the work's whole history, which is what this endpoint
+            answered before spans existed. `current_progression` and
+            `eta_seconds` are never narrowed: where the reader is in a
+            book is true now, whatever span the totals beside it cover.
+          schema: { type: string }
       responses:
         "200":
-          description: Per-work aggregates; eta_seconds is null when no speed history exists
+          description: |
+            One work's aggregate; `eta_seconds` is null when no speed
+            history exists. The span is named back as `range_days`
+            (always) and `from`/`to` (when bounded).
           content:
             application/json:
               schema:
                 type: object
                 properties:
+                  range_days: { type: integer, description: "Days covered; 0 when unbounded" }
+                  from: { type: string, format: date }
+                  to: { type: string, format: date }
                   work_id: { type: string }
                   sessions: { type: integer }
                   total_active_minutes: { type: number }
@@ -676,15 +736,48 @@ paths:
       tags: [insights]
       summary: Per-work statistics for every work with reading history
       security: [{ deviceToken: [] }]  # requires read-insights scope
+      parameters:
+        - name: from
+          in: query
+          description: |
+            First day of the span, inclusive, in the user's timezone.
+            Must be paired with `to`, and takes precedence over `range`.
+            Prefer this over `range`: a count of days is resolved against
+            the server's clock, a pair of dates says exactly what was
+            meant, and both are echoed back so a client can tell an
+            honoured span from one a server too old to understand it
+            ignored.
+          schema: { type: string, format: date }
+        - name: to
+          in: query
+          description: Last day of the span, inclusive. Must be paired with `from` and not fall before it.
+          schema: { type: string, format: date }
+        - name: range
+          in: query
+          description: |
+            The older spelling of a span: a whole number of calendar days
+            from 1 through 3660, or `all`. Omitted, every aggregate
+            covers its work's whole history. Give this the same span as
+            `/v1/insights/summary` when the two are shown on one screen,
+            or the headline and the rows below it will describe
+            different spans.
+          schema: { type: string }
       responses:
         "200":
-          description: Per-work aggregates, ordered by active time descending
+          description: |
+            Per-work aggregates, ordered by active time descending.
+            `range_days` is always present, and `from`/`to` whenever the
+            span was bounded; both must be checked before the rows are
+            labelled with a span.
           content:
             application/json:
               schema:
                 type: object
-                required: [works]
+                required: [works, range_days]
                 properties:
+                  range_days: { type: integer, description: "Days covered; 0 when unbounded" }
+                  from: { type: string, format: date }
+                  to: { type: string, format: date }
                   works:
                     type: array
                     items:
@@ -702,22 +795,40 @@ paths:
   /v1/insights/calendar:
     get:
       tags: [insights]
-      summary: Daily reading minutes for a year (user's timezone)
+      summary: Daily reading minutes over a year or an arbitrary span (user's timezone)
       security: [{ deviceToken: [] }]  # requires read-insights scope
       parameters:
         - name: year
           in: query
-          description: A year from 1971 through 2999. Omitted or invalid values use the server's current year.
+          description: A year from 1971 through 2999. Omitted or invalid values use the server's current year. Ignored when a valid `from`/`to` pair is given.
           schema: { type: integer }
+        - name: from
+          in: query
+          description: |
+            First day to include. Must be paired with `to`. A rolling
+            window costs one request in this form rather than one per
+            calendar year it straddles. A span longer than 4000 days is
+            refused rather than served.
+          schema: { type: string, format: date }
+        - name: to
+          in: query
+          description: Last day to include, inclusive. Must be paired with `from` and not fall before it.
+          schema: { type: string, format: date }
       responses:
         "200":
-          description: Days with activity; midnight-crossing sessions are split
+          description: |
+            Days with activity; midnight-crossing sessions are split.
+            `from` and `to` are echoed back only when they were honoured,
+            so a client can tell this server from one that predates them,
+            ignored them, and answered with the current year.
           content:
             application/json:
               schema:
                 type: object
                 properties:
                   year: { type: integer }
+                  from: { type: string, format: date }
+                  to: { type: string, format: date }
                   days:
                     type: array
                     items:
@@ -726,6 +837,7 @@ paths:
                         date: { type: string, format: date }
                         minutes: { type: number }
                         pages: { type: number }
+        "400": { $ref: "#/components/responses/Error" }
 
   /v1/folders:
     get:

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -812,6 +812,41 @@ func TestInsightsRangeIsWholeDays(t *testing.T) {
 	}
 }
 
+// A malformed span is not a licence to answer about everything. The
+// summary's default is thirty days; a `range` that cannot be read must
+// land there rather than on the whole history, which is both the most
+// expensive answer the endpoint has and one nobody asked for.
+func TestInsightsBadRangeFallsBackToDefault(t *testing.T) {
+	ts, st := testServer(t)
+	ctx := t.Context()
+	hash, _ := auth.HashPassword("hunter2hunter")
+	u := store.User{ID: "u1", Name: "alice", Argon2Hash: hash, Timezone: "UTC", CreatedAt: time.Now()}
+	if err := st.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	svc := auth.NewService(st)
+	roSecret, _, _ := svc.MintToken(ctx, u.ID, "ro", store.ScopeSet{store.ScopeReadInsights}, nil)
+
+	for _, raw := range []string{"wat", "0d", "-3d", "99999d"} {
+		code, out := get(t, ts.URL+"/v1/insights/summary?range="+raw, roSecret)
+		if code != 200 {
+			t.Fatalf("range=%s: %d %v", raw, code, out)
+		}
+		if got := out["range_days"].(float64); got != 30 {
+			t.Fatalf("range=%s: want the 30d default, got range_days=%v", raw, got)
+		}
+	}
+	// The works endpoints have no default, so there a bad span is still
+	// the lifetime they answered with before spans existed.
+	code, out := get(t, ts.URL+"/v1/insights/works?range=wat", roSecret)
+	if code != 200 {
+		t.Fatalf("works range=wat: %d %v", code, out)
+	}
+	if got := out["range_days"].(float64); got != 0 {
+		t.Fatalf("works range=wat: want unbounded, got range_days=%v", got)
+	}
+}
+
 // A sitting that begins before the span and runs into it belongs to one
 // day, and both the summary and the per-work rows have to pick the same
 // one — otherwise a dashboard showing them together displays a headline

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -827,7 +827,7 @@ func TestInsightsBadRangeFallsBackToDefault(t *testing.T) {
 	svc := auth.NewService(st)
 	roSecret, _, _ := svc.MintToken(ctx, u.ID, "ro", store.ScopeSet{store.ScopeReadInsights}, nil)
 
-	for _, raw := range []string{"wat", "0d", "-3d", "99999d"} {
+	for _, raw := range []string{"wat", "30", "0d", "-3d", "99999d"} {
 		code, out := get(t, ts.URL+"/v1/insights/summary?range="+raw, roSecret)
 		if code != 200 {
 			t.Fatalf("range=%s: %d %v", raw, code, out)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -577,6 +577,308 @@ func TestSessionsAndInsights(t *testing.T) {
 
 func ptrI64(v int64) *int64 { return &v }
 
+// A range narrows what the totals cover but must never narrow what the
+// server knows. The per-book aggregates gain the same window the
+// summary already had, so a dashboard's headline and its rows describe
+// one span; the streak keeps counting every day on record, because a
+// hundred-day run is still a hundred days when you ask about last week.
+func TestInsightsRanges(t *testing.T) {
+	ts, st := testServer(t)
+	ctx := t.Context()
+	hash, _ := auth.HashPassword("hunter2hunter")
+	u := store.User{ID: "u1", Name: "alice", Argon2Hash: hash, Timezone: "UTC", CreatedAt: time.Now()}
+	if err := st.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	svc := auth.NewService(st)
+	syncSecret, _, _ := svc.MintToken(ctx, u.ID, "phone", store.ScopeSet{store.ScopeSync}, nil)
+	roSecret, _, _ := svc.MintToken(ctx, u.ID, "ro", store.ScopeSet{store.ScopeReadInsights}, nil)
+
+	w := store.Work{ID: "w1", UserID: u.ID, CreatedAt: time.Now()}
+	if err := st.CreateWork(ctx, w, &store.Edition{UserID: u.ID, SHA256: "abc123", WorkID: "w1"},
+		[]store.Identifier{{Kind: "sha256", Value: "abc123"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := time.Now().UTC()
+	noon := time.Date(current.Year(), current.Month(), current.Day(), 12, 0, 0, 0, time.UTC)
+	// Ten consecutive days ending today, plus one session far enough
+	// back that a thirty-day window cannot see it.
+	sessions := []map[string]any{}
+	mk := func(id string, start time.Time, sp, ep float64) map[string]any {
+		return map[string]any{
+			"session_id": id, "work_id": "w1", "edition_sha": "abc123",
+			"started_at":        start.Format(time.RFC3339Nano),
+			"ended_at":          start.Add(30 * time.Minute).Format(time.RFC3339Nano),
+			"start_progression": sp, "end_progression": ep,
+		}
+	}
+	for day := range 10 {
+		sessions = append(sessions, mk(
+			fmt.Sprintf("recent-%d", day),
+			noon.AddDate(0, 0, -day),
+			0.5, 0.5,
+		))
+	}
+	sessions = append(sessions, mk("ancient", noon.AddDate(0, 0, -100), 0.1, 0.2))
+	if code, out := post(t, ts.URL+"/v1/sessions", syncSecret,
+		map[string]any{"sessions": sessions}); code != 200 {
+		t.Fatalf("sessions push: %d %v", code, out)
+	}
+
+	// A seven-day window sees seven of the eleven sessions.
+	code, out := get(t, ts.URL+"/v1/insights/works/w1?range=7d", roSecret)
+	if code != 200 {
+		t.Fatalf("ranged work insights: %d %v", code, out)
+	}
+	if got := out["sessions"].(float64); got != 7 {
+		t.Fatalf("7d work sessions: want 7, got %v", got)
+	}
+	// And a lifetime one, asked for by name, sees all of them.
+	code, out = get(t, ts.URL+"/v1/insights/works/w1?range=all", roSecret)
+	if code != 200 || out["sessions"].(float64) != 11 {
+		t.Fatalf("range=all work sessions: %d %v", code, out["sessions"])
+	}
+	// No range at all still means lifetime, as it always has.
+	code, out = get(t, ts.URL+"/v1/insights/works/w1", roSecret)
+	if code != 200 || out["sessions"].(float64) != 11 {
+		t.Fatalf("unranged work sessions: %d %v", code, out["sessions"])
+	}
+	// The collection endpoint honours the same window.
+	code, out = get(t, ts.URL+"/v1/insights/works?range=7d", roSecret)
+	works, ok := out["works"].([]any)
+	if code != 200 || !ok || len(works) != 1 {
+		t.Fatalf("ranged works: %d %v", code, out)
+	}
+	if got := works[0].(map[string]any)["sessions"].(float64); got != 7 {
+		t.Fatalf("7d works sessions: want 7, got %v", got)
+	}
+
+	// The streak is the reader's, not the window's: ten days either way.
+	for _, rng := range []string{"7d", "30d", "all"} {
+		code, out = get(t, ts.URL+"/v1/insights/summary?range="+rng, roSecret)
+		if code != 200 {
+			t.Fatalf("summary %s: %d", rng, code)
+		}
+		if got := out["streak_days"].(float64); got != 10 {
+			t.Fatalf("streak at range=%s: want 10, got %v", rng, got)
+		}
+	}
+	// The totals, unlike the streak, do follow the window.
+	code, out = get(t, ts.URL+"/v1/insights/summary?range=7d", roSecret)
+	if code != 200 || out["sessions"].(float64) != 7 {
+		t.Fatalf("7d summary sessions: %d %v", code, out["sessions"])
+	}
+	// A bounded answer names the days it counted. Without that a client
+	// cannot tell a narrowed total from an old server's lifetime one.
+	wantFrom := noon.AddDate(0, 0, -6).Format("2006-01-02")
+	wantTo := noon.Format("2006-01-02")
+	if out["from"] != wantFrom || out["to"] != wantTo {
+		t.Fatalf("summary echo: want %s..%s, got %v..%v", wantFrom, wantTo, out["from"], out["to"])
+	}
+	if out["range_days"].(float64) != 7 {
+		t.Fatalf("7d range_days: %v", out["range_days"])
+	}
+	code, out = get(t, ts.URL+"/v1/insights/summary?range=all", roSecret)
+	if code != 200 || out["sessions"].(float64) != 11 {
+		t.Fatalf("all summary sessions: %d %v", code, out["sessions"])
+	}
+	// Everything on record has no bounds to name, and says so by naming
+	// none rather than by quoting a ten-year window it did not mean.
+	if _, echoed := out["from"]; echoed {
+		t.Fatalf("range=all echoed bounds: %v", out)
+	}
+	if out["range_days"].(float64) != 0 {
+		t.Fatalf("range=all range_days: want 0, got %v", out["range_days"])
+	}
+	// The collection endpoint echoes on the same terms.
+	code, out = get(t, ts.URL+"/v1/insights/works?range=7d", roSecret)
+	if code != 200 || out["from"] != wantFrom || out["to"] != wantTo {
+		t.Fatalf("works echo: %d %v..%v", code, out["from"], out["to"])
+	}
+	code, out = get(t, ts.URL+"/v1/insights/works", roSecret)
+	if _, echoed := out["from"]; code != 200 || echoed {
+		t.Fatalf("unranged works echoed bounds: %d %v", code, out)
+	}
+	// A span named as days is the same span named as dates.
+	code, out = get(t, ts.URL+"/v1/insights/summary?from="+wantFrom+"&to="+wantTo, roSecret)
+	if code != 200 || out["sessions"].(float64) != 7 {
+		t.Fatalf("dated summary sessions: %d %v", code, out["sessions"])
+	}
+
+	// A bounded calendar answers one span in one request and echoes the
+	// bounds, so a client can tell it apart from a server that ignored
+	// them and replied with this calendar year.
+	from := noon.AddDate(0, 0, -100).Format("2006-01-02")
+	to := noon.Format("2006-01-02")
+	code, out = get(t, ts.URL+"/v1/insights/calendar?from="+from+"&to="+to, roSecret)
+	if code != 200 {
+		t.Fatalf("bounded calendar: %d %v", code, out)
+	}
+	if out["from"] != from || out["to"] != to {
+		t.Fatalf("calendar echo: want %s..%s, got %v..%v", from, to, out["from"], out["to"])
+	}
+	if got := len(out["days"].([]any)); got != 11 {
+		t.Fatalf("bounded calendar days: want 11, got %d", got)
+	}
+	// A span the reader did not read in is empty, not the whole year.
+	early := noon.AddDate(0, 0, -400).Format("2006-01-02")
+	code, out = get(t, ts.URL+"/v1/insights/calendar?from="+early+"&to="+early, roSecret)
+	if code != 200 || len(out["days"].([]any)) != 0 {
+		t.Fatalf("empty bounded calendar: %d %v", code, out["days"])
+	}
+	// Nonsense bounds fall back to the year form, and say so by not
+	// echoing anything.
+	code, out = get(t, ts.URL+"/v1/insights/calendar?from=whenever&to=later", roSecret)
+	if code != 200 {
+		t.Fatalf("malformed calendar bounds: %d", code)
+	}
+	if _, echoed := out["from"]; echoed {
+		t.Fatalf("malformed bounds echoed as honoured: %v", out)
+	}
+	if out["year"].(float64) != float64(noon.Year()) {
+		t.Fatalf("fallback year: %v", out["year"])
+	}
+	// A calendar longer than any reader can have is refused rather than
+	// walked: one authenticated request must not be able to ask the
+	// store for an unbounded history.
+	huge := noon.AddDate(-40, 0, 0).Format("2006-01-02")
+	if code, _ = get(t, ts.URL+"/v1/insights/calendar?from="+huge+"&to="+to, roSecret); code != 400 {
+		t.Fatalf("over-long calendar span: want 400, got %d", code)
+	}
+}
+
+// A range names calendar days, not a count of hours ending now.
+//
+// The reader's device works in whole local days, and a headline that
+// disagreed with the list beneath it by one partial day would be
+// unexplainable. The old spelling reached back N times twenty-four
+// hours from the moment of the request, so an evening request counted
+// part of an eighth day; these two sessions sit either side of that
+// difference.
+func TestInsightsRangeIsWholeDays(t *testing.T) {
+	ts, st := testServer(t)
+	ctx := t.Context()
+	hash, _ := auth.HashPassword("hunter2hunter")
+	u := store.User{ID: "u1", Name: "alice", Argon2Hash: hash, Timezone: "UTC", CreatedAt: time.Now()}
+	if err := st.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	svc := auth.NewService(st)
+	syncSecret, _, _ := svc.MintToken(ctx, u.ID, "phone", store.ScopeSet{store.ScopeSync}, nil)
+	roSecret, _, _ := svc.MintToken(ctx, u.ID, "ro", store.ScopeSet{store.ScopeReadInsights}, nil)
+	if err := st.CreateWork(ctx,
+		store.Work{ID: "w1", UserID: u.ID, CreatedAt: time.Now()},
+		&store.Edition{UserID: u.ID, SHA256: "abc123", WorkID: "w1"},
+		[]store.Identifier{{Kind: "sha256", Value: "abc123"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := time.Now().UTC()
+	midnight := time.Date(current.Year(), current.Month(), current.Day(), 0, 0, 0, 0, time.UTC)
+	at := func(id string, start time.Time) map[string]any {
+		return map[string]any{
+			"session_id": id, "work_id": "w1", "edition_sha": "abc123",
+			"started_at":        start.Format(time.RFC3339Nano),
+			"ended_at":          start.Add(20 * time.Minute).Format(time.RFC3339Nano),
+			"start_progression": 0.5, "end_progression": 0.5,
+		}
+	}
+	// Just inside the seventh day back, and just outside the eighth.
+	inside := midnight.AddDate(0, 0, -6).Add(30 * time.Minute)
+	outside := midnight.AddDate(0, 0, -7).Add(22 * time.Hour)
+	if code, out := post(t, ts.URL+"/v1/sessions", syncSecret, map[string]any{
+		"sessions": []map[string]any{at("inside", inside), at("outside", outside)},
+	}); code != 200 {
+		t.Fatalf("sessions push: %d %v", code, out)
+	}
+
+	code, out := get(t, ts.URL+"/v1/insights/summary?range=7d", roSecret)
+	if code != 200 {
+		t.Fatalf("7d summary: %d %v", code, out)
+	}
+	if got := out["sessions"].(float64); got != 1 {
+		t.Fatalf("7d covers whole days only: want 1 session, got %v", got)
+	}
+	code, out = get(t, ts.URL+"/v1/insights/works/w1?range=7d", roSecret)
+	if code != 200 || out["sessions"].(float64) != 1 {
+		t.Fatalf("7d work sessions: %d %v", code, out["sessions"])
+	}
+	// Eight days reaches the earlier one, which is the proof that it was
+	// excluded for being on the wrong day rather than lost.
+	code, out = get(t, ts.URL+"/v1/insights/summary?range=8d", roSecret)
+	if code != 200 || out["sessions"].(float64) != 2 {
+		t.Fatalf("8d summary sessions: %d %v", code, out["sessions"])
+	}
+}
+
+// A sitting that begins before the span and runs into it belongs to one
+// day, and both the summary and the per-work rows have to pick the same
+// one — otherwise a dashboard showing them together displays a headline
+// that its own rows do not add up to.
+func TestInsightsStraddlingSessionCountedOnce(t *testing.T) {
+	ts, st := testServer(t)
+	ctx := t.Context()
+	hash, _ := auth.HashPassword("hunter2hunter")
+	u := store.User{ID: "u1", Name: "alice", Argon2Hash: hash, Timezone: "UTC", CreatedAt: time.Now()}
+	if err := st.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	svc := auth.NewService(st)
+	syncSecret, _, _ := svc.MintToken(ctx, u.ID, "phone", store.ScopeSet{store.ScopeSync}, nil)
+	roSecret, _, _ := svc.MintToken(ctx, u.ID, "ro", store.ScopeSet{store.ScopeReadInsights}, nil)
+	if err := st.CreateWork(ctx,
+		store.Work{ID: "w1", UserID: u.ID, CreatedAt: time.Now()},
+		&store.Edition{UserID: u.ID, SHA256: "abc123", WorkID: "w1"},
+		[]store.Identifier{{Kind: "sha256", Value: "abc123"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	current := time.Now().UTC()
+	midnight := time.Date(current.Year(), current.Month(), current.Day(), 0, 0, 0, 0, time.UTC)
+	// Begins on the day before the window opens, ends inside it.
+	start := midnight.AddDate(0, 0, -7).Add(23*time.Hour + 30*time.Minute)
+	if code, out := post(t, ts.URL+"/v1/sessions", syncSecret, map[string]any{
+		"sessions": []map[string]any{{
+			"session_id": "straddle", "work_id": "w1", "edition_sha": "abc123",
+			"started_at":        start.Format(time.RFC3339Nano),
+			"ended_at":          start.Add(time.Hour).Format(time.RFC3339Nano),
+			"start_progression": 0.1, "end_progression": 0.2,
+		}},
+	}); code != 200 {
+		t.Fatalf("sessions push: %d %v", code, out)
+	}
+
+	code, summary := get(t, ts.URL+"/v1/insights/summary?range=7d", roSecret)
+	if code != 200 {
+		t.Fatalf("summary: %d %v", code, summary)
+	}
+	code, work := get(t, ts.URL+"/v1/insights/works/w1?range=7d", roSecret)
+	if code != 200 {
+		t.Fatalf("work: %d %v", code, work)
+	}
+	if summary["sessions"] != work["sessions"] {
+		t.Fatalf("summary and work disagree: %v vs %v", summary["sessions"], work["sessions"])
+	}
+	if summary["total_active_minutes"] != work["total_active_minutes"] {
+		t.Fatalf("minutes disagree: %v vs %v",
+			summary["total_active_minutes"], work["total_active_minutes"])
+	}
+	// It ended inside the window, so it counts — the two agreeing on
+	// nothing would pass the checks above and prove nothing.
+	if summary["sessions"].(float64) != 1 {
+		t.Fatalf("sitting ending inside the span should count: %v", summary["sessions"])
+	}
+	code, collection := get(t, ts.URL+"/v1/insights/works?range=7d", roSecret)
+	works, ok := collection["works"].([]any)
+	if code != 200 || !ok || len(works) != 1 {
+		t.Fatalf("works collection: %d %v", code, collection)
+	}
+	if works[0].(map[string]any)["sessions"] != work["sessions"] {
+		t.Fatalf("collection disagrees with the single work: %v", works[0])
+	}
+}
+
 // A batch item that names a work the server no longer holds — orphan
 // cleanup deleted it — is the one refusal a client can recover from, so
 // it answers with the machine-readable code and the exact ids. The

--- a/internal/api/insights.go
+++ b/internal/api/insights.go
@@ -107,10 +107,15 @@ func (w window) days() int {
 
 // sessionBounds are the instants to query raw sessions between. An
 // unbounded window reaches back to the epoch, which predates every
-// session any store can hold.
-func (w window) sessionBounds(now time.Time) (time.Time, time.Time) {
+// session any store can hold, and forward to the end of today in the
+// user's timezone — the same far end a bounded window ending today has,
+// so that a lifetime total can never come out below a ranged one when a
+// device with a fast clock files a session a moment into the future.
+func (w window) sessionBounds(now time.Time, loc *time.Location) (time.Time, time.Time) {
 	if w.unbounded() {
-		return time.Unix(0, 0), now.AddDate(0, 0, 1)
+		today := now.In(loc)
+		endOfToday := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1)
+		return time.Unix(0, 0), endOfToday
 	}
 	return w.from, w.to
 }
@@ -250,7 +255,7 @@ func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 	now := time.Now()
 	loc := s.userLocation(r, tok.UserID)
 	win := insightsWindow(r, loc, now, defaultSummaryRange)
-	from, to := win.sessionBounds(now)
+	from, to := win.sessionBounds(now, loc)
 	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "summary failed")
@@ -418,8 +423,13 @@ func (s *Server) workInsightFrom(
 // the last N calendar days ending today — calendar days, so that a
 // request made at nine in the evening covers the same dates as one made
 // at dawn, which is what a reader means and what their own device
-// counts locally. `range=all`, an unparseable span, and an absent
-// parameter with no default all mean everything on record.
+// counts locally. `range=all` means everything on record, as does an
+// absent parameter where the endpoint has no default.
+//
+// A range that cannot be read falls back to the endpoint's default
+// rather than to everything: a typo asking for a fortnight should not
+// quietly become the most expensive query the endpoint can run, and the
+// echo would report a span the client never asked for either way.
 func insightsWindow(r *http.Request, loc *time.Location, now time.Time, def string) window {
 	q := r.URL.Query()
 	rawFrom, rawTo := q.Get("from"), q.Get("to")
@@ -437,7 +447,7 @@ func insightsWindow(r *http.Request, loc *time.Location, now time.Time, def stri
 	if raw == "" || raw == unboundedRange {
 		return window{}
 	}
-	days := parseRangeDays(raw, 0)
+	days := parseRangeDays(raw, parseRangeDays(def, 0))
 	if days <= 0 {
 		return window{}
 	}
@@ -465,7 +475,7 @@ func (s *Server) HandleInsightsWorks(w http.ResponseWriter, r *http.Request) {
 	loc := s.userLocation(r, tok.UserID)
 	now := time.Now()
 	win := insightsWindow(r, loc, now, "")
-	from, to := win.sessionBounds(now)
+	from, to := win.sessionBounds(now, loc)
 	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "work insights failed")

--- a/internal/api/insights.go
+++ b/internal/api/insights.go
@@ -43,6 +43,123 @@ type workInsight struct {
 	LastReadAt         *time.Time `json:"last_read_at"`
 }
 
+// window is the span an insight covers, always a whole number of days
+// in the user's timezone.
+//
+// Whole days rather than a rolling count of hours, because that is what
+// the question means: a reader asking for their last seven days at nine
+// in the evening means the same seven dates they would have meant at
+// dawn, not the 168 hours ending now — which would reach back into an
+// eighth day and count part of it.
+//
+// A zero window is unbounded: "everything on record", which is what a
+// caller that names no range has always meant and must keep meaning.
+type window struct {
+	// from is the first instant counted, to the first instant after.
+	from time.Time
+	to   time.Time
+	// fromDay and toDay are the same bounds as tz-local dates, both
+	// inclusive, and are empty exactly when the window is unbounded.
+	fromDay string
+	toDay   string
+}
+
+func (w window) unbounded() bool { return w.fromDay == "" }
+
+// holdsSession reports whether a session ended inside the window. The
+// end is what places a session in a range, so that a stretch of reading
+// counts once, on the day it was finished, rather than being smeared
+// across a boundary it happened to straddle.
+func (w window) holdsSession(ses store.Session) bool {
+	if w.unbounded() {
+		return true
+	}
+	return !ses.EndedAt.Before(w.from) && ses.EndedAt.Before(w.to)
+}
+
+// holdsDay reports whether a rollup's tz-local day falls in the window.
+// Compared as strings because a rollup's day was fixed in the timezone
+// in force when it was rolled up, and re-parsing it in today's timezone
+// would move reading between days retroactively.
+func (w window) holdsDay(day string) bool {
+	if w.unbounded() {
+		return true
+	}
+	return day >= w.fromDay && day <= w.toDay
+}
+
+// days counts the calendar days the window covers, 0 when unbounded.
+//
+// Counted from the day strings in UTC rather than by dividing the
+// instants, because a span containing a daylight-saving change is not a
+// whole number of twenty-four hour periods and would come out short.
+func (w window) days() int {
+	if w.unbounded() {
+		return 0
+	}
+	from, errFrom := time.Parse("2006-01-02", w.fromDay)
+	to, errTo := time.Parse("2006-01-02", w.toDay)
+	if errFrom != nil || errTo != nil {
+		return 0
+	}
+	return int(to.Sub(from).Hours()/24) + 1
+}
+
+// sessionBounds are the instants to query raw sessions between. An
+// unbounded window reaches back to the epoch, which predates every
+// session any store can hold.
+func (w window) sessionBounds(now time.Time) (time.Time, time.Time) {
+	if w.unbounded() {
+		return time.Unix(0, 0), now.AddDate(0, 0, 1)
+	}
+	return w.from, w.to
+}
+
+// dayBounds are the inclusive tz-local dates to query rollups between.
+func (w window) dayBounds(now time.Time, loc *time.Location) (string, string) {
+	if w.unbounded() {
+		return epochDay, now.In(loc).Format("2006-01-02")
+	}
+	return w.fromDay, w.toDay
+}
+
+// describe adds the window to a response so a client can tell what was
+// actually counted from what it asked for. `range_days` is always
+// written — nought for an unbounded window — because "everything on
+// record" needs checking as much as any other span does: a server too
+// old to know the word answers with a horizon of its own and nothing in
+// the totals says which it was.
+//
+// This is what makes a new client safe against an old server. The
+// aggregates themselves look identical either way, so without an echo a
+// client cannot tell a range that was honoured from one that was
+// silently ignored — and would label a lifetime total as a fortnight.
+func (w window) describe(answer map[string]any) {
+	answer["range_days"] = w.days()
+	if w.unbounded() {
+		return
+	}
+	answer["from"] = w.fromDay
+	answer["to"] = w.toDay
+}
+
+// dayWindow builds the window covering firstDay through lastDay
+// inclusive, in loc.
+func dayWindow(firstDay, lastDay time.Time, loc *time.Location) window {
+	from := time.Date(firstDay.Year(), firstDay.Month(), firstDay.Day(), 0, 0, 0, 0, loc)
+	last := time.Date(lastDay.Year(), lastDay.Month(), lastDay.Day(), 0, 0, 0, 0, loc)
+	return window{
+		from:    from,
+		to:      last.AddDate(0, 0, 1),
+		fromDay: from.Format("2006-01-02"),
+		toDay:   last.Format("2006-01-02"),
+	}
+}
+
+// epochDay is older than any session or rollup a store can hold, and is
+// what an unbounded window uses where a query insists on a lower bound.
+const epochDay = "1970-01-01"
+
 // userLocation loads the user's configured timezone.
 func (s *Server) userLocation(r *http.Request, userID string) *time.Location {
 	u, err := s.St.UserByID(r.Context(), userID)
@@ -54,6 +171,52 @@ func (s *Server) userLocation(r *http.Request, userID string) *time.Location {
 		return time.UTC
 	}
 	return loc
+}
+
+// activeDays returns the set of tz-local days with reading on them,
+// across all of history rather than a requested window.
+//
+// The set the caller already built for its own range is reused as a
+// starting point, and an unbounded range has nothing left to add, so
+// the extra queries are skipped. Raw sessions only survive the
+// retention horizon, so the long tail here is rollups, which are one
+// row per work per day and cheap to walk.
+func (s *Server) activeDays(
+	ctx context.Context,
+	userID string,
+	loc *time.Location,
+	now time.Time,
+	known map[string]bool,
+	win window,
+) (map[string]bool, error) {
+	if win.unbounded() {
+		return known, nil
+	}
+	all := make(map[string]bool, len(known))
+	for day := range known {
+		all[day] = true
+	}
+	from := now.AddDate(0, 0, -streakLookbackDays)
+	sessions, err := s.St.SessionsInRange(ctx, userID, from, now)
+	if err != nil {
+		return nil, err
+	}
+	for _, ses := range sessions {
+		for _, day := range splitDays(ses, loc) {
+			all[day.date] = true
+		}
+	}
+	rollups, err := s.St.RollupsInRange(ctx, userID,
+		from.In(loc).Format("2006-01-02"), now.In(loc).Format("2006-01-02"))
+	if err != nil {
+		return nil, err
+	}
+	for _, ru := range rollups {
+		if ru.ActiveSeconds > 0 {
+			all[ru.Day] = true
+		}
+	}
+	return all, nil
 }
 
 // activeSeconds returns duration minus idle, clamped >= 0.
@@ -79,26 +242,37 @@ func (s *Server) pagesRead(ctx context.Context, ses store.Session) float64 {
 	return delta * float64(*ed.PageCount)
 }
 
-// HandleInsightsSummary implements GET /v1/insights/summary?range=30d.
+// HandleInsightsSummary implements GET /v1/insights/summary. The span
+// is either `from=2026-01-01&to=2026-03-31` or the older `range=30d`,
+// and defaults to the last thirty days when neither is given.
 func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 	tok, _ := auth.TokenFrom(r)
-	days := parseRangeDays(r.URL.Query().Get("range"), 30)
 	now := time.Now()
-	from := now.AddDate(0, 0, -days)
-	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, now)
+	loc := s.userLocation(r, tok.UserID)
+	win := insightsWindow(r, loc, now, defaultSummaryRange)
+	from, to := win.sessionBounds(now)
+	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "summary failed")
 		return
 	}
-	loc := s.userLocation(r, tok.UserID)
 
 	var totalActive float64
 	var totalPages float64
-	sessionCount := len(sessions)
+	sessionCount := 0
 	daySet := map[string]bool{}
 	// Rolling speed: progression delta per active second over range.
 	var progDelta float64
 	for _, ses := range sessions {
+		// A query by overlap returns a session that began before the
+		// window and ran into it. Where it counts is settled the same
+		// way here as for one book — by where it ended — so that the
+		// headline and the rows beneath it cannot disagree about a
+		// stretch of reading that straddles the first morning.
+		if !win.holdsSession(ses) {
+			continue
+		}
+		sessionCount++
 		a := activeSeconds(ses)
 		totalActive += a
 		totalPages += s.pagesRead(r.Context(), ses)
@@ -111,8 +285,8 @@ func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 	}
 	// Aged sessions live as daily rollups; merge them in so ranges
 	// wider than the retention window stay correct.
-	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID,
-		from.In(loc).Format("2006-01-02"), now.In(loc).Format("2006-01-02"))
+	fromDay, toDay := win.dayBounds(now, loc)
+	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID, fromDay, toDay)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "summary failed")
 		return
@@ -126,31 +300,62 @@ func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 			daySet[ru.Day] = true
 		}
 	}
-	streak := streakDays(daySet, loc, now)
+	// A streak is a fact about the reader, not about the window they
+	// asked to look through. Counted from every day on record, so that
+	// asking for the last week cannot report a hundred-day run as seven.
+	streakSet, err := s.activeDays(r.Context(), tok.UserID, loc, now, daySet, win)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "summary failed")
+		return
+	}
+	streak := streakDays(streakSet, loc, now)
 
 	speed := 0.0
 	if totalActive > 0 {
 		speed = progDelta / totalActive // progression fraction per second
 	}
-	writeJSON(w, http.StatusOK, map[string]any{
-		"range_days":           days,
+	answer := map[string]any{
 		"total_active_minutes": totalActive / 60,
 		"total_pages":          totalPages,
 		"sessions":             sessionCount,
 		"streak_days":          streak,
 		"speed_prog_per_hour":  speed * 3600,
-	})
+	}
+	win.describe(answer)
+	writeJSON(w, http.StatusOK, answer)
 }
 
-func (s *Server) workInsight(ctx context.Context, userID, workID string, loc *time.Location) (workInsight, error) {
-	sessions, err := s.St.CurrentSessionsForWork(ctx, userID, workID, 10_000)
+func (s *Server) workInsight(ctx context.Context, userID, workID string, loc *time.Location, win window) (workInsight, error) {
+	sessions, err := s.St.CurrentSessionsForWork(ctx, userID, workID, sessionsPerWork)
 	if err != nil {
 		return workInsight{}, err
 	}
+	return s.workInsightFrom(ctx, userID, workID, loc, win, sessions)
+}
+
+// workInsightFrom builds one work's aggregate from sessions already in
+// hand.
+//
+// The collection endpoint fetches the whole window once and groups it,
+// rather than asking per work: that is one query instead of one per
+// book, and it is not subject to the row limit a per-work fetch needs —
+// which, applied newest-first to a narrow window deep in the past,
+// could otherwise drop the very sessions being asked about.
+func (s *Server) workInsightFrom(
+	ctx context.Context,
+	userID, workID string,
+	loc *time.Location,
+	win window,
+	sessions []store.Session,
+) (workInsight, error) {
 	var totalActive, totalPages, progDelta float64
-	sessionCount := len(sessions)
+	sessionCount := 0
 	var lastReadAt *time.Time
 	for _, ses := range sessions {
+		if !win.holdsSession(ses) {
+			continue
+		}
+		sessionCount++
 		totalActive += activeSeconds(ses)
 		totalPages += s.pagesRead(ctx, ses)
 		if d := ses.EndProg - ses.StartProg; d > 0 {
@@ -167,6 +372,9 @@ func (s *Server) workInsight(ctx context.Context, userID, workID string, loc *ti
 		return workInsight{}, err
 	}
 	for _, ru := range rollups {
+		if !win.holdsDay(ru.Day) {
+			continue
+		}
 		totalActive += ru.ActiveSeconds
 		totalPages += ru.Pages
 		progDelta += ru.ProgDelta
@@ -176,7 +384,9 @@ func (s *Server) workInsight(ctx context.Context, userID, workID string, loc *ti
 			lastReadAt = &day
 		}
 	}
-	// Current position: newest op.
+	// Current position: newest op. Never windowed — where the reader is
+	// in a book is true now, whatever span the totals beside it cover,
+	// and an estimate of what is left must be measured from there.
 	var currentProg float64
 	var etaSeconds *float64
 	if ops, err := s.St.Positions(ctx, userID, workID, 1); err == nil && len(ops) > 0 {
@@ -201,9 +411,50 @@ func (s *Server) workInsight(ctx context.Context, userID, workID string, loc *ti
 	}, nil
 }
 
+// insightsWindow resolves the span an insights request asks for.
+//
+// `from=2026-01-01&to=2026-03-31` names whole days in the user's own
+// timezone, both included. `range=Nd` is the older spelling and means
+// the last N calendar days ending today — calendar days, so that a
+// request made at nine in the evening covers the same dates as one made
+// at dawn, which is what a reader means and what their own device
+// counts locally. `range=all`, an unparseable span, and an absent
+// parameter with no default all mean everything on record.
+func insightsWindow(r *http.Request, loc *time.Location, now time.Time, def string) window {
+	q := r.URL.Query()
+	rawFrom, rawTo := q.Get("from"), q.Get("to")
+	if rawFrom != "" && rawTo != "" {
+		from, errFrom := time.ParseInLocation("2006-01-02", rawFrom, loc)
+		to, errTo := time.ParseInLocation("2006-01-02", rawTo, loc)
+		if errFrom == nil && errTo == nil && !to.Before(from) {
+			return dayWindow(from, to, loc)
+		}
+	}
+	raw := q.Get("range")
+	if raw == "" {
+		raw = def
+	}
+	if raw == "" || raw == unboundedRange {
+		return window{}
+	}
+	days := parseRangeDays(raw, 0)
+	if days <= 0 {
+		return window{}
+	}
+	today := now.In(loc)
+	return dayWindow(today.AddDate(0, 0, -(days-1)), today, loc)
+}
+
 // HandleInsightsWorks implements GET /v1/insights/works. It returns one
 // aggregate per work with reading history, so a client can render its
 // per-book dashboard without issuing one request for every catalog item.
+//
+// An optional span narrows every aggregate to the same window the
+// summary uses, so that a dashboard's headline and its per-book rows
+// add up to each other instead of describing two different spans. It is
+// echoed back for the same reason the calendar's is: a client must be
+// able to tell a narrowed answer from a lifetime one, because the two
+// are indistinguishable from the aggregates alone.
 func (s *Server) HandleInsightsWorks(w http.ResponseWriter, r *http.Request) {
 	tok, _ := auth.TokenFrom(r)
 	workIDs, err := s.St.WorkIDsWithInsights(r.Context(), tok.UserID)
@@ -212,9 +463,22 @@ func (s *Server) HandleInsightsWorks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	loc := s.userLocation(r, tok.UserID)
+	now := time.Now()
+	win := insightsWindow(r, loc, now, "")
+	from, to := win.sessionBounds(now)
+	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "work insights failed")
+		return
+	}
+	byWork := map[string][]store.Session{}
+	for _, ses := range sessions {
+		byWork[ses.WorkID] = append(byWork[ses.WorkID], ses)
+	}
 	works := make([]workInsight, 0, len(workIDs))
 	for _, workID := range workIDs {
-		insight, err := s.workInsight(r.Context(), tok.UserID, workID, loc)
+		insight, err := s.workInsightFrom(
+			r.Context(), tok.UserID, workID, loc, win, byWork[workID])
 		if err != nil {
 			writeError(w, http.StatusInternalServerError, "work insights failed")
 			return
@@ -226,7 +490,19 @@ func (s *Server) HandleInsightsWorks(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(works, func(i, j int) bool {
 		return works[i].TotalActiveMinutes > works[j].TotalActiveMinutes
 	})
-	writeJSON(w, http.StatusOK, map[string]any{"works": works})
+	answer := map[string]any{"works": works}
+	win.describe(answer)
+	writeJSON(w, http.StatusOK, answer)
+}
+
+// workInsightAnswer is one work's aggregate with the span it covers.
+// The embedded type's fields are promoted, so this stays the flat object
+// it has always been rather than growing a nested envelope.
+type workInsightAnswer struct {
+	workInsight
+	RangeDays int    `json:"range_days"`
+	From      string `json:"from,omitempty"`
+	To        string `json:"to,omitempty"`
 }
 
 // HandleInsightsWork implements GET /v1/insights/works/{id}.
@@ -237,29 +513,38 @@ func (s *Server) HandleInsightsWork(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "work not found")
 		return
 	}
-	insight, err := s.workInsight(r.Context(), tok.UserID, workID, s.userLocation(r, tok.UserID))
+	loc := s.userLocation(r, tok.UserID)
+	win := insightsWindow(r, loc, time.Now(), "")
+	insight, err := s.workInsight(r.Context(), tok.UserID, workID, loc, win)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "work insights failed")
 		return
 	}
-	writeJSON(w, http.StatusOK, insight)
+	writeJSON(w, http.StatusOK, workInsightAnswer{
+		workInsight: insight,
+		RangeDays:   win.days(),
+		From:        win.fromDay,
+		To:          win.toDay,
+	})
 }
 
-// HandleInsightsCalendar implements GET /v1/insights/calendar?year=2026 —
-// daily minutes for heatmaps, days in the user's timezone.
+// HandleInsightsCalendar implements GET /v1/insights/calendar — daily
+// minutes for heatmaps, days in the user's timezone.
+//
+// Either `year=2026` or `from=2025-04-01&to=2026-03-31`. The bounded
+// form exists so a rolling window costs one request rather than one per
+// calendar year it happens to straddle, and both bounds are echoed back
+// so a client can tell a server that understood them from one that
+// ignored them and answered with this year.
 func (s *Server) HandleInsightsCalendar(w http.ResponseWriter, r *http.Request) {
 	tok, _ := auth.TokenFrom(r)
-	year := time.Now().Year()
-	if y := r.URL.Query().Get("year"); y != "" {
-		var v int
-		if _, err := parseInt(y, &v); err == nil && v > 1970 && v < 3000 {
-			year = v
-		}
-	}
 	loc := s.userLocation(r, tok.UserID)
-	from := time.Date(year, 1, 1, 0, 0, 0, 0, loc)
-	to := from.AddDate(1, 0, 0)
-	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
+	win, bounded, ok := calendarBounds(r, loc)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "calendar span too long")
+		return
+	}
+	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, win.from, win.to)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "calendar failed")
 		return
@@ -276,8 +561,7 @@ func (s *Server) HandleInsightsCalendar(w http.ResponseWriter, r *http.Request) 
 			d.Pages += part.pages
 		}
 	}
-	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID,
-		from.Format("2006-01-02"), to.AddDate(0, 0, -1).Format("2006-01-02"))
+	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID, win.fromDay, win.toDay)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "calendar failed")
 		return
@@ -296,7 +580,42 @@ func (s *Server) HandleInsightsCalendar(w http.ResponseWriter, r *http.Request) 
 		out = append(out, *d)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Date < out[j].Date })
-	writeJSON(w, http.StatusOK, map[string]any{"year": year, "days": out})
+	answer := map[string]any{"year": win.from.In(loc).Year(), "days": out}
+	if bounded {
+		win.describe(answer)
+	}
+	writeJSON(w, http.StatusOK, answer)
+}
+
+// calendarBounds resolves the requested span. It reports whether an
+// explicit from/to pair was honoured, which is what the response echo is
+// derived from: a client must not be able to mistake an ignored
+// parameter for an obeyed one. A span longer than any reader can have
+// is refused rather than served, so that one authenticated request
+// cannot ask the store to walk an unbounded history.
+func calendarBounds(r *http.Request, loc *time.Location) (window, bool, bool) {
+	q := r.URL.Query()
+	rawFrom, rawTo := q.Get("from"), q.Get("to")
+	if rawFrom != "" && rawTo != "" {
+		from, errFrom := time.ParseInLocation("2006-01-02", rawFrom, loc)
+		to, errTo := time.ParseInLocation("2006-01-02", rawTo, loc)
+		if errFrom == nil && errTo == nil && !to.Before(from) {
+			win := dayWindow(from, to, loc)
+			if win.days() > maxCalendarDays {
+				return window{}, true, false
+			}
+			return win, true, true
+		}
+	}
+	year := time.Now().In(loc).Year()
+	if y := q.Get("year"); y != "" {
+		var v int
+		if _, err := parseInt(y, &v); err == nil && v > 1970 && v < 3000 {
+			year = v
+		}
+	}
+	first := time.Date(year, 1, 1, 0, 0, 0, 0, loc)
+	return dayWindow(first, first.AddDate(1, 0, -1), loc), false, true
 }
 
 type dayPart struct {
@@ -379,10 +698,45 @@ func streakDays(daySet map[string]bool, loc *time.Location, now time.Time) int {
 	return streak
 }
 
+// maxRangeDays is as long a span as `range=Nd` may name: ten years,
+// which is longer than this software has existed. It is not a limit on
+// how far back an insight can reach — `range=all` and an absent range
+// are unbounded and always were, and rollups are kept indefinitely.
+const maxRangeDays = 3660
+
+// streakLookbackDays is how far back a streak is searched for. A run of
+// consecutive days is broken by the first day without reading on it, so
+// looking further back than any reader has been syncing cannot lengthen
+// one, and the query is bounded rather than open.
+const streakLookbackDays = maxRangeDays
+
+// sessionsPerWork bounds a single work's raw session fetch. Raw
+// sessions are reduced to daily rollups past the retention horizon, so
+// this is far more sittings than one book can hold; the collection
+// endpoint does not use it at all, fetching the window once and
+// grouping it instead.
+const sessionsPerWork = 10_000
+
+// maxCalendarDays is the longest calendar a single request may ask for.
+// Comfortably more than a client showing a year at a time needs, and
+// short of asking the store to walk an entire history per request.
+const maxCalendarDays = 4000
+
+// defaultSummaryRange is what the summary counts when a caller names
+// no span at all, kept from before ranges were selectable.
+const defaultSummaryRange = "30d"
+
+// unboundedRange is how a caller spells "everything on record" rather
+// than encoding it as a magic number of days nobody could read back.
+const unboundedRange = "all"
+
+// parseRangeDays reads a `range=Nd` parameter, returning def for
+// anything else — including `all`, which names no number of days and is
+// resolved to an unbounded window by insightsWindow instead.
 func parseRangeDays(s string, def int) int {
 	if len(s) >= 2 && s[len(s)-1] == 'd' {
 		var v int
-		if _, err := parseInt(s[:len(s)-1], &v); err == nil && v > 0 && v <= 3660 {
+		if _, err := parseInt(s[:len(s)-1], &v); err == nil && v > 0 && v <= maxRangeDays {
 			return v
 		}
 	}


### PR DESCRIPTION
## Summary

Insights took a `range=Nd` that meant N times 24 hours ending at the moment of the request. A client counting the same days from its own sessions counts calendar days, so the two never agreed at the far end, and nothing in the response said which days had been counted. A client had no way to tell an honoured request from one an older server ignored: thirty days of reading and ten years of it are both just a number of minutes.

Pairs with chmouel/liseur#71, which consumes it.

## Changes

- Take a `from`/`to` pair of inclusive dates, resolved in the user's timezone, on the summary and both works endpoints. `range=Nd` still works and now means N calendar days ending today.
- Every answer names its span: `range_days` always, `from`/`to` when bounded, on the summary, the works collection and a single work. `/v1/insights/works/{id}` documented an echo it never emitted.
- `range=all` is genuinely unbounded rather than the old ten year horizon, since rollups are kept indefinitely.
- The summary filtered sessions by overlap while per-work rows filtered by end, so a sitting straddling the first morning of a span was counted by the headline and not by the rows beneath it. Both now use the end.
- The works collection fetched each work's newest 10,000 sessions before filtering, which could miss rows in a narrow historical window. It fetches the span once and groups by work, removing a query per book at the same time.
- A calendar span longer than 4000 days is refused with 400 rather than served.
- `docs/integrating.md` and `docs/openapi.yaml` updated, including the streak's bounded lookback, which the prose had overstated.

## Testing

- `go build ./...`, `go vet ./internal/...`, `gofmt -l internal/` clean
- `golangci-lint run ./...` reports 0 issues
- `redocly lint` reports the description valid
- `go test ./internal/...` passes

New tests: `TestInsightsRanges` covers the echo on all three endpoints, bounded and unbounded; `TestInsightsRangeIsWholeDays` covers the calendar-day boundary; `TestInsightsStraddlingSessionCountedOnce` asserts the summary, the single work and the collection agree on a sitting that crosses the first morning.

## Compatibility

`range=Nd` and an absent span keep working. The shift from rolling hours to calendar days changes `Nd` by a partial day at the far end, which is the defect being fixed. Nothing else in this repository consumes `range=`.