### PR TITLE
feat: let the web dashboard ask about any span of reading

### DIFF
--- a/internal/api/insights.go
+++ b/internal/api/insights.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/insights"
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
@@ -43,91 +44,6 @@ type workInsight struct {
 	LastReadAt         *time.Time `json:"last_read_at"`
 }
 
-// window is the span an insight covers, always a whole number of days
-// in the user's timezone.
-//
-// Whole days rather than a rolling count of hours, because that is what
-// the question means: a reader asking for their last seven days at nine
-// in the evening means the same seven dates they would have meant at
-// dawn, not the 168 hours ending now — which would reach back into an
-// eighth day and count part of it.
-//
-// A zero window is unbounded: "everything on record", which is what a
-// caller that names no range has always meant and must keep meaning.
-type window struct {
-	// from is the first instant counted, to the first instant after.
-	from time.Time
-	to   time.Time
-	// fromDay and toDay are the same bounds as tz-local dates, both
-	// inclusive, and are empty exactly when the window is unbounded.
-	fromDay string
-	toDay   string
-}
-
-func (w window) unbounded() bool { return w.fromDay == "" }
-
-// holdsSession reports whether a session ended inside the window. The
-// end is what places a session in a range, so that a stretch of reading
-// counts once, on the day it was finished, rather than being smeared
-// across a boundary it happened to straddle.
-func (w window) holdsSession(ses store.Session) bool {
-	if w.unbounded() {
-		return true
-	}
-	return !ses.EndedAt.Before(w.from) && ses.EndedAt.Before(w.to)
-}
-
-// holdsDay reports whether a rollup's tz-local day falls in the window.
-// Compared as strings because a rollup's day was fixed in the timezone
-// in force when it was rolled up, and re-parsing it in today's timezone
-// would move reading between days retroactively.
-func (w window) holdsDay(day string) bool {
-	if w.unbounded() {
-		return true
-	}
-	return day >= w.fromDay && day <= w.toDay
-}
-
-// days counts the calendar days the window covers, 0 when unbounded.
-//
-// Counted from the day strings in UTC rather than by dividing the
-// instants, because a span containing a daylight-saving change is not a
-// whole number of twenty-four hour periods and would come out short.
-func (w window) days() int {
-	if w.unbounded() {
-		return 0
-	}
-	from, errFrom := time.Parse("2006-01-02", w.fromDay)
-	to, errTo := time.Parse("2006-01-02", w.toDay)
-	if errFrom != nil || errTo != nil {
-		return 0
-	}
-	return int(to.Sub(from).Hours()/24) + 1
-}
-
-// sessionBounds are the instants to query raw sessions between. An
-// unbounded window reaches back to the epoch, which predates every
-// session any store can hold, and forward to the end of today in the
-// user's timezone — the same far end a bounded window ending today has,
-// so that a lifetime total can never come out below a ranged one when a
-// device with a fast clock files a session a moment into the future.
-func (w window) sessionBounds(now time.Time, loc *time.Location) (time.Time, time.Time) {
-	if w.unbounded() {
-		today := now.In(loc)
-		endOfToday := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1)
-		return time.Unix(0, 0), endOfToday
-	}
-	return w.from, w.to
-}
-
-// dayBounds are the inclusive tz-local dates to query rollups between.
-func (w window) dayBounds(now time.Time, loc *time.Location) (string, string) {
-	if w.unbounded() {
-		return epochDay, now.In(loc).Format("2006-01-02")
-	}
-	return w.fromDay, w.toDay
-}
-
 // describe adds the window to a response so a client can tell what was
 // actually counted from what it asked for. `range_days` is always
 // written — nought for an unbounded window — because "everything on
@@ -139,31 +55,17 @@ func (w window) dayBounds(now time.Time, loc *time.Location) (string, string) {
 // aggregates themselves look identical either way, so without an echo a
 // client cannot tell a range that was honoured from one that was
 // silently ignored — and would label a lifetime total as a fortnight.
-func (w window) describe(answer map[string]any) {
-	answer["range_days"] = w.days()
-	if w.unbounded() {
+//
+// It lives here rather than in the insights package because it is the
+// shape of a JSON answer, not a fact about a span.
+func describe(w insights.Window, answer map[string]any) {
+	answer["range_days"] = w.Days()
+	if w.Unbounded() {
 		return
 	}
-	answer["from"] = w.fromDay
-	answer["to"] = w.toDay
+	answer["from"] = w.FromDay()
+	answer["to"] = w.ToDay()
 }
-
-// dayWindow builds the window covering firstDay through lastDay
-// inclusive, in loc.
-func dayWindow(firstDay, lastDay time.Time, loc *time.Location) window {
-	from := time.Date(firstDay.Year(), firstDay.Month(), firstDay.Day(), 0, 0, 0, 0, loc)
-	last := time.Date(lastDay.Year(), lastDay.Month(), lastDay.Day(), 0, 0, 0, 0, loc)
-	return window{
-		from:    from,
-		to:      last.AddDate(0, 0, 1),
-		fromDay: from.Format("2006-01-02"),
-		toDay:   last.Format("2006-01-02"),
-	}
-}
-
-// epochDay is older than any session or rollup a store can hold, and is
-// what an unbounded window uses where a query insists on a lower bound.
-const epochDay = "1970-01-01"
 
 // userLocation loads the user's configured timezone.
 func (s *Server) userLocation(r *http.Request, userID string) *time.Location {
@@ -192,16 +94,16 @@ func (s *Server) activeDays(
 	loc *time.Location,
 	now time.Time,
 	known map[string]bool,
-	win window,
+	win insights.Window,
 ) (map[string]bool, error) {
-	if win.unbounded() {
+	if win.Unbounded() {
 		return known, nil
 	}
 	all := make(map[string]bool, len(known))
 	for day := range known {
 		all[day] = true
 	}
-	from := now.AddDate(0, 0, -streakLookbackDays)
+	from := now.AddDate(0, 0, -insights.StreakLookbackDays)
 	sessions, err := s.St.SessionsInRange(ctx, userID, from, now)
 	if err != nil {
 		return nil, err
@@ -222,15 +124,6 @@ func (s *Server) activeDays(
 		}
 	}
 	return all, nil
-}
-
-// activeSeconds returns duration minus idle, clamped >= 0.
-func activeSeconds(ses store.Session) float64 {
-	d := ses.EndedAt.Sub(ses.StartedAt).Seconds() - float64(ses.IdleMs)/1000
-	if d < 0 {
-		return 0
-	}
-	return d
 }
 
 // pagesRead converts a progression delta to pages using the session's
@@ -254,8 +147,8 @@ func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 	tok, _ := auth.TokenFrom(r)
 	now := time.Now()
 	loc := s.userLocation(r, tok.UserID)
-	win := insightsWindow(r, loc, now, defaultSummaryRange)
-	from, to := win.sessionBounds(now, loc)
+	win := requestWindow(r, loc, now, insights.DefaultSummaryRange)
+	from, to := win.SessionBounds(now, loc)
 	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "summary failed")
@@ -274,11 +167,11 @@ func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 		// way here as for one book — by where it ended — so that the
 		// headline and the rows beneath it cannot disagree about a
 		// stretch of reading that straddles the first morning.
-		if !win.holdsSession(ses) {
+		if !win.HoldsSession(ses) {
 			continue
 		}
 		sessionCount++
-		a := activeSeconds(ses)
+		a := insights.ActiveSeconds(ses)
 		totalActive += a
 		totalPages += s.pagesRead(r.Context(), ses)
 		if d := ses.EndProg - ses.StartProg; d > 0 {
@@ -290,7 +183,7 @@ func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 	}
 	// Aged sessions live as daily rollups; merge them in so ranges
 	// wider than the retention window stay correct.
-	fromDay, toDay := win.dayBounds(now, loc)
+	fromDay, toDay := win.DayBounds(now, loc)
 	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID, fromDay, toDay)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "summary failed")
@@ -313,7 +206,7 @@ func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "summary failed")
 		return
 	}
-	streak := streakDays(streakSet, loc, now)
+	streak := insights.StreakDays(streakSet, loc, now)
 
 	speed := 0.0
 	if totalActive > 0 {
@@ -326,11 +219,11 @@ func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
 		"streak_days":          streak,
 		"speed_prog_per_hour":  speed * 3600,
 	}
-	win.describe(answer)
+	describe(win, answer)
 	writeJSON(w, http.StatusOK, answer)
 }
 
-func (s *Server) workInsight(ctx context.Context, userID, workID string, loc *time.Location, win window) (workInsight, error) {
+func (s *Server) workInsight(ctx context.Context, userID, workID string, loc *time.Location, win insights.Window) (workInsight, error) {
 	sessions, err := s.St.CurrentSessionsForWork(ctx, userID, workID, sessionsPerWork)
 	if err != nil {
 		return workInsight{}, err
@@ -350,18 +243,18 @@ func (s *Server) workInsightFrom(
 	ctx context.Context,
 	userID, workID string,
 	loc *time.Location,
-	win window,
+	win insights.Window,
 	sessions []store.Session,
 ) (workInsight, error) {
 	var totalActive, totalPages, progDelta float64
 	sessionCount := 0
 	var lastReadAt *time.Time
 	for _, ses := range sessions {
-		if !win.holdsSession(ses) {
+		if !win.HoldsSession(ses) {
 			continue
 		}
 		sessionCount++
-		totalActive += activeSeconds(ses)
+		totalActive += insights.ActiveSeconds(ses)
 		totalPages += s.pagesRead(ctx, ses)
 		if d := ses.EndProg - ses.StartProg; d > 0 {
 			progDelta += d
@@ -377,7 +270,7 @@ func (s *Server) workInsightFrom(
 		return workInsight{}, err
 	}
 	for _, ru := range rollups {
-		if !win.holdsDay(ru.Day) {
+		if !win.HoldsDay(ru.Day) {
 			continue
 		}
 		totalActive += ru.ActiveSeconds
@@ -416,45 +309,6 @@ func (s *Server) workInsightFrom(
 	}, nil
 }
 
-// insightsWindow resolves the span an insights request asks for.
-//
-// `from=2026-01-01&to=2026-03-31` names whole days in the user's own
-// timezone, both included. `range=Nd` is the older spelling and means
-// the last N calendar days ending today — calendar days, so that a
-// request made at nine in the evening covers the same dates as one made
-// at dawn, which is what a reader means and what their own device
-// counts locally. `range=all` means everything on record, as does an
-// absent parameter where the endpoint has no default.
-//
-// A range that cannot be read falls back to the endpoint's default
-// rather than to everything: a typo asking for a fortnight should not
-// quietly become the most expensive query the endpoint can run, and the
-// echo would report a span the client never asked for either way.
-func insightsWindow(r *http.Request, loc *time.Location, now time.Time, def string) window {
-	q := r.URL.Query()
-	rawFrom, rawTo := q.Get("from"), q.Get("to")
-	if rawFrom != "" && rawTo != "" {
-		from, errFrom := time.ParseInLocation("2006-01-02", rawFrom, loc)
-		to, errTo := time.ParseInLocation("2006-01-02", rawTo, loc)
-		if errFrom == nil && errTo == nil && !to.Before(from) {
-			return dayWindow(from, to, loc)
-		}
-	}
-	raw := q.Get("range")
-	if raw == "" {
-		raw = def
-	}
-	if raw == "" || raw == unboundedRange {
-		return window{}
-	}
-	days := parseRangeDays(raw, parseRangeDays(def, 0))
-	if days <= 0 {
-		return window{}
-	}
-	today := now.In(loc)
-	return dayWindow(today.AddDate(0, 0, -(days-1)), today, loc)
-}
-
 // HandleInsightsWorks implements GET /v1/insights/works. It returns one
 // aggregate per work with reading history, so a client can render its
 // per-book dashboard without issuing one request for every catalog item.
@@ -474,8 +328,8 @@ func (s *Server) HandleInsightsWorks(w http.ResponseWriter, r *http.Request) {
 	}
 	loc := s.userLocation(r, tok.UserID)
 	now := time.Now()
-	win := insightsWindow(r, loc, now, "")
-	from, to := win.sessionBounds(now, loc)
+	win := requestWindow(r, loc, now, "")
+	from, to := win.SessionBounds(now, loc)
 	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "work insights failed")
@@ -501,7 +355,7 @@ func (s *Server) HandleInsightsWorks(w http.ResponseWriter, r *http.Request) {
 		return works[i].TotalActiveMinutes > works[j].TotalActiveMinutes
 	})
 	answer := map[string]any{"works": works}
-	win.describe(answer)
+	describe(win, answer)
 	writeJSON(w, http.StatusOK, answer)
 }
 
@@ -524,7 +378,7 @@ func (s *Server) HandleInsightsWork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	loc := s.userLocation(r, tok.UserID)
-	win := insightsWindow(r, loc, time.Now(), "")
+	win := requestWindow(r, loc, time.Now(), "")
 	insight, err := s.workInsight(r.Context(), tok.UserID, workID, loc, win)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "work insights failed")
@@ -532,9 +386,9 @@ func (s *Server) HandleInsightsWork(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, workInsightAnswer{
 		workInsight: insight,
-		RangeDays:   win.days(),
-		From:        win.fromDay,
-		To:          win.toDay,
+		RangeDays:   win.Days(),
+		From:        win.FromDay(),
+		To:          win.ToDay(),
 	})
 }
 
@@ -554,7 +408,8 @@ func (s *Server) HandleInsightsCalendar(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "calendar span too long")
 		return
 	}
-	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, win.from, win.to)
+	from, to := win.SessionBounds(time.Now(), loc)
+	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "calendar failed")
 		return
@@ -571,7 +426,7 @@ func (s *Server) HandleInsightsCalendar(w http.ResponseWriter, r *http.Request) 
 			d.Pages += part.pages
 		}
 	}
-	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID, win.fromDay, win.toDay)
+	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID, win.FromDay(), win.ToDay())
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "calendar failed")
 		return
@@ -590,9 +445,9 @@ func (s *Server) HandleInsightsCalendar(w http.ResponseWriter, r *http.Request) 
 		out = append(out, *d)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].Date < out[j].Date })
-	answer := map[string]any{"year": win.from.In(loc).Year(), "days": out}
+	answer := map[string]any{"year": calendarYear(win, loc), "days": out}
 	if bounded {
-		win.describe(answer)
+		describe(win, answer)
 	}
 	writeJSON(w, http.StatusOK, answer)
 }
@@ -603,16 +458,16 @@ func (s *Server) HandleInsightsCalendar(w http.ResponseWriter, r *http.Request) 
 // parameter for an obeyed one. A span longer than any reader can have
 // is refused rather than served, so that one authenticated request
 // cannot ask the store to walk an unbounded history.
-func calendarBounds(r *http.Request, loc *time.Location) (window, bool, bool) {
+func calendarBounds(r *http.Request, loc *time.Location) (insights.Window, bool, bool) {
 	q := r.URL.Query()
 	rawFrom, rawTo := q.Get("from"), q.Get("to")
 	if rawFrom != "" && rawTo != "" {
 		from, errFrom := time.ParseInLocation("2006-01-02", rawFrom, loc)
 		to, errTo := time.ParseInLocation("2006-01-02", rawTo, loc)
 		if errFrom == nil && errTo == nil && !to.Before(from) {
-			win := dayWindow(from, to, loc)
-			if win.days() > maxCalendarDays {
-				return window{}, true, false
+			win := insights.DayWindow(from, to, loc)
+			if win.Days() > maxCalendarDays {
+				return insights.Window{}, true, false
 			}
 			return win, true, true
 		}
@@ -625,7 +480,7 @@ func calendarBounds(r *http.Request, loc *time.Location) (window, bool, bool) {
 		}
 	}
 	first := time.Date(year, 1, 1, 0, 0, 0, 0, loc)
-	return dayWindow(first, first.AddDate(1, 0, -1), loc), false, true
+	return insights.DayWindow(first, first.AddDate(1, 0, -1), loc), false, true
 }
 
 type dayPart struct {
@@ -689,37 +544,6 @@ func splitDays(ses store.Session, loc *time.Location) []dayPart {
 	return parts
 }
 
-// streakDays counts consecutive days (ending today or yesterday) with
-// activity.
-func streakDays(daySet map[string]bool, loc *time.Location, now time.Time) int {
-	streak := 0
-	day := now.In(loc)
-	// Allow the streak to start today or yesterday.
-	if !daySet[day.Format("2006-01-02")] {
-		day = day.AddDate(0, 0, -1)
-		if !daySet[day.Format("2006-01-02")] {
-			return 0
-		}
-	}
-	for daySet[day.Format("2006-01-02")] {
-		streak++
-		day = day.AddDate(0, 0, -1)
-	}
-	return streak
-}
-
-// maxRangeDays is as long a span as `range=Nd` may name: ten years,
-// which is longer than this software has existed. It is not a limit on
-// how far back an insight can reach — `range=all` and an absent range
-// are unbounded and always were, and rollups are kept indefinitely.
-const maxRangeDays = 3660
-
-// streakLookbackDays is how far back a streak is searched for. A run of
-// consecutive days is broken by the first day without reading on it, so
-// looking further back than any reader has been syncing cannot lengthen
-// one, and the query is bounded rather than open.
-const streakLookbackDays = maxRangeDays
-
 // sessionsPerWork bounds a single work's raw session fetch. Raw
 // sessions are reduced to daily rollups past the retention horizon, so
 // this is far more sittings than one book can hold; the collection
@@ -732,25 +556,24 @@ const sessionsPerWork = 10_000
 // short of asking the store to walk an entire history per request.
 const maxCalendarDays = 4000
 
-// defaultSummaryRange is what the summary counts when a caller names
-// no span at all, kept from before ranges were selectable.
-const defaultSummaryRange = "30d"
+// requestWindow resolves the span an insights request asks for, from
+// the parameters this API spells them with. The resolving itself lives
+// in the insights package, so that the web UI — which spells them
+// differently and never sees an *http.Request — reaches the same
+// answer.
+func requestWindow(r *http.Request, loc *time.Location, now time.Time, def string) insights.Window {
+	q := r.URL.Query()
+	return insights.ParseWindow(q.Get("from"), q.Get("to"), q.Get("range"), def, loc, now)
+}
 
-// unboundedRange is how a caller spells "everything on record" rather
-// than encoding it as a magic number of days nobody could read back.
-const unboundedRange = "all"
-
-// parseRangeDays reads a `range=Nd` parameter, returning def for
-// anything else — including `all`, which names no number of days and is
-// resolved to an unbounded window by insightsWindow instead.
-func parseRangeDays(s string, def int) int {
-	if len(s) >= 2 && s[len(s)-1] == 'd' {
-		var v int
-		if _, err := parseInt(s[:len(s)-1], &v); err == nil && v > 0 && v <= maxRangeDays {
-			return v
-		}
+// calendarYear is the year the calendar's span opens in, which is the
+// only thing the `year` field in its answer ever meant.
+func calendarYear(win insights.Window, loc *time.Location) int {
+	day, err := time.ParseInLocation(insights.DayFormat, win.FromDay(), loc)
+	if err != nil {
+		return time.Now().In(loc).Year()
 	}
-	return def
+	return day.Year()
 }
 
 func parseInt(s string, out *int) (int, error) {

--- a/internal/api/materializer.go
+++ b/internal/api/materializer.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/infer"
+	"github.com/chmouel/liseur-sync/internal/insights"
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
@@ -122,7 +123,7 @@ func (s *Server) rollupSessionsOnce(ctx context.Context, retention time.Duration
 		byDay := make(map[key]*store.SessionRollup)
 		for _, ses := range sessions {
 			parts := s.splitDaysFull(ctx, ses, loc)
-			activeTotal := activeSeconds(ses)
+			activeTotal := insights.ActiveSeconds(ses)
 			progDelta := ses.EndProg - ses.StartProg
 			if progDelta < 0 {
 				progDelta = 0

--- a/internal/insights/insights_test.go
+++ b/internal/insights/insights_test.go
@@ -1,0 +1,296 @@
+package insights
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+var paris = mustLoad("Europe/Paris")
+
+func mustLoad(name string) *time.Location {
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		panic(err)
+	}
+	return loc
+}
+
+// A span is a number of whole days in the reader's own timezone, not a
+// number of hours ending at the moment of the request. Asked at nine in
+// the evening it must name the same dates it would have named at dawn.
+func TestRangeIsWholeLocalDays(t *testing.T) {
+	evening := time.Date(2026, 8, 9, 21, 30, 0, 0, paris)
+	win := ParseWindow("", "", "7d", "", paris, evening)
+
+	if got, want := win.FromDay(), "2026-08-03"; got != want {
+		t.Errorf("first day: got %q, want %q", got, want)
+	}
+	if got, want := win.ToDay(), "2026-08-09"; got != want {
+		t.Errorf("last day: got %q, want %q", got, want)
+	}
+	if got := win.Days(); got != 7 {
+		t.Errorf("seven days is seven days, got %d", got)
+	}
+
+	dawn := time.Date(2026, 8, 9, 5, 0, 0, 0, paris)
+	if atDawn := ParseWindow("", "", "7d", "", paris, dawn); atDawn.FromDay() != win.FromDay() {
+		t.Errorf("the same day names a different span at dawn: %q vs %q",
+			atDawn.FromDay(), win.FromDay())
+	}
+}
+
+func TestExplicitDaysWinOverARange(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	win := ParseWindow("2026-01-01", "2026-03-31", "7d", DefaultSummaryRange, paris, now)
+	if win.FromDay() != "2026-01-01" || win.ToDay() != "2026-03-31" {
+		t.Fatalf("from/to ignored: %q..%q", win.FromDay(), win.ToDay())
+	}
+	if got := win.Days(); got != 90 {
+		t.Errorf("January to March 2026 is 90 days, got %d", got)
+	}
+}
+
+// A malformed span is not a licence to answer about everything: a typo
+// asking for a fortnight must land on the caller's default, which is
+// the cheapest correct answer, rather than on the whole history.
+func TestUnreadableRangeFallsBackToTheDefault(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	for _, raw := range []string{"wat", "30", "0d", "-3d", "99999d"} {
+		win := ParseWindow("", "", raw, DefaultSummaryRange, paris, now)
+		if got := win.Days(); got != 30 {
+			t.Errorf("range=%q: want the 30d default, got %d days", raw, got)
+		}
+	}
+}
+
+// A caller with no default of its own still means "everything", which
+// is what the works endpoints answered before spans existed.
+func TestUnreadableRangeWithNoDefaultIsUnbounded(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	for _, raw := range []string{"", UnboundedRange, "wat"} {
+		if win := ParseWindow("", "", raw, "", paris, now); !win.Unbounded() {
+			t.Errorf("range=%q with no default: want unbounded, got %d days", raw, win.Days())
+		}
+	}
+}
+
+func TestAllTimeIsUnboundedEvenWithADefault(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	if win := ParseWindow("", "", UnboundedRange, DefaultSummaryRange, paris, now); !win.Unbounded() {
+		t.Fatalf("range=all: want unbounded, got %d days", win.Days())
+	}
+}
+
+// A session is placed by its end, so a sitting that began before the
+// span and finished inside it belongs to the span. This is the rule the
+// web UI used to get wrong in the other direction.
+func TestASessionIsPlacedByItsEnd(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	win := ParseWindow("", "", "7d", "", paris, now)
+
+	across := store.Session{
+		StartedAt: time.Date(2026, 8, 2, 23, 40, 0, 0, paris),
+		EndedAt:   time.Date(2026, 8, 3, 0, 20, 0, 0, paris),
+	}
+	if !win.HoldsSession(across) {
+		t.Error("a sitting finishing on the first day of the span is inside it")
+	}
+
+	before := store.Session{
+		StartedAt: time.Date(2026, 8, 2, 20, 0, 0, 0, paris),
+		EndedAt:   time.Date(2026, 8, 2, 23, 0, 0, 0, paris),
+	}
+	if win.HoldsSession(before) {
+		t.Error("a sitting finishing the day before the span is outside it")
+	}
+}
+
+// The far end of an unbounded window is the end of today, exactly as it
+// is for a bounded window ending today. A device with a fast clock can
+// file a session a moment into the future, and the two disagreeing
+// about it would put a lifetime total below a ranged one.
+func TestUnboundedReachesTheSameFarEndAsToday(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	future := store.Session{
+		StartedAt: now.Add(30 * time.Minute),
+		EndedAt:   now.Add(90 * time.Minute),
+	}
+
+	ranged := ParseWindow("", "", "30d", "", paris, now)
+	if !ranged.HoldsSession(future) {
+		t.Fatal("precondition: a bounded window ending today admits this session")
+	}
+
+	_, lifetimeEnd := Window{}.SessionBounds(now, paris)
+	_, rangedEnd := ranged.SessionBounds(now, paris)
+	if !lifetimeEnd.Equal(rangedEnd) {
+		t.Errorf("far ends differ: lifetime %v, ranged %v", lifetimeEnd, rangedEnd)
+	}
+}
+
+func TestDaysAcrossADaylightSavingChange(t *testing.T) {
+	// The clocks go forward in Paris on 29 March 2026, so this span is
+	// not a whole number of twenty-four hour periods.
+	win := DayWindow(
+		time.Date(2026, 3, 28, 0, 0, 0, 0, paris),
+		time.Date(2026, 3, 30, 0, 0, 0, 0, paris),
+		paris,
+	)
+	if got := win.Days(); got != 3 {
+		t.Errorf("three dates is three days, got %d", got)
+	}
+}
+
+func TestEachDayIncludesTheEmptyOnes(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	win := ParseWindow("", "", "7d", "", paris, now)
+	var days []string
+	win.EachDay("", now, paris, func(day string) { days = append(days, day) })
+
+	if len(days) != 7 {
+		t.Fatalf("want 7 days, got %d: %v", len(days), days)
+	}
+	if days[0] != "2026-08-03" || days[6] != "2026-08-09" {
+		t.Errorf("wrong ends: %q..%q", days[0], days[6])
+	}
+}
+
+// An unbounded span has no first day of its own. Drawing every day
+// since the epoch would be mostly a picture of before the reader owned
+// the software, so the caller says where its own history starts.
+func TestEachDayOnAnUnboundedSpanStartsAtTheEarliestReading(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	var days []string
+	Window{}.EachDay("2026-08-07", now, paris, func(day string) { days = append(days, day) })
+
+	want := []string{"2026-08-07", "2026-08-08", "2026-08-09"}
+	if len(days) != len(want) {
+		t.Fatalf("want %v, got %v", want, days)
+	}
+	for i := range want {
+		if days[i] != want[i] {
+			t.Fatalf("want %v, got %v", want, days)
+		}
+	}
+
+	var none []string
+	Window{}.EachDay("", now, paris, func(day string) { none = append(none, day) })
+	if len(none) != 0 {
+		t.Errorf("no reading on record draws no days, got %d", len(none))
+	}
+}
+
+// This year is resolved against today, not as a fixed count of days:
+// the first of January is a different distance away every time it is
+// asked, and 365 would call last December part of this year for most of
+// the spring.
+func TestThisYearOpensOnTheFirstOfJanuary(t *testing.T) {
+	spring := time.Date(2026, 3, 4, 12, 0, 0, 0, paris)
+	win := SpanThisYear.Window(spring, paris)
+	if got, want := win.FromDay(), "2026-01-01"; got != want {
+		t.Errorf("first day: got %q, want %q", got, want)
+	}
+	if got, want := win.ToDay(), "2026-03-04"; got != want {
+		t.Errorf("last day: got %q, want %q", got, want)
+	}
+
+	newYear := time.Date(2026, 1, 1, 9, 0, 0, 0, paris)
+	if got := SpanThisYear.Window(newYear, paris).Days(); got != 1 {
+		t.Errorf("on new year's day this year is one day, got %d", got)
+	}
+}
+
+func TestSpanWindowsAreTheDaysTheyName(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	for span, want := range map[Span]int{
+		Span7Days:   7,
+		Span30Days:  30,
+		Span90Days:  90,
+		Span365Days: 365,
+	} {
+		if got := span.Window(now, paris).Days(); got != want {
+			t.Errorf("%s: want %d days, got %d", span, want, got)
+		}
+	}
+	if !SpanAllTime.Window(now, paris).Unbounded() {
+		t.Error("all time is unbounded")
+	}
+}
+
+// Bars while a day is still a readable unit, a grid once it is not.
+func TestBarsGiveWayToTheGridAtAMonth(t *testing.T) {
+	now := time.Date(2026, 8, 9, 12, 0, 0, 0, paris)
+	for _, span := range []Span{Span7Days, Span30Days} {
+		if !span.SuitsDailyBars(now, paris) {
+			t.Errorf("%s (%d days) fits in bars", span, span.Window(now, paris).Days())
+		}
+	}
+	for _, span := range []Span{Span90Days, Span365Days, SpanAllTime} {
+		if span.SuitsDailyBars(now, paris) {
+			t.Errorf("%s is too long for bars", span)
+		}
+	}
+	// The boundary itself, which is what MaxBarDays names.
+	edge := DayWindow(now.AddDate(0, 0, -(MaxBarDays-1)), now, paris)
+	if edge.Days() != MaxBarDays {
+		t.Fatalf("precondition: %d days, want %d", edge.Days(), MaxBarDays)
+	}
+}
+
+// A cookie and a query parameter are both user input: an unknown value
+// is a value somebody typed, not a value to render.
+func TestParseSpanRefusesWhatItDoesNotKnow(t *testing.T) {
+	for _, raw := range []string{"", "wat", "8d", "this_decade", "ALL"} {
+		if got := ParseSpan(raw); got != DefaultSpan {
+			t.Errorf("ParseSpan(%q) = %q, want the default %q", raw, got, DefaultSpan)
+		}
+	}
+	for _, span := range Spans {
+		if got := ParseSpan(string(span)); got != span {
+			t.Errorf("ParseSpan(%q) = %q", span, got)
+		}
+		if span.Label() == "" {
+			t.Errorf("%q has no label", span)
+		}
+	}
+}
+
+func TestActiveSecondsSubtractsIdleAndNeverGoesNegative(t *testing.T) {
+	start := time.Date(2026, 8, 9, 20, 0, 0, 0, paris)
+	ses := store.Session{StartedAt: start, EndedAt: start.Add(20 * time.Minute), IdleMs: 12 * 60 * 1000}
+	if got := ActiveSeconds(ses); got != 8*60 {
+		t.Errorf("twenty minutes less twelve idle is eight, got %v", got/60)
+	}
+
+	// A backward clock, or an idle figure larger than the sitting.
+	broken := store.Session{StartedAt: start, EndedAt: start.Add(time.Minute), IdleMs: 60 * 60 * 1000}
+	if got := ActiveSeconds(broken); got != 0 {
+		t.Errorf("want nought, got %v", got)
+	}
+}
+
+// A streak may end today or yesterday: a reader who has not opened a
+// book before lunch has not broken anything.
+func TestStreakMayEndYesterday(t *testing.T) {
+	now := time.Date(2026, 8, 9, 10, 0, 0, 0, paris)
+	days := map[string]bool{
+		"2026-08-08": true,
+		"2026-08-07": true,
+		"2026-08-06": true,
+	}
+	if got := StreakDays(days, paris, now); got != 3 {
+		t.Errorf("want 3, got %d", got)
+	}
+
+	days["2026-08-09"] = true
+	if got := StreakDays(days, paris, now); got != 4 {
+		t.Errorf("today extends it to 4, got %d", got)
+	}
+
+	stale := map[string]bool{"2026-08-06": true, "2026-08-05": true}
+	if got := StreakDays(stale, paris, now); got != 0 {
+		t.Errorf("a run that ended before yesterday is over, got %d", got)
+	}
+}

--- a/internal/insights/span.go
+++ b/internal/insights/span.go
@@ -1,0 +1,108 @@
+package insights
+
+import "time"
+
+// Span is one of the fixed spans a reader can pick from a menu.
+//
+// The identifiers are the ones `StatsRange` uses in the Android app, so
+// the two menus offer the same choices under the same names and a span
+// can be carried between them without translation. They are also what
+// gets written into a URL and a cookie, so they must not change once
+// released.
+//
+// This sits on top of [Window] rather than replacing it: the API's
+// `range=Nd` accepts any number of days, and only a menu needs a fixed
+// list.
+type Span string
+
+const (
+	Span7Days    Span = "7d"
+	Span30Days   Span = "30d"
+	Span90Days   Span = "90d"
+	Span365Days  Span = "365d"
+	SpanThisYear Span = "this_year"
+	SpanAllTime  Span = "all"
+)
+
+// DefaultSpan is what a reader who has never chosen gets, and what an
+// unreadable choice falls back to. Thirty days is long enough to show a
+// habit and short enough that every day in it is still a day the reader
+// remembers.
+const DefaultSpan = Span30Days
+
+// MaxBarDays is as many days as read as a row of bars. Past this a bar
+// per day is a picket fence nobody can read a date off, and the
+// calendar grid takes over.
+const MaxBarDays = 31
+
+// Spans is the menu, in the order it is offered.
+var Spans = []Span{Span7Days, Span30Days, Span90Days, Span365Days, SpanThisYear, SpanAllTime}
+
+// ParseSpan reads a span identifier, falling back to [DefaultSpan] for
+// anything it does not recognise. A query parameter and a cookie are
+// both user input: an unknown value is a value somebody typed, not a
+// value to render.
+func ParseSpan(raw string) Span {
+	for _, s := range Spans {
+		if string(s) == raw {
+			return s
+		}
+	}
+	return DefaultSpan
+}
+
+// Label is how the span is named in a menu.
+func (s Span) Label() string {
+	switch s {
+	case Span7Days:
+		return "Last 7 days"
+	case Span90Days:
+		return "Last 90 days"
+	case Span365Days:
+		return "Last 365 days"
+	case SpanThisYear:
+		return "This year"
+	case SpanAllTime:
+		return "All time"
+	case Span30Days:
+		return "Last 30 days"
+	default:
+		return "Last 30 days"
+	}
+}
+
+// Window resolves the span against a moment and a timezone.
+//
+// "This year" is resolved against now rather than a day count, because
+// the first of January is a different distance away every time it is
+// asked and a fixed 365 would call last December part of this year for
+// most of the spring.
+func (s Span) Window(now time.Time, loc *time.Location) Window {
+	today := now.In(loc)
+	switch s {
+	case Span7Days:
+		return DayWindow(today.AddDate(0, 0, -6), today, loc)
+	case Span90Days:
+		return DayWindow(today.AddDate(0, 0, -89), today, loc)
+	case Span365Days:
+		return DayWindow(today.AddDate(0, 0, -364), today, loc)
+	case SpanThisYear:
+		return DayWindow(time.Date(today.Year(), 1, 1, 0, 0, 0, 0, loc), today, loc)
+	case SpanAllTime:
+		return Window{}
+	case Span30Days:
+		return DayWindow(today.AddDate(0, 0, -29), today, loc)
+	default:
+		return DayWindow(today.AddDate(0, 0, -29), today, loc)
+	}
+}
+
+// SuitsDailyBars reports whether the span is short enough to read as a
+// row of one bar per day.
+func (s Span) SuitsDailyBars(now time.Time, loc *time.Location) bool {
+	w := s.Window(now, loc)
+	if w.Unbounded() {
+		return false
+	}
+	return w.Days() <= MaxBarDays
+}

--- a/internal/insights/window.go
+++ b/internal/insights/window.go
@@ -1,0 +1,289 @@
+// Package insights holds the span vocabulary the reading statistics are
+// answered in.
+//
+// It exists because there are three surfaces — the native API, the web
+// UI and the Android app — that must agree on what "the last thirty
+// days" means, and two of them run in this binary. When they each had
+// their own copy they drifted: the API placed a sitting on the day it
+// ended and the web dashboard on the day it began, so a session read
+// across midnight appeared on different days depending on which screen
+// the reader was looking at.
+//
+// Nothing here knows about HTTP. A caller hands over the strings it
+// received and gets back a [Window] it can query the store with.
+package insights
+
+import (
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// DayFormat is how a tz-local day is written down everywhere in this
+// package and in the store: rollups are keyed by it and windows are
+// compared as strings against it.
+const DayFormat = "2006-01-02"
+
+// MaxRangeDays is as long a span as `range=Nd` may name: ten years,
+// which is longer than this software has existed. It is not a limit on
+// how far back an insight can reach — an unbounded window is unbounded
+// and always was, and rollups are kept indefinitely.
+const MaxRangeDays = 3660
+
+// StreakLookbackDays is how far back a streak is searched for. A run of
+// consecutive days is broken by the first day without reading on it, so
+// looking further back than any reader has been syncing cannot lengthen
+// one, and the query is bounded rather than open.
+const StreakLookbackDays = MaxRangeDays
+
+// DefaultSummaryRange is what the summary counts when a caller names no
+// span at all, kept from before ranges were selectable.
+const DefaultSummaryRange = "30d"
+
+// UnboundedRange is how a caller spells "everything on record" rather
+// than encoding it as a magic number of days nobody could read back.
+const UnboundedRange = "all"
+
+// EpochDay is older than any session or rollup a store can hold, and is
+// what an unbounded window uses where a query insists on a lower bound.
+const EpochDay = "1970-01-01"
+
+// Window is the span an insight covers, always a whole number of days
+// in the user's timezone.
+//
+// Whole days rather than a rolling count of hours, because that is what
+// the question means: a reader asking for their last seven days at nine
+// in the evening means the same seven dates they would have meant at
+// dawn, not the 168 hours ending now — which would reach back into an
+// eighth day and count part of it.
+//
+// A zero Window is unbounded: "everything on record", which is what a
+// caller that names no range has always meant and must keep meaning.
+type Window struct {
+	// from is the first instant counted, to the first instant after.
+	from time.Time
+	to   time.Time
+	// fromDay and toDay are the same bounds as tz-local dates, both
+	// inclusive, and are empty exactly when the window is unbounded.
+	fromDay string
+	toDay   string
+}
+
+// Unbounded reports whether this window has no beginning.
+func (w Window) Unbounded() bool { return w.fromDay == "" }
+
+// FromDay is the first tz-local day counted, empty when unbounded.
+func (w Window) FromDay() string { return w.fromDay }
+
+// ToDay is the last tz-local day counted, empty when unbounded.
+func (w Window) ToDay() string { return w.toDay }
+
+// HoldsSession reports whether a session ended inside the window. The
+// end is what places a session in a range, so that a stretch of reading
+// counts once, on the day it was finished, rather than being smeared
+// across a boundary it happened to straddle.
+func (w Window) HoldsSession(ses store.Session) bool {
+	if w.Unbounded() {
+		return true
+	}
+	return !ses.EndedAt.Before(w.from) && ses.EndedAt.Before(w.to)
+}
+
+// HoldsDay reports whether a rollup's tz-local day falls in the window.
+// Compared as strings because a rollup's day was fixed in the timezone
+// in force when it was rolled up, and re-parsing it in today's timezone
+// would move reading between days retroactively.
+func (w Window) HoldsDay(day string) bool {
+	if w.Unbounded() {
+		return true
+	}
+	return day >= w.fromDay && day <= w.toDay
+}
+
+// Days counts the calendar days the window covers, 0 when unbounded.
+//
+// Counted from the day strings in UTC rather than by dividing the
+// instants, because a span containing a daylight-saving change is not a
+// whole number of twenty-four hour periods and would come out short.
+func (w Window) Days() int {
+	if w.Unbounded() {
+		return 0
+	}
+	from, errFrom := time.Parse(DayFormat, w.fromDay)
+	to, errTo := time.Parse(DayFormat, w.toDay)
+	if errFrom != nil || errTo != nil {
+		return 0
+	}
+	return int(to.Sub(from).Hours()/24) + 1
+}
+
+// SessionBounds are the instants to query raw sessions between. An
+// unbounded window reaches back to the epoch, which predates every
+// session any store can hold, and forward to the end of today in the
+// user's timezone — the same far end a bounded window ending today has,
+// so that a lifetime total can never come out below a ranged one when a
+// device with a fast clock files a session a moment into the future.
+func (w Window) SessionBounds(now time.Time, loc *time.Location) (time.Time, time.Time) {
+	if w.Unbounded() {
+		today := now.In(loc)
+		endOfToday := time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1)
+		return time.Unix(0, 0), endOfToday
+	}
+	return w.from, w.to
+}
+
+// DayBounds are the inclusive tz-local dates to query rollups between.
+func (w Window) DayBounds(now time.Time, loc *time.Location) (string, string) {
+	if w.Unbounded() {
+		return EpochDay, now.In(loc).Format(DayFormat)
+	}
+	return w.fromDay, w.toDay
+}
+
+// EachDay calls fn with every tz-local day in the window, in order,
+// including the ones with nothing on them.
+//
+// Empty days are kept deliberately: a fortnight with two gaps in it is
+// the information, and a series that silently skipped them would read
+// as an unbroken run. An unbounded window has no first day of its own,
+// so the caller supplies one — the earliest day it found reading on,
+// because a chart of every day since the epoch is mostly a picture of
+// before the reader owned the software.
+func (w Window) EachDay(earliest string, now time.Time, loc *time.Location, fn func(day string)) {
+	first, last := w.DayBounds(now, loc)
+	if w.Unbounded() {
+		if earliest == "" {
+			return
+		}
+		first = earliest
+	}
+	from, err := time.Parse(DayFormat, first)
+	if err != nil {
+		return
+	}
+	to, err := time.Parse(DayFormat, last)
+	if err != nil || to.Before(from) {
+		return
+	}
+	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
+		fn(d.Format(DayFormat))
+	}
+}
+
+// DayWindow builds the window covering firstDay through lastDay
+// inclusive, in loc.
+func DayWindow(firstDay, lastDay time.Time, loc *time.Location) Window {
+	from := time.Date(firstDay.Year(), firstDay.Month(), firstDay.Day(), 0, 0, 0, 0, loc)
+	last := time.Date(lastDay.Year(), lastDay.Month(), lastDay.Day(), 0, 0, 0, 0, loc)
+	return Window{
+		from:    from,
+		to:      last.AddDate(0, 0, 1),
+		fromDay: from.Format(DayFormat),
+		toDay:   last.Format(DayFormat),
+	}
+}
+
+// ParseWindow resolves the span a request asks for.
+//
+// rawFrom and rawTo name whole days in the user's own timezone, both
+// included, and win when they are both present and readable. rawRange
+// is the older spelling: `Nd` means the last N calendar days ending
+// today — calendar days, so that a request made at nine in the evening
+// covers the same dates as one made at dawn, which is what a reader
+// means and what their own device counts locally. [UnboundedRange]
+// means everything on record, as does an absent parameter where the
+// caller passes no def.
+//
+// A range that cannot be read falls back to def rather than to
+// everything: a typo asking for a fortnight should not quietly become
+// the most expensive query there is, and an echo would report a span
+// the caller never asked for either way.
+func ParseWindow(rawFrom, rawTo, rawRange, def string, loc *time.Location, now time.Time) Window {
+	if rawFrom != "" && rawTo != "" {
+		from, errFrom := time.ParseInLocation(DayFormat, rawFrom, loc)
+		to, errTo := time.ParseInLocation(DayFormat, rawTo, loc)
+		if errFrom == nil && errTo == nil && !to.Before(from) {
+			return DayWindow(from, to, loc)
+		}
+	}
+	raw := rawRange
+	if raw == "" {
+		raw = def
+	}
+	if raw == "" || raw == UnboundedRange {
+		return Window{}
+	}
+	days := parseRangeDays(raw, parseRangeDays(def, 0))
+	if days <= 0 {
+		return Window{}
+	}
+	today := now.In(loc)
+	return DayWindow(today.AddDate(0, 0, -(days-1)), today, loc)
+}
+
+// parseRangeDays reads a `Nd` parameter, returning def for anything
+// else — including [UnboundedRange], which names no number of days and
+// is resolved to an unbounded window by [ParseWindow] instead.
+func parseRangeDays(s string, def int) int {
+	if len(s) >= 2 && s[len(s)-1] == 'd' {
+		var v int
+		if _, err := parseInt(s[:len(s)-1], &v); err == nil && v > 0 && v <= MaxRangeDays {
+			return v
+		}
+	}
+	return def
+}
+
+func parseInt(s string, out *int) (int, error) {
+	var v int
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, errBadInt
+		}
+		v = v*10 + int(c-'0')
+	}
+	*out = v
+	return v, nil
+}
+
+var errBadInt = errString("bad int")
+
+type errString string
+
+func (e errString) Error() string { return string(e) }
+
+// ActiveSeconds returns a session's length minus its idle time, clamped
+// at nought. The device counts reading off a monotonic clock that stops
+// when the app leaves the foreground and reports the difference, so a
+// book left open while the reader answered the door spans more time
+// than it counted.
+func ActiveSeconds(ses store.Session) float64 {
+	d := ses.EndedAt.Sub(ses.StartedAt).Seconds() - float64(ses.IdleMs)/1000
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// StreakDays counts consecutive days with activity, ending today or
+// yesterday.
+//
+// Yesterday counts because a streak is about a habit and the day is not
+// over: a reader who has not opened a book before lunch has not broken
+// anything, and a screen that said so every morning would be lying by
+// eleven o'clock.
+func StreakDays(daySet map[string]bool, loc *time.Location, now time.Time) int {
+	streak := 0
+	day := now.In(loc)
+	if !daySet[day.Format(DayFormat)] {
+		day = day.AddDate(0, 0, -1)
+		if !daySet[day.Format(DayFormat)] {
+			return 0
+		}
+	}
+	for daySet[day.Format(DayFormat)] {
+		streak++
+		day = day.AddDate(0, 0, -1)
+	}
+	return streak
+}

--- a/internal/webui/dashboard.templ
+++ b/internal/webui/dashboard.templ
@@ -1,9 +1,18 @@
 package webui
 
+import "github.com/chmouel/liseur-sync/internal/insights"
+
 // Dashboard data carriers (populated by handlers).
 
 type SummaryData struct {
-	RangeDays     int
+	// Span is what the reader asked for; RangeDays is how many days
+	// that came to, which is nought for all time.
+	Span      insights.Span
+	RangeDays int
+	// Bars says whether the span is short enough to read as one bar a
+	// day. Decided in the handler, which is the only place that knows
+	// the reader's timezone and the moment being asked about.
+	Bars          bool
 	ActiveMinutes float64
 	Pages         float64
 	Sessions      int
@@ -18,25 +27,33 @@ type DayCell struct {
 
 templ dashboard(
 	prefix string, u userCtx, csrf string,
-	sum SummaryData, heatmap []DayCell, recent []SessionRow, reading []WorkRow,
+	sum SummaryData, days []DayCell, recent []SessionRow, reading []WorkRow,
 ) {
-	@layout("Dashboard", prefix, u, csrf, dashboardBody(prefix, csrf, sum, heatmap, recent, reading))
+	@layout("Dashboard", prefix, u, csrf, dashboardBody(prefix, csrf, sum, days, recent, reading))
 }
 
 templ dashboardBody(
 	prefix string, csrf string,
-	sum SummaryData, heatmap []DayCell, recent []SessionRow, reading []WorkRow,
+	sum SummaryData, days []DayCell, recent []SessionRow, reading []WorkRow,
 ) {
-	<h1>Dashboard</h1>
+	<header class="dashhead">
+		<div>
+			<p class="eyebrow">{ sum.Span.Label() }</p>
+			<h1>Dashboard</h1>
+		</div>
+		@spanPicker(sum.Span)
+	</header>
 	<section class="cards">
-		<div class="stat"><span class="num">{ f0(sum.ActiveMinutes) }</span><span class="lbl">minutes ({ i2s(sum.RangeDays) }d)</span></div>
+		<div class="stat"><span class="num">{ f0(sum.ActiveMinutes) }</span><span class="lbl">minutes</span></div>
 		if sum.Pages > 0 {
 			<div class="stat"><span class="num">{ f0(sum.Pages) }</span><span class="lbl">pages</span></div>
 		}
 		<div class="stat"><span class="num">{ i2s(sum.Sessions) }</span><span class="lbl">sessions</span></div>
-		<div class="stat"><span class="num">{ i2s(sum.StreakDays) }</span><span class="lbl">day streak</span></div>
+		// The streak deliberately reaches back past the span, so it says
+		// so rather than being left to look like another figure about
+		// the last week.
+		<div class="stat"><span class="num">{ i2s(sum.StreakDays) }</span><span class="lbl">day streak (all time)</span></div>
 	</section>
-
 	if len(reading) > 0 {
 		<section class="card">
 			<h2>Continue reading</h2>
@@ -47,16 +64,16 @@ templ dashboardBody(
 			</div>
 		</section>
 	}
-
 	<section class="card">
-		<h2>This year</h2>
-		<div class="heatmap" role="img" aria-label="daily reading minutes">
-			for _, d := range heatmap {
-				<span class={ cellClass(d.Minutes) } title={ d.Date + " — " + f0(d.Minutes) + " min" }></span>
-			}
-		</div>
+		<h2>{ chartHeading(sum.Span) }</h2>
+		if len(days) == 0 {
+			<p class="muted">Nothing recorded in this span.</p>
+		} else if sum.Bars {
+			@dayBars(days)
+		} else {
+			@readingHeatmap(days)
+		}
 	</section>
-
 	<section class="card">
 		<h2>Recent sessions</h2>
 		if len(recent) == 0 {
@@ -76,4 +93,85 @@ templ dashboardBody(
 			</table>
 		}
 	</section>
+}
+
+// spanPicker is how far back the dashboard looks.
+//
+// A menu rather than a row of chips: six spans across a phone would
+// either wrap into a paragraph or shrink to initials, and this is a
+// control a reader touches rarely and deliberately. It submits itself
+// where there is scripting (static/ui.js) and shows its button where
+// there is not, like every other picker here.
+templ spanPicker(current insights.Span) {
+	// No action: the dashboard is the only page this draws on, and a
+	// form without one submits to wherever it already is.
+	<form class="spanpick" method="get">
+		<label class="visually-hidden" for="span-pick">How far back</label>
+		<select id="span-pick" name="span">
+			for _, s := range insights.Spans {
+				if s == current {
+					<option value={ string(s) } selected>{ s.Label() }</option>
+				} else {
+					<option value={ string(s) }>{ s.Label() }</option>
+				}
+			}
+		</select>
+		<noscript><button type="submit">Show</button></noscript>
+	</form>
+}
+
+// dayBars is one bar a day, for a span short enough that a day is still
+// a readable unit.
+//
+// Only every seventh day is captioned, counted back from the last so
+// that today always carries its own label. Captioning all thirty turns
+// the axis into a smear; captioning every fifth lands on a different
+// weekday each time the span changes.
+templ dayBars(days []DayCell) {
+	{{ chart := layOutBars(days) }}
+	<div class="daybars" role="img" aria-label={ chart.Label }>
+		for _, b := range chart.Bars {
+			<div class="daybar" title={ b.Title }>
+				<div class="daybar-track"><span class={ b.Class }></span></div>
+				<span class="daybar-cap">{ b.Caption }</span>
+			</div>
+		}
+	</div>
+}
+
+// readingHeatmap is a square a day, for a span too long to read as bars.
+//
+// Where the bars show how much, this shows when: months of daily bars
+// are a picket fence nobody can read a date off, but the same months as
+// a grid make the shape of a reading habit visible at a glance — the
+// fortnight on holiday, the month nothing happened.
+//
+// The columns are weeks and the rows are weekdays, which is what makes
+// a square findable at all: without the leading padding the grid is a
+// spiral and the row a square sits in means nothing. It scrolls, and
+// opens at its far end — the reader came to see how this week went, not
+// how last January did.
+//
+// Each month label sits in the column it names, so the two stay
+// together whatever the browser does with the widths.
+templ readingHeatmap(days []DayCell) {
+	{{ grid := layOutHeatmap(days) }}
+	<div class="heatwrap" data-scroll-end="1">
+		<div class="heatmap" role="img" aria-label={ grid.Label }>
+			for _, wk := range grid.Weeks {
+				<div class="heatweek">
+					<span class="heatmonth" aria-hidden="true">{ wk.Month }</span>
+					<div class="heatdays">
+						for _, c := range wk.Days {
+							if c.Blank {
+								<span class="cell blank" aria-hidden="true"></span>
+							} else {
+								<span class={ c.Class } title={ c.Title }></span>
+							}
+						}
+					</div>
+				</div>
+			}
+		</div>
+	</div>
 }

--- a/internal/webui/dashboardchart.go
+++ b/internal/webui/dashboardchart.go
@@ -1,10 +1,12 @@
 package webui
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/insights"
+	"github.com/chmouel/liseur-sync/internal/store"
 )
 
 // Laying out the dashboard's two charts.
@@ -180,18 +182,26 @@ func layOutHeatmap(days []DayCell) heatGrid {
 	return grid
 }
 
-// opensMonth reports the month a column starts in, and its name, when
-// that is not the month the column before it was already in.
+// opensMonth reports the month a column opens, and its name, when that
+// is not the month the column before it was already in.
+//
+// Every real day in the column is looked at, not only the first. A
+// month rarely starts on the day a column does, and captioning the
+// column after the one holding the first of the month would put every
+// label up to six days late — a label that has drifted off the thing
+// it names is worse than no label.
 func opensMonth(week []heatCell, running time.Month) (time.Month, string) {
 	for _, c := range week {
 		if c.Blank {
 			continue
 		}
 		d, err := time.Parse(insights.DayFormat, c.Date)
-		if err != nil || d.Month() == running {
+		if err != nil {
 			return running, ""
 		}
-		return d.Month(), d.Format("Jan")
+		if d.Month() != running {
+			return d.Month(), d.Format("Jan")
+		}
 	}
 	return running, ""
 }
@@ -211,4 +221,41 @@ func chartLabel(days []DayCell) string {
 	}
 	return fmt.Sprintf("daily reading minutes, %s to %s: %s minutes over %d days with reading",
 		days[0].Date, days[len(days)-1].Date, f0(total), active)
+}
+
+// pageCounter turns a sitting's progress into a number of pages.
+//
+// The same arithmetic the API and the per-work page do: how far through
+// the book the reader got, times how many pages the edition has. It is
+// an approximation and says so, but a page count is what a reader
+// recognises and a progression fraction is not.
+//
+// The editions are remembered for the length of one request because a
+// dashboard is a few books read many times over: without the map, a
+// year of reading is a year of lookups for the same handful of rows.
+type pageCounter struct {
+	st       store.Store
+	editions map[string]*int64
+}
+
+func newPageCounter(st store.Store) *pageCounter {
+	return &pageCounter{st: st, editions: map[string]*int64{}}
+}
+
+func (p *pageCounter) of(ctx context.Context, ses store.Session) float64 {
+	delta := ses.EndProg - ses.StartProg
+	if delta <= 0 || ses.EditionSHA == nil {
+		return 0
+	}
+	count, seen := p.editions[*ses.EditionSHA]
+	if !seen {
+		if ed, err := p.st.EditionBySHA(ctx, ses.UserID, *ses.EditionSHA); err == nil {
+			count = ed.PageCount
+		}
+		p.editions[*ses.EditionSHA] = count
+	}
+	if count == nil {
+		return 0
+	}
+	return delta * float64(*count)
 }

--- a/internal/webui/dashboardchart.go
+++ b/internal/webui/dashboardchart.go
@@ -1,0 +1,214 @@
+package webui
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/insights"
+)
+
+// Laying out the dashboard's two charts.
+//
+// Both are computed here rather than in the template because both need
+// arithmetic — a week boundary, a running month, a bar height as a
+// percentage of the busiest day — and a template that can do arithmetic
+// is a template nobody can test.
+
+// chartHeading names the chart for the span it is drawing. "This past
+// week" is only true when it is one; thirty bars under that heading is
+// the page telling the reader something they can see is false.
+func chartHeading(span insights.Span) string {
+	if span == insights.Span7Days {
+		return "This past week"
+	}
+	return "Day by day"
+}
+
+// barCaptionEvery is how often a bar is captioned once they cannot all
+// be. Seven puts the labels on the same weekday all the way along, so
+// the axis reads as a series of weeks rather than as an arbitrary tick.
+const barCaptionEvery = 7
+
+type barChart struct {
+	Bars  []barCell
+	Label string
+}
+
+type barCell struct {
+	Class   string
+	Caption string
+	Title   string
+}
+
+// layOutBars turns a run of days into a row of bars.
+//
+// Heights are relative to the busiest day in the span, because the
+// question a bar chart answers is "which days were the big ones" and an
+// absolute scale would flatten a quiet fortnight into nothing. The
+// colour stays absolute (cellClass), so a green bar means the same
+// amount of reading here as it does on the heatmap.
+func layOutBars(days []DayCell) barChart {
+	chart := barChart{Bars: make([]barCell, 0, len(days))}
+	busiest := 0.0
+	for _, d := range days {
+		if d.Minutes > busiest {
+			busiest = d.Minutes
+		}
+	}
+	if busiest <= 0 {
+		busiest = 1
+	}
+	last := len(days) - 1
+	// A week fits its own letters. Longer than that and captioning
+	// every bar turns the axis into a smear, so it goes to one a week,
+	// counted back from the end — that way today always carries its
+	// own label, whatever the span happens to divide into.
+	everyBar := len(days) <= barCaptionEvery
+	for i, d := range days {
+		caption := ""
+		if everyBar || (last-i)%barCaptionEvery == 0 {
+			caption = dayCaption(d.Date)
+		}
+		chart.Bars = append(chart.Bars, barCell{
+			Class:   cellClass(d.Minutes) + " " + barHeightClass(d.Minutes/busiest),
+			Caption: caption,
+			Title:   d.Date + " — " + f0(d.Minutes) + " min",
+		})
+	}
+	chart.Label = chartLabel(days)
+	return chart
+}
+
+// barHeightClass is how tall a bar is drawn, as one of the stylesheet's
+// five-percent steps. A class rather than an inline height because the
+// CSP has no `unsafe-inline` and this UI has answered that question
+// once already, for progress bars (pctClass, ADR-0011).
+//
+// A day with any reading on it gets the smallest visible step even when
+// the arithmetic rounds it to nothing: a bar of zero height reads as a
+// day with no reading at all, which is a different fact.
+func barHeightClass(fraction float64) string {
+	if fraction > 0 && fraction < 0.05 {
+		fraction = 0.05
+	}
+	return pctClass(fraction)
+}
+
+// dayCaption is the short weekday a bar is labelled with.
+func dayCaption(day string) string {
+	d, err := time.Parse(insights.DayFormat, day)
+	if err != nil {
+		return ""
+	}
+	return d.Format("Mon")
+}
+
+// daysInWeek is how many rows the heatmap has, and how long a column is.
+const daysInWeek = 7
+
+type heatGrid struct {
+	Weeks []heatWeek
+	Label string
+}
+
+type heatWeek struct {
+	// Month captions this column when its first real day opens a month
+	// the column before it did not, which puts the name where the month
+	// actually starts rather than at a fixed interval that drifts off it.
+	Month string
+	Days  []heatCell
+}
+
+type heatCell struct {
+	Date    string
+	Minutes float64
+	Class   string
+	Title   string
+	Blank   bool
+}
+
+// layOutHeatmap arranges days into columns of a week, one weekday a row.
+//
+// The leading blanks are what make every row one weekday, the way a
+// wall calendar reads. Without them the grid is a spiral: a square's
+// row would mean nothing, and the shape a reader is here to see — the
+// weekends, the fortnight away — would not be there to see.
+//
+// The month label lives inside its own column rather than in a row of
+// its own, so the two cannot drift apart however the columns are sized.
+//
+// Weeks start on Monday. The server does not know the reader's locale,
+// and guessing it from a timezone would be worse than picking one;
+// Monday is what the ISO week is, and what the rest of this UI assumes.
+func layOutHeatmap(days []DayCell) heatGrid {
+	grid := heatGrid{Label: chartLabel(days)}
+	if len(days) == 0 {
+		return grid
+	}
+	first, err := time.Parse(insights.DayFormat, days[0].Date)
+	if err != nil {
+		return grid
+	}
+
+	cells := make([]heatCell, 0, len(days)+2*daysInWeek)
+	leading := (int(first.Weekday()) + 6) % daysInWeek // Monday is 0
+	for range leading {
+		cells = append(cells, heatCell{Blank: true})
+	}
+	for _, d := range days {
+		cells = append(cells, heatCell{
+			Date:    d.Date,
+			Minutes: d.Minutes,
+			Class:   cellClass(d.Minutes),
+			Title:   d.Date + " — " + f0(d.Minutes) + " min",
+		})
+	}
+	// Pad the last column out to a full week: a ragged column would let
+	// its squares fall on the wrong weekday rows.
+	for len(cells)%daysInWeek != 0 {
+		cells = append(cells, heatCell{Blank: true})
+	}
+
+	var running time.Month
+	for i := 0; i < len(cells); i += daysInWeek {
+		week := heatWeek{Days: cells[i : i+daysInWeek]}
+		if opens, name := opensMonth(week.Days, running); name != "" {
+			running, week.Month = opens, name
+		}
+		grid.Weeks = append(grid.Weeks, week)
+	}
+	return grid
+}
+
+// opensMonth reports the month a column starts in, and its name, when
+// that is not the month the column before it was already in.
+func opensMonth(week []heatCell, running time.Month) (time.Month, string) {
+	for _, c := range week {
+		if c.Blank {
+			continue
+		}
+		d, err := time.Parse(insights.DayFormat, c.Date)
+		if err != nil || d.Month() == running {
+			return running, ""
+		}
+		return d.Month(), d.Format("Jan")
+	}
+	return running, ""
+}
+
+// chartLabel is what a screen reader is told instead of the picture.
+func chartLabel(days []DayCell) string {
+	if len(days) == 0 {
+		return "no reading recorded"
+	}
+	total := 0.0
+	active := 0
+	for _, d := range days {
+		total += d.Minutes
+		if d.Minutes > 0 {
+			active++
+		}
+	}
+	return fmt.Sprintf("daily reading minutes, %s to %s: %s minutes over %d days with reading",
+		days[0].Date, days[len(days)-1].Date, f0(total), active)
+}

--- a/internal/webui/dashboardspan_ext_test.go
+++ b/internal/webui/dashboardspan_ext_test.go
@@ -1,0 +1,261 @@
+package webui
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/insights"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// seedWork puts a work with one edition behind the test user.
+func seedWork(t *testing.T, st store.Store, id, title string) store.Edition {
+	t.Helper()
+	w := store.Work{ID: id, UserID: "u1", Title: title, CreatedAt: time.Now()}
+	ed := store.Edition{UserID: "u1", SHA256: id + "-edition", WorkID: id}
+	if err := st.CreateWork(t.Context(), w, &ed, nil); err != nil {
+		t.Fatal(err)
+	}
+	return ed
+}
+
+// seedSession records one sitting, given in the server's own timezone.
+func seedSession(t *testing.T, st store.Store, id string, ed store.Edition, start, end time.Time) {
+	t.Helper()
+	err := st.AppendSessions(t.Context(), "u1", []store.Session{{
+		SessionID: id, WorkID: ed.WorkID, EditionSHA: &ed.SHA256, DeviceID: "reader",
+		StartedAt: start, EndedAt: end, StartProg: 0.1, EndProg: 0.2,
+		Origin: store.OriginNative,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDashboardSpanPicker is the picker doing what a picker is for: the
+// page comes back describing the span that was asked for, and offering
+// the others.
+func TestDashboardSpanPicker(t *testing.T) {
+	ts, _ := testServer(t)
+	cookie := loginCookie(t, ts)
+
+	for _, tc := range []struct {
+		span  insights.Span
+		wants string
+	}{
+		{insights.Span7Days, "This past week"},
+		{insights.Span90Days, "Day by day"},
+		{insights.SpanAllTime, "Day by day"},
+	} {
+		_, body := page(t, ts, cookie, "/ui?span="+string(tc.span))
+		if !strings.Contains(body, tc.wants) {
+			t.Errorf("span %s: heading %q missing", tc.span, tc.wants)
+		}
+		if !strings.Contains(body, `value="`+string(tc.span)+`" selected`) {
+			t.Errorf("span %s: not selected in the picker", tc.span)
+		}
+		if !strings.Contains(body, tc.span.Label()) {
+			t.Errorf("span %s: label %q missing", tc.span, tc.span.Label())
+		}
+	}
+}
+
+// TestDashboardSpanFallsBackToDefault is a span nobody offers. An
+// unknown token in a URL must not be an error page or an empty chart;
+// it is the default, which is what a reader who typed nothing gets.
+func TestDashboardSpanFallsBackToDefault(t *testing.T) {
+	ts, _ := testServer(t)
+	cookie := loginCookie(t, ts)
+
+	_, body := page(t, ts, cookie, "/ui?span=fortnight")
+	if !strings.Contains(body, `value="`+string(insights.DefaultSpan)+`" selected`) {
+		t.Fatal("an unknown span did not fall back to the default")
+	}
+}
+
+// TestDashboardSpanRemembered is the point of writing it to the cookie:
+// a reader who chose ninety days and comes back to a bare /ui gets
+// ninety days, not thirty.
+func TestDashboardSpanRemembered(t *testing.T) {
+	ts, _ := testServer(t)
+	cookie := loginCookie(t, ts)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/ui?span=90d", nil)
+	req.AddCookie(cookie)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	var prefs *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == prefsCookie {
+			prefs = c
+		}
+	}
+	if prefs == nil {
+		t.Fatal("choosing a span did not write the preference cookie")
+	}
+	if !strings.Contains(prefs.Value, "span-90d") {
+		t.Fatalf("preference cookie does not carry the span: %q", prefs.Value)
+	}
+
+	// And a bare /ui carrying it back comes up on ninety days.
+	req, _ = http.NewRequest("GET", ts.URL+"/ui", nil)
+	req.AddCookie(cookie)
+	req.AddCookie(prefs)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body := readAll(t, resp)
+	if !strings.Contains(body, `value="90d" selected`) {
+		t.Fatal("a bare /ui did not remember the chosen span")
+	}
+}
+
+// TestDashboardSpanQueryBeatsCookie: a link to a span is a link to that
+// span, whatever the browser last chose.
+func TestDashboardSpanQueryBeatsCookie(t *testing.T) {
+	ts, _ := testServer(t)
+	cookie := loginCookie(t, ts)
+
+	req, _ := http.NewRequest("GET", ts.URL+"/ui?span=7d", nil)
+	req.AddCookie(cookie)
+	req.AddCookie(&http.Cookie{Name: prefsCookie, Value: "dark.grid.series.span-365d"})
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if body := readAll(t, resp); !strings.Contains(body, `value="7d" selected`) {
+		t.Fatal("the query parameter lost to the cookie")
+	}
+}
+
+// TestDashboardPlacesSessionOnTheDayItEnded is the disagreement this
+// set out to remove. A sitting that runs past midnight belongs to one
+// day, and the API, the app and this page have to name the same one.
+func TestDashboardPlacesSessionOnTheDayItEnded(t *testing.T) {
+	ts, st := testServer(t)
+	cookie := loginCookie(t, ts)
+	ed := seedWork(t, st, "late-work", "Read past midnight")
+
+	// Yesterday at half eleven until ten past midnight today.
+	end := time.Now().Truncate(24 * time.Hour).Add(10 * time.Minute)
+	seedSession(t, st, "midnight", ed, end.Add(-40*time.Minute), end)
+
+	_, body := page(t, ts, cookie, "/ui?span=7d")
+	today := end.Format(insights.DayFormat)
+	yesterday := end.AddDate(0, 0, -1).Format(insights.DayFormat)
+	if !strings.Contains(body, today+" — 40 min") {
+		t.Errorf("the sitting is not on the day it ended (%s)", today)
+	}
+	if !strings.Contains(body, yesterday+" — 0 min") {
+		t.Errorf("the day it started (%s) should be empty", yesterday)
+	}
+}
+
+// TestDashboardChartShape: short spans are bars, long ones are the
+// calendar. Thirty-one days of squares is unreadable and a year of bars
+// is a picket fence.
+func TestDashboardChartShape(t *testing.T) {
+	ts, _ := testServer(t)
+	cookie := loginCookie(t, ts)
+
+	if _, body := page(t, ts, cookie, "/ui?span=30d"); !strings.Contains(body, "daybars") ||
+		strings.Contains(body, "heatweek") {
+		t.Error("thirty days should be bars")
+	}
+	if _, body := page(t, ts, cookie, "/ui?span=365d"); !strings.Contains(body, "heatweek") ||
+		strings.Contains(body, "daybars") {
+		t.Error("a year should be the calendar")
+	}
+}
+
+// TestDashboardHeatmapAlignsWeekdays: every column is a Monday-to-Sunday
+// week, which is the only reason a square's row means anything.
+func TestDashboardHeatmapAlignsWeekdays(t *testing.T) {
+	ts, _ := testServer(t)
+	cookie := loginCookie(t, ts)
+
+	_, body := page(t, ts, cookie, "/ui?span=365d")
+	weeks := strings.Count(body, `class="heatweek"`)
+	if weeks < 52 {
+		t.Fatalf("a year is %d columns, want at least 52", weeks)
+	}
+	// A column is seven cells whether they carry a day or not.
+	cells := strings.Count(body, `class="cell`)
+	if cells != weeks*7 {
+		t.Fatalf("%d cells over %d columns; the grid is ragged", cells, weeks)
+	}
+	if !strings.Contains(body, `class="heatmonth"`) {
+		t.Fatal("the calendar has no month labels")
+	}
+}
+
+// TestDashboardShowsEmptyDays: a fortnight with two gaps in it is the
+// information. A chart that quietly skipped them would read as a run.
+func TestDashboardShowsEmptyDays(t *testing.T) {
+	ts, st := testServer(t)
+	cookie := loginCookie(t, ts)
+	ed := seedWork(t, st, "gap-work", "One sitting only")
+
+	end := time.Now().Add(-2 * time.Hour)
+	seedSession(t, st, "one", ed, end.Add(-30*time.Minute), end)
+
+	_, body := page(t, ts, cookie, "/ui?span=7d")
+	if bars := strings.Count(body, `class="daybar"`); bars != 7 {
+		t.Fatalf("%d bars for a seven-day span, want 7", bars)
+	}
+}
+
+func readAll(t *testing.T, resp *http.Response) string {
+	t.Helper()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+// TestWorkCountsRollupsOnce is the bug this page had all along: the
+// rolled-up totals were read inside the loop over the sessions still
+// held in full, so a work with three current sittings counted its
+// history three times. The longer a book had been read, the more wrong
+// its page was about it.
+func TestWorkCountsRollupsOnce(t *testing.T) {
+	ts, st := testServer(t)
+	cookie := loginCookie(t, ts)
+	ed := seedWork(t, st, "long-read", "A book with a past")
+
+	// Three sittings of ten minutes each still held in full.
+	base := time.Now().Add(-3 * time.Hour)
+	for i := range 3 {
+		at := base.Add(time.Duration(i) * time.Hour)
+		seedSession(t, st, "recent-"+string(rune('a'+i)), ed, at, at.Add(10*time.Minute))
+	}
+	// And an hour of reading from before the compaction cut-off.
+	err := st.ApplyRollups(t.Context(), "u1", []store.SessionRollup{{
+		UserID: "u1", WorkID: ed.WorkID, Day: "2024-01-01",
+		ActiveSeconds: 3600, Pages: 40, ProgDelta: 0.2, SessionCount: 2,
+	}}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, body := page(t, ts, cookie, "/ui/works/"+ed.WorkID)
+	// Thirty minutes raw plus sixty rolled up, counted once.
+	if !strings.Contains(body, ">90<") {
+		t.Error("minutes are not 30 raw + 60 rolled up, counted once")
+	}
+	// Three sittings plus the two the rollup stands for.
+	if !strings.Contains(body, ">5<") {
+		t.Error("sessions are not 3 raw + 2 rolled up, counted once")
+	}
+}

--- a/internal/webui/dashboardspan_ext_test.go
+++ b/internal/webui/dashboardspan_ext_test.go
@@ -259,3 +259,98 @@ func TestWorkCountsRollupsOnce(t *testing.T) {
 		t.Error("sessions are not 3 raw + 2 rolled up, counted once")
 	}
 }
+
+// TestDashboardExcludesSessionEndingPastTheSpan: the store answers with
+// an overlap, so a sitting that started inside the span and ran out the
+// far end of it comes back too. The window counts by the day a sitting
+// ended, and so must this page, or the totals include reading that has
+// not finished happening.
+func TestDashboardExcludesSessionEndingPastTheSpan(t *testing.T) {
+	ts, st := testServer(t)
+	cookie := loginCookie(t, ts)
+	ed := seedWork(t, st, "overrun", "Still being read")
+
+	// Starts before midnight tonight and ends after it, so it belongs
+	// to tomorrow and to no span that stops at today.
+	midnight := time.Now().Truncate(24*time.Hour).AddDate(0, 0, 1)
+	seedSession(t, st, "overrun-1", ed, midnight.Add(-20*time.Minute), midnight.Add(30*time.Minute))
+	// And an ordinary hour today, so the page has something to say.
+	today := time.Now().Add(-2 * time.Hour)
+	seedSession(t, st, "today-1", ed, today, today.Add(time.Hour))
+
+	_, body := page(t, ts, cookie, "/ui?span=7d")
+	if !strings.Contains(body, `<span class="num">60</span><span class="lbl">minutes</span>`) {
+		t.Error("the sitting running past the span was counted in the total")
+	}
+	if !strings.Contains(body, `<span class="num">1</span><span class="lbl">sessions</span>`) {
+		t.Error("the sitting running past the span was counted as a session")
+	}
+}
+
+// TestDashboardCountsPagesFromSessions: the page card was fed only by
+// rollups, so a reader whose history had not been compacted yet saw no
+// pages at all.
+func TestDashboardCountsPagesFromSessions(t *testing.T) {
+	ts, st := testServer(t)
+	cookie := loginCookie(t, ts)
+
+	w := store.Work{ID: "paged", UserID: "u1", Title: "A book with pages", CreatedAt: time.Now()}
+	count := int64(400)
+	ed := store.Edition{UserID: "u1", SHA256: "paged-edition", WorkID: w.ID, PageCount: &count}
+	if err := st.CreateWork(t.Context(), w, &ed, nil); err != nil {
+		t.Fatal(err)
+	}
+	at := time.Now().Add(-2 * time.Hour)
+	err := st.AppendSessions(t.Context(), "u1", []store.Session{{
+		SessionID: "paged-1", WorkID: w.ID, EditionSHA: &ed.SHA256, DeviceID: "reader",
+		StartedAt: at, EndedAt: at.Add(time.Hour), StartProg: 0.10, EndProg: 0.20,
+		Origin: store.OriginNative,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, body := page(t, ts, cookie, "/ui?span=7d")
+	// A tenth of four hundred pages.
+	if !strings.Contains(body, `<span class="num">40</span><span class="lbl">pages</span>`) {
+		t.Error("pages read in sittings still held in full are not counted")
+	}
+}
+
+// TestHeatmapLabelsTheColumnHoldingTheFirst: a month almost never
+// starts on the day a column does. Captioning the column after the one
+// that holds the first of the month puts every label up to six days
+// late, drifting off the thing it names.
+func TestHeatmapLabelsTheColumnHoldingTheFirst(t *testing.T) {
+	// A Wednesday, so the column runs Mon 29 Sep to Sun 5 Oct and the
+	// first of October falls in the middle of it.
+	days := []DayCell{}
+	for d := time.Date(2025, 9, 29, 0, 0, 0, 0, time.UTC); d.Before(time.Date(2025, 10, 13, 0, 0, 0, 0, time.UTC)); d = d.AddDate(0, 0, 1) {
+		days = append(days, DayCell{Date: d.Format(insights.DayFormat)})
+	}
+	grid := layOutHeatmap(days)
+	if len(grid.Weeks) != 2 {
+		t.Fatalf("%d columns, want 2", len(grid.Weeks))
+	}
+	if grid.Weeks[0].Month != "Sep" {
+		t.Errorf("first column is %q, want Sep", grid.Weeks[0].Month)
+	}
+	if grid.Weeks[1].Month != "Oct" {
+		t.Errorf("the column holding 1 October is %q, want Oct", grid.Weeks[1].Month)
+	}
+}
+
+// TestDaySeriesStartsAtRealReading: a sitting that was all pause leaves
+// a day behind without leaving any reading behind, and an all-time
+// chart should not open on it.
+func TestDaySeriesStartsAtRealReading(t *testing.T) {
+	now := time.Date(2026, 3, 10, 12, 0, 0, 0, time.UTC)
+	win := insights.SpanAllTime.Window(now, time.UTC)
+	cells := daySeries(win, map[string]float64{
+		"2026-01-01": 0,
+		"2026-03-08": 45,
+	}, now, time.UTC)
+	if len(cells) == 0 || cells[0].Date != "2026-03-08" {
+		t.Fatalf("the chart opens on %v, want 2026-03-08", cells[0].Date)
+	}
+}

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -10,15 +10,28 @@ import (
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/insights"
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
 // --- dashboard ---
 
+// handleDashboard draws the reading dashboard over the span the reader
+// picked.
+//
+// One span, one window, one read. The two separate reads this replaced —
+// thirty days for the numbers and year-to-date for the heatmap — could
+// describe different stretches of time on the same screen, and neither
+// of them was the stretch the reader had asked about, because there was
+// no way to ask.
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User) {
 	now := time.Now()
-	from := now.AddDate(0, 0, -30)
-	sessions, err := s.St.SessionsInRange(r.Context(), u.ID, from, now)
+	loc := userLoc(u)
+	span := dashboardSpan(w, r)
+	win := span.Window(now, loc)
+
+	from, to := win.SessionBounds(now, loc)
+	sessions, err := s.St.SessionsInRange(r.Context(), u.ID, from, to)
 	if err != nil {
 		http.Error(w, "internal", http.StatusInternalServerError)
 		return
@@ -29,72 +42,119 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request, a store
 		titles[ws.Work.ID] = orPlaceholder(ws.Work.Title)
 	}
 
-	var sum SummaryData
-	sum.RangeDays = 30
+	sum := SummaryData{
+		Span: span, RangeDays: win.Days(),
+		Bars: span.SuitsDailyBars(now, loc),
+	}
 	dayMin := map[string]float64{}
-	loc := userLoc(u)
 	for _, ses := range sessions {
-		active := sessionActiveSeconds(ses)
+		active := insights.ActiveSeconds(ses)
 		sum.ActiveMinutes += active / 60
 		sum.Sessions++
-		dayMin[ses.StartedAt.In(loc).Format("2006-01-02")] += active / 60
+		// By the day it ended, which is where the API and the app put
+		// it. A sitting read across midnight belongs to one day, and
+		// the three surfaces have to pick the same one.
+		dayMin[ses.EndedAt.In(loc).Format(insights.DayFormat)] += active / 60
 	}
-	if rollups, err := s.St.RollupsInRange(r.Context(), u.ID,
-		from.In(loc).Format("2006-01-02"), now.In(loc).Format("2006-01-02")); err == nil {
+	fromDay, toDay := win.DayBounds(now, loc)
+	if rollups, err := s.St.RollupsInRange(r.Context(), u.ID, fromDay, toDay); err == nil {
 		for _, ru := range rollups {
 			sum.ActiveMinutes += ru.ActiveSeconds / 60
 			sum.Sessions += int(ru.SessionCount)
+			sum.Pages += ru.Pages
 			dayMin[ru.Day] += ru.ActiveSeconds / 60
 		}
 	}
-	sum.StreakDays = streakFrom(dayMin, u, now)
+	// The streak is answered from further back than the span on
+	// purpose: asking about the last week must not report a
+	// months-long run as seven days.
+	sum.StreakDays = s.streakFor(r, u.ID, loc, now, dayMin)
 
-	// Year heatmap.
-	yearStart := time.Date(now.In(loc).Year(), 1, 1, 0, 0, 0, 0, loc)
-	yearSessions, err := s.St.SessionsInRange(r.Context(), u.ID, yearStart, now)
-	if err == nil {
-		yearMin := map[string]float64{}
-		for _, ses := range yearSessions {
-			yearMin[ses.StartedAt.In(loc).Format("2006-01-02")] +=
-				sessionActiveSeconds(ses) / 60
-		}
-		if rollups, err := s.St.RollupsInRange(r.Context(), u.ID,
-			yearStart.Format("2006-01-02"), now.In(loc).Format("2006-01-02")); err == nil {
-			for _, ru := range rollups {
-				yearMin[ru.Day] += ru.ActiveSeconds / 60
-			}
-		}
-		var heat []DayCell
-		for d := yearStart; !d.After(now); d = d.AddDate(0, 0, 1) {
-			heat = append(heat, DayCell{Date: d.Format("2006-01-02"), Minutes: yearMin[d.Format("2006-01-02")]})
-		}
-
-		// Recent sessions (10 newest in the 30d window).
-		var recent []SessionRow
-		for i := len(sessions) - 1; i >= 0 && len(recent) < 10; i-- {
-			ses := sessions[i]
-			recent = append(recent, SessionRow{
-				When:      ses.StartedAt.In(loc).Format("Jan 2 15:04"),
-				WorkID:    ses.WorkID,
-				WorkTitle: titles[ses.WorkID],
-				DeviceID:  ses.DeviceID,
-				Minutes:   int(ses.EndedAt.Sub(ses.StartedAt).Minutes()),
-				StartProg: ses.StartProg,
-				EndProg:   ses.EndProg,
-			})
-		}
-		links := s.workBookIDs(r.Context(), u.ID, works)
-		dashboard(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a),
-			sum, heat, recent,
-			s.markReadable(r, u.ID, continueReading(works, links.active, loc))).
-			Render(r.Context(), w)
-		return
-	}
 	links := s.workBookIDs(r.Context(), u.ID, works)
 	dashboard(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a),
-		sum, nil, nil,
+		sum,
+		daySeries(win, dayMin, now, loc),
+		recentSessions(sessions, titles, loc),
 		s.markReadable(r, u.ID, continueReading(works, links.active, loc))).
 		Render(r.Context(), w)
+}
+
+// daySeries is every day in the window, the empty ones included.
+//
+// A fortnight with two gaps in it is the information; a chart that
+// silently skipped them would read as an unbroken run.
+func daySeries(win insights.Window, dayMin map[string]float64, now time.Time, loc *time.Location) []DayCell {
+	earliest := ""
+	for day := range dayMin {
+		if earliest == "" || day < earliest {
+			earliest = day
+		}
+	}
+	var cells []DayCell
+	win.EachDay(earliest, now, loc, func(day string) {
+		cells = append(cells, DayCell{Date: day, Minutes: dayMin[day]})
+	})
+	return cells
+}
+
+// recentSessionLimit is how many sittings the table names one by one.
+// It is a glance at what has just been read, not a log; the log is the
+// per-work page.
+const recentSessionLimit = 10
+
+// recentSessions is the newest sittings in the window, newest first.
+func recentSessions(sessions []store.Session, titles map[string]string, loc *time.Location) []SessionRow {
+	rows := make([]SessionRow, 0, recentSessionLimit)
+	for i := len(sessions) - 1; i >= 0 && len(rows) < recentSessionLimit; i-- {
+		ses := sessions[i]
+		rows = append(rows, SessionRow{
+			When:      ses.EndedAt.In(loc).Format("Jan 2 15:04"),
+			WorkID:    ses.WorkID,
+			WorkTitle: titles[ses.WorkID],
+			DeviceID:  ses.DeviceID,
+			Minutes:   int(insights.ActiveSeconds(ses) / 60),
+			StartProg: ses.StartProg,
+			EndProg:   ses.EndProg,
+		})
+	}
+	return rows
+}
+
+// streakFor counts the reader's current run of days.
+//
+// It looks back over the whole lookback rather than over the span,
+// because a streak is a fact about the reader and not about the
+// question: narrowing it to the chosen span would report a
+// months-long run as seven days to anybody looking at their week.
+// The days already counted for the span are passed in so the common
+// case — a span that reaches back further than the run — needs no
+// second read.
+func (s *Server) streakFor(
+	r *http.Request, userID string, loc *time.Location, now time.Time, known map[string]float64,
+) int {
+	days := make(map[string]bool, len(known))
+	for day, minutes := range known {
+		if minutes > 0 {
+			days[day] = true
+		}
+	}
+	from := now.AddDate(0, 0, -insights.StreakLookbackDays)
+	if sessions, err := s.St.SessionsInRange(r.Context(), userID, from, now); err == nil {
+		for _, ses := range sessions {
+			if insights.ActiveSeconds(ses) > 0 {
+				days[ses.EndedAt.In(loc).Format(insights.DayFormat)] = true
+			}
+		}
+	}
+	if rollups, err := s.St.RollupsInRange(r.Context(), userID,
+		from.In(loc).Format(insights.DayFormat), now.In(loc).Format(insights.DayFormat)); err == nil {
+		for _, ru := range rollups {
+			if ru.ActiveSeconds > 0 {
+				days[ru.Day] = true
+			}
+		}
+	}
+	return insights.StreakDays(days, loc, now)
 }
 
 // continueReadingLimit is a shelf, not a list: the point is to get back
@@ -141,28 +201,6 @@ func userLoc(u *store.User) *time.Location {
 	return loc
 }
 
-func sessionActiveSeconds(ses store.Session) float64 {
-	active := ses.EndedAt.Sub(ses.StartedAt).Seconds() - float64(ses.IdleMs)/1000
-	if active < 0 {
-		return 0
-	}
-	return active
-}
-
-func streakFrom(dayMin map[string]float64, u *store.User, now time.Time) int {
-	loc := userLoc(u)
-	day := now.In(loc)
-	if dayMin[day.Format("2006-01-02")] == 0 {
-		day = day.AddDate(0, 0, -1)
-	}
-	streak := 0
-	for dayMin[day.Format("2006-01-02")] > 0 {
-		streak++
-		day = day.AddDate(0, 0, -1)
-	}
-	return streak
-}
-
 // --- works ---
 
 // markReadable says which of these works' books the browser reader can
@@ -197,7 +235,7 @@ func (s *Server) handleWork(w http.ResponseWriter, r *http.Request, a store.Auth
 	d.Sessions = len(sessions)
 	var progDelta float64
 	for _, ses := range sessions {
-		d.Minutes += sessionActiveSeconds(ses) / 60
+		d.Minutes += insights.ActiveSeconds(ses) / 60
 		if delta := ses.EndProg - ses.StartProg; delta > 0 {
 			progDelta += delta
 			if ses.EditionSHA != nil {
@@ -206,13 +244,17 @@ func (s *Server) handleWork(w http.ResponseWriter, r *http.Request, a store.Auth
 				}
 			}
 		}
-		if rollups, err := s.St.RollupsForWork(r.Context(), u.ID, workID); err == nil {
-			for _, ru := range rollups {
-				d.Sessions += int(ru.SessionCount)
-				d.Minutes += ru.ActiveSeconds / 60
-				d.Pages += ru.Pages
-				progDelta += ru.ProgDelta
-			}
+	}
+	// Once, not once per sitting. A work old enough for its early
+	// sessions to have been compacted counted its rolled-up totals
+	// again for every session it still holds in full, so the longer a
+	// book had been read the more wrong this page was about it.
+	if rollups, err := s.St.RollupsForWork(r.Context(), u.ID, workID); err == nil {
+		for _, ru := range rollups {
+			d.Sessions += int(ru.SessionCount)
+			d.Minutes += ru.ActiveSeconds / 60
+			d.Pages += ru.Pages
+			progDelta += ru.ProgDelta
 		}
 	}
 	ops, _ := s.St.Positions(r.Context(), u.ID, workID, 50)
@@ -248,7 +290,7 @@ func (s *Server) handleWork(w http.ResponseWriter, r *http.Request, a store.Auth
 			WorkID:    workID,
 			WorkTitle: wk.Title,
 			DeviceID:  ses.DeviceID,
-			Minutes:   int(sessionActiveSeconds(ses) / 60),
+			Minutes:   int(insights.ActiveSeconds(ses) / 60),
 			StartProg: ses.StartProg,
 			EndProg:   ses.EndProg,
 		})

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -31,10 +31,21 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request, a store
 	win := span.Window(now, loc)
 
 	from, to := win.SessionBounds(now, loc)
-	sessions, err := s.St.SessionsInRange(r.Context(), u.ID, from, to)
+	stored, err := s.St.SessionsInRange(r.Context(), u.ID, from, to)
 	if err != nil {
 		http.Error(w, "internal", http.StatusInternalServerError)
 		return
+	}
+	// SessionsInRange asks for an overlap, so it also answers with a
+	// sitting that began inside the span and ran out the far end of
+	// it. The window decides membership by the day a sitting ended,
+	// and it has to decide it here too or the totals count reading
+	// that has not happened yet.
+	sessions := make([]store.Session, 0, len(stored))
+	for _, ses := range stored {
+		if win.HoldsSession(ses) {
+			sessions = append(sessions, ses)
+		}
 	}
 	works, _ := s.St.ListWorks(r.Context(), u.ID)
 	titles := map[string]string{}
@@ -47,13 +58,23 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request, a store
 		Bars: span.SuitsDailyBars(now, loc),
 	}
 	dayMin := map[string]float64{}
+	pages := newPageCounter(s.St)
 	for _, ses := range sessions {
 		active := insights.ActiveSeconds(ses)
 		sum.ActiveMinutes += active / 60
 		sum.Sessions++
-		// By the day it ended, which is where the API and the app put
-		// it. A sitting read across midnight belongs to one day, and
-		// the three surfaces have to pick the same one.
+		sum.Pages += pages.of(r.Context(), ses)
+		// By the day it ended, which is where the app puts it and
+		// where the window draws its own edges. A sitting read across
+		// midnight belongs to one day, and the reader should find it
+		// on the same one wherever they look.
+		//
+		// A rollup is the exception, and knowingly: the materializer
+		// divides a crossing sitting between the days it touched, so
+		// once retention compacts that evening its minutes move off
+		// the end day. Making the two agree means changing how
+		// rollups are allocated, which is a change to stored data and
+		// to what the API answers, not to this page.
 		dayMin[ses.EndedAt.In(loc).Format(insights.DayFormat)] += active / 60
 	}
 	fromDay, toDay := win.DayBounds(now, loc)
@@ -68,7 +89,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request, a store
 	// The streak is answered from further back than the span on
 	// purpose: asking about the last week must not report a
 	// months-long run as seven days.
-	sum.StreakDays = s.streakFor(r, u.ID, loc, now, dayMin)
+	sum.StreakDays = s.streakFor(r, u.ID, loc, now, win, dayMin)
 
 	links := s.workBookIDs(r.Context(), u.ID, works)
 	dashboard(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a),
@@ -84,8 +105,15 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request, a store
 // A fortnight with two gaps in it is the information; a chart that
 // silently skipped them would read as an unbroken run.
 func daySeries(win insights.Window, dayMin map[string]float64, now time.Time, loc *time.Location) []DayCell {
+	// The days with nothing on them are what an unbounded span starts
+	// after, not what it starts at: a sitting that was all pause, or a
+	// rollup whose active time came to nothing, leaves a key behind
+	// without leaving any reading behind.
 	earliest := ""
-	for day := range dayMin {
+	for day, minutes := range dayMin {
+		if minutes <= 0 {
+			continue
+		}
 		if earliest == "" || day < earliest {
 			earliest = day
 		}
@@ -130,13 +158,19 @@ func recentSessions(sessions []store.Session, titles map[string]string, loc *tim
 // case — a span that reaches back further than the run — needs no
 // second read.
 func (s *Server) streakFor(
-	r *http.Request, userID string, loc *time.Location, now time.Time, known map[string]float64,
+	r *http.Request, userID string, loc *time.Location, now time.Time,
+	win insights.Window, known map[string]float64,
 ) int {
 	days := make(map[string]bool, len(known))
 	for day, minutes := range known {
 		if minutes > 0 {
 			days[day] = true
 		}
+	}
+	// An unbounded span has already read everything there is, so the
+	// lookback would be the same two queries over the same rows.
+	if win.Unbounded() {
+		return insights.StreakDays(days, loc, now)
 	}
 	from := now.AddDate(0, 0, -insights.StreakLookbackDays)
 	if sessions, err := s.St.SessionsInRange(r.Context(), userID, from, now); err == nil {

--- a/internal/webui/prefs.go
+++ b/internal/webui/prefs.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/chmouel/liseur-sync/internal/insights"
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
@@ -42,16 +43,25 @@ const (
 	seriesUngrouped = "series-ungrouped"
 )
 
+// spanTokenPrefix is how the dashboard's chosen span is written into
+// the cookie: "span-30d" and so on, so that an old cookie without one
+// falls through to the default like any other missing token.
+const spanTokenPrefix = "span-"
+
 // prefs is what the shell needs to know before it draws anything.
 type prefs struct {
 	Theme       string
 	View        string
 	GroupSeries bool
+	Span        insights.Span
 }
 
 // defaultPrefs is what a browser that has never said otherwise gets.
 func defaultPrefs() prefs {
-	return prefs{Theme: themeDark, View: viewGrid, GroupSeries: true}
+	return prefs{
+		Theme: themeDark, View: viewGrid, GroupSeries: true,
+		Span: insights.DefaultSpan,
+	}
 }
 
 // readPrefs reads the preference cookie, falling back to the defaults
@@ -73,6 +83,10 @@ func readPrefs(r *http.Request) prefs {
 			p.GroupSeries = true
 		case seriesUngrouped:
 			p.GroupSeries = false
+		default:
+			if raw, ok := strings.CutPrefix(part, spanTokenPrefix); ok {
+				p.Span = insights.ParseSpan(raw)
+			}
 		}
 	}
 	return p
@@ -84,8 +98,9 @@ func readPrefs(r *http.Request) prefs {
 // to the wrong path.
 func writePrefs(w http.ResponseWriter, r *http.Request, p prefs) {
 	http.SetCookie(w, &http.Cookie{
-		Name:     prefsCookie,
-		Value:    p.Theme + "." + p.View + "." + seriesPreference(p.GroupSeries),
+		Name: prefsCookie,
+		Value: p.Theme + "." + p.View + "." + seriesPreference(p.GroupSeries) +
+			"." + spanTokenPrefix + string(p.Span),
 		Path:     "/",
 		MaxAge:   365 * 24 * 60 * 60,
 		HttpOnly: false,
@@ -187,4 +202,34 @@ func themeGlyph(current string) string {
 	default:
 		return "◐"
 	}
+}
+
+// dashboardSpan is the span the dashboard should draw, and remembers it.
+//
+// A `span` in the query wins, so that a link to a particular stretch of
+// reading is a link to it and can be bookmarked, shared or opened with
+// scripting switched off. Without one the reader gets back whatever
+// they last looked at.
+//
+// This writes the preference cookie from a GET, where every mutation in
+// this UI otherwise carries the session's CSRF token. The exception is
+// deliberate and narrow: nothing on the server changes, no other user
+// can observe the result, and the very same request already renders the
+// span — the worst a forged link could do is what the link plainly says
+// it does. Making it a POST would cost a redirect and the shareable URL
+// and buy nothing. Theme, view mode and series grouping still go
+// through the CSRF-checked POST, because those are set from a control
+// that has no page of its own to render.
+func dashboardSpan(w http.ResponseWriter, r *http.Request) insights.Span {
+	p := readPrefs(r)
+	raw := r.URL.Query().Get("span")
+	if raw == "" {
+		return p.Span
+	}
+	span := insights.ParseSpan(raw)
+	if span != p.Span {
+		p.Span = span
+		writePrefs(w, r, p)
+	}
+	return span
 }

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -231,7 +231,14 @@ func (s *Server) Mount(mux *http.ServeMux, secure func(http.Handler) http.Handle
 	// directory with the other top-level pages and relative links
 	// resolve identically everywhere.
 	mux.Handle("GET /ui", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		redirectRel(w, "ui/", http.StatusMovedPermanently)
+		// Carry the query across: /ui?span=90d is a link somebody
+		// bookmarked, and a redirect that dropped it would answer a
+		// different question than the one that was asked.
+		to := "ui/"
+		if r.URL.RawQuery != "" {
+			to += "?" + r.URL.RawQuery
+		}
+		redirectRel(w, to, http.StatusMovedPermanently)
 	}))
 	mux.Handle("GET /ui/", sec(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/ui/" {

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -483,11 +483,70 @@ a.chip:hover { background: var(--primary); border-color: var(--primary); color: 
 }
 .bar span { display: block; height: 100%; background: var(--primary); }
 
-.heatmap {
-	display: grid; grid-template-rows: repeat(7, 1fr); grid-auto-flow: column;
-	gap: 3px; margin: .5rem 0;
+/* --------------------------------------------------- dashboard insights */
+
+.dashhead {
+	display: flex; align-items: end; justify-content: space-between;
+	gap: 1rem; margin: 0 0 .75rem; flex-wrap: wrap;
+}
+.dashhead h1 { font-size: 2rem; line-height: 1.1; margin: 0; }
+.dashhead .eyebrow { margin: 0 0 .15rem; }
+.spanpick { margin: 0; }
+.spanpick select { min-width: min(12rem, 44vw); }
+
+/* One bar a day, for the spans short enough to read that way. The row
+   stretches, so a week's seven bars are wide and a month's thirty-one
+   are narrow, and neither leaves a gap at the end. */
+.daybars {
+	display: flex; align-items: flex-end; gap: 3px;
+	margin: .5rem 0 0;
+}
+.daybar { flex: 1 1 0; min-width: 0; display: flex; flex-direction: column; gap: .35rem; }
+/* No track behind the bar. A full-height box on a day with no reading
+   in it reads as a bar in its own right, and the chart then says the
+   opposite of what happened; an empty day is a stub on the baseline. */
+.daybar-track { height: 6rem; display: flex; align-items: flex-end; }
+/* The height classes are the progress bars' percentage steps (.p0-.p100)
+   turned on their side; the CSP has no unsafe-inline, so a bar's height
+   has to be a class like every other measurement here. */
+.daybar-track > span {
+	width: 100%; align-self: flex-end;
+	border-radius: 3px 3px 0 0;
+}
+.daybar-track > .c0 { height: 2px; background: var(--surface-3) }
+.daybar-track > .p5 { height: 5% }
+.daybar-track > .p10 { height: 10% } .daybar-track > .p15 { height: 15% }
+.daybar-track > .p20 { height: 20% } .daybar-track > .p25 { height: 25% }
+.daybar-track > .p30 { height: 30% } .daybar-track > .p35 { height: 35% }
+.daybar-track > .p40 { height: 40% } .daybar-track > .p45 { height: 45% }
+.daybar-track > .p50 { height: 50% } .daybar-track > .p55 { height: 55% }
+.daybar-track > .p60 { height: 60% } .daybar-track > .p65 { height: 65% }
+.daybar-track > .p70 { height: 70% } .daybar-track > .p75 { height: 75% }
+.daybar-track > .p80 { height: 80% } .daybar-track > .p85 { height: 85% }
+.daybar-track > .p90 { height: 90% } .daybar-track > .p95 { height: 95% }
+.daybar-track > .p100 { height: 100% }
+.daybar-cap {
+	font-size: .65rem; color: var(--muted); text-align: center;
+	white-space: nowrap; overflow: hidden; min-height: 1em;
+}
+
+/* Weeks run down the columns and weekdays across the rows, so the grid
+   reads like a wall calendar. It scrolls rather than shrinking: a year
+   of 11px squares is wider than a phone, and squeezing them would cost
+   the one thing the picture has, which is that a square is a day. */
+.heatwrap { overflow-x: auto; margin: .5rem 0 0; padding-bottom: .25rem; }
+.heatmap { display: flex; gap: 3px; width: max-content; }
+.heatweek { width: 11px; display: flex; flex-direction: column; gap: 3px; }
+.heatdays { display: grid; grid-template-rows: repeat(7, 11px); gap: 3px; }
+/* The label is wider than the column it names and is allowed to say so:
+   it runs on over the columns to its right, which are the rest of that
+   same month. */
+.heatmonth {
+	font-size: .65rem; line-height: 1; height: 1em;
+	color: var(--muted); white-space: nowrap;
 }
 .cell { width: 11px; height: 11px; border-radius: 2px; background: var(--surface-3); }
+.cell.blank { background: none; }
 .cell.c1 { background: var(--c1); } .cell.c2 { background: var(--c2); }
 .cell.c3 { background: var(--c3); } .cell.c4 { background: var(--c4); }
 

--- a/internal/webui/static/ui.js
+++ b/internal/webui/static/ui.js
@@ -31,19 +31,27 @@
     }
   });
 
-  // Choosing a library goes there at once. Without this the form still
-  // works — the <noscript> button submits it — so this is the same
-  // behaviour the onchange attribute used to give, minus the attribute
-  // the CSP now refuses.
+  // Choosing a library, or a span on the dashboard, goes there at once.
+  // Without this the forms still work — their <noscript> buttons submit
+  // them — so this is the same behaviour the onchange attribute used to
+  // give, minus the attribute the CSP now refuses.
+  const goOnChange = ['folder-pick', 'span-pick'];
   document.addEventListener('change', function (e) {
     const select = e.target;
-    if (select && select.id === 'library-pick' && select.form) {
+    if (!select || !select.form) return;
+    if (goOnChange.indexOf(select.id) !== -1) {
       select.form.submit();
       return;
     }
-    if (select && select.id === 'group-series-toggle' && select.form) {
+    if (select.id === 'group-series-toggle') {
       select.form.requestSubmit();
     }
+  });
+
+  // The heatmap opens at its far end: the reader came to see how this
+  // week went, not how last January did.
+  document.querySelectorAll('[data-scroll-end]').forEach(function (el) {
+    el.scrollLeft = el.scrollWidth;
   });
 
 })();

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -223,10 +223,15 @@ func TestAuthFlowAndPages(t *testing.T) {
 			}
 		}
 	}
-	// Dashboard shows the heatmap and stat cards.
+	// Dashboard shows the day chart, the stat cards and the span picker.
+	// Thirty days is the default span, which is drawn as bars; the
+	// heatmap has its own test below.
 	_, body = page(t, ts, cookie, "/ui")
-	if !strings.Contains(body, "heatmap") || !strings.Contains(body, "day streak") {
-		t.Fatal("dashboard missing heatmap/stats")
+	if !strings.Contains(body, "daybars") || !strings.Contains(body, "day streak") {
+		t.Fatal("dashboard missing chart/stats")
+	}
+	if !strings.Contains(body, `id="span-pick"`) {
+		t.Fatal("dashboard missing the span picker")
 	}
 	// The admin tab is forbidden to an ordinary account, and the rail does
 	// not advertise it in the first place.


### PR DESCRIPTION
The app and the API both answer reading insights over whatever stretch of time the reader names. The dashboard at `/ui` never got that: thirty days for the numbers, January the first to now for the calendar, and no way to ask for anything else.

It also disagreed about when a sitting happened. A session that ran past midnight was counted here on the day it started, and in the app on the day it ended, so the same evening's reading landed on different days depending on which screen you looked at.

## What changed

Both of those follow from the same cause: the span vocabulary lived in `internal/api`, and the web UI kept its own near-copy of `activeSeconds` and `streakDays`. So the shared parts move into a new `internal/insights` package that both surfaces use, along with the fixed menu of spans the pickers offer. The API's behaviour does not move; `go test ./internal/api/` runs unchanged.

On the dashboard that becomes one window rather than two. Sessions and rollups are read once for the span the reader picked, filtered by the same `HoldsSession` rule the API uses, placed on the day they ended, with the empty days kept, because a fortnight with two gaps in it is the information. The streak still reaches back past the span, because a streak is a fact about the reader rather than about the question, and the card now says so.

Short spans are drawn as one bar a day and long ones as a calendar with weekday-aligned columns, month labels in the column holding the first of the month, and a scroll that opens at the far end. Bar heights are the existing percentage classes rather than inline styles: ADR-0011 banned style attributes and the CSP has no `unsafe-inline`.

The choice rides in `?span=` so a stretch of reading can be bookmarked, and in the `liseur_ui` cookie so a bare `/ui` opens where you left off. `/ui?span=90d` keeps its query across the redirect to `/ui/`.

The span cookie is written from a GET, which is the one exception to this UI's rule that mutations carry the CSRF token. It changes nothing on the server, nothing another user can observe, and the same request already renders the span; the rationale is in a comment on `dashboardSpan`.

## Known divergence

Raw sessions are placed on the day they ended; a rollup was divided between the days it touched when the materializer made it. So an evening that crossed midnight moves once retention compacts it. Making the two agree means changing how rollups are allocated, which changes stored data and what the API answers, so it is written down at the point where the placement happens rather than patched here.

## Drive-by fixes

`RollupsForWork` was called inside the loop over the sessions a work still holds in full, so a work with twelve current sittings counted its compacted history twelve times. `TestWorkCountsRollupsOnce` pins it.

The page card was fed only by rollups, so a reader whose history had not been compacted yet saw no pages at all. It now does the same progression-times-page-count arithmetic the API and the work page do, with the editions cached for the request.

## Tests

New `internal/insights` tests for the window and span arithmetic, and `internal/webui/dashboardspan_ext_test.go` for the picker round-trip, the unknown-span fallback, cookie memory, query-beats-cookie, end-day placement, sittings running out the far end of the span, page counting, the bars/calendar boundary, weekday alignment, month labelling and the empty days.

`gofmt`, `go vet ./...`, `golangci-lint run ./...` (0 issues) and `go test -race` on the affected packages all pass.

## What it looks like

A year of seeded reading with the gaps a real year has, shot at 1440px.

**Last 7 days** — every bar captioned, and an empty day is a stub on the baseline rather than a grey box that reads as a bar of its own.

![span-7d.png](https://github.com/user-attachments/assets/06fe2204-fec5-4aca-9b86-e9c20ff096af)

**Last 30 days** — one caption a week, counted back from the end so today always carries its own.

![span-30d.png](https://github.com/user-attachments/assets/b8c6f644-020e-4199-a649-50c158527d6a)

**Last 90 days** — past the point where bars are readable, so the calendar takes over.

![span-90d.png](https://github.com/user-attachments/assets/cf9c9d71-b567-4bf0-94d3-80dc8fb7ada8)

**Last 365 days** — weekday-aligned columns, one label a month.

![span-365d.png](https://github.com/user-attachments/assets/5afb1eb7-97be-4675-8a72-ce130778af9f)

**All time** — starts at the first day with reading on it, not at the epoch.

![span-all.png](https://github.com/user-attachments/assets/73f5fdfb-2105-4494-8d77-faf057184a93)
