### PR TITLE
feat: sync annotations across devices (ADR-0028)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -753,11 +753,14 @@ mutates the watched tree.
   additive.
 - **Cross-user shared works / social features**: deliberately excluded,
   privacy-sensitive and design-heavy.
-- **Annotation sync** is designed in
+- **Annotation sync** shipped as designed in
   [ADR-0028](adr/0028-annotation-sync.md): highlights, notes and
   bookmarks as mutable per-user state beside the op log, with rev-based
-  conflicts, bounded tombstones and their own delta feed. Not built in
-  v1.
+  compare-and-set, bounded tombstones and their own delta feed
+  (`POST /v1/annotations`, `GET /v1/annotations/changes`,
+  `GET /v1/works/{id}/annotations`, `DELETE /v1/annotations/{id}`).
+  The web reader renders them view-only; editing from the web, import
+  and export remain future work.
 - **calibre-web / Komga bridging**: the server pulling positions from a
   remote catalog on the user's behalf. Liseur already handles this
   client-side.

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -260,6 +260,83 @@ devices, and the last op you acknowledged as baseline. Liseur's
 implementation (`domain/ReadingStateMerge.kt`) is the reference; the
 protocol is shaped so that logic transfers unchanged.
 
+## Annotations
+
+Highlights, notes and bookmarks sync too (ADR-0028), and they are the
+one *mutable* kind of reading state: an annotation is a record with a
+stable client-chosen `id` and a server-held `rev`, and every write is a
+compare-and-set against that rev. A create sends `base_rev: 0`; an edit
+sends the rev you read. Like ops, they need only the `sync` scope, and
+`device_id` comes from your token.
+
+```json
+POST /v1/annotations
+{
+  "annotations": [{
+    "id": "018e6f20-…",
+    "base_rev": 0,
+    "work_id": "…",
+    "edition_sha": "…",
+    "kind": "highlight",
+    "locator": { "href": "…", "locations": { "…": "…" } },
+    "progression": 0.413,
+    "excerpt": "the sea was calm",
+    "color": "yellow",
+    "client_ts": "2026-07-13T10:00:00Z"
+  }]
+}
+-> { "results": [{ "id": "018e6f20-…", "status": "applied", "rev": 1, "seq": 7 }] }
+```
+
+The kinds carve up the fields: a **highlight** anchors to the text
+(`locator` required) and may carry a `body`; a **bookmark** is an
+anchor with no body; a **note** is a body with no anchor. `color` is a
+token from a fixed palette (`yellow, green, blue, pink, purple,
+orange`), highlights only, never CSS. Excerpts are capped at 1 KiB and
+bodies at 16 KiB by default.
+
+The rev dance:
+
+- A byte-identical retry of your last write answers `duplicate` with
+  the stored rev and seq — interrupted pushes are free to repeat.
+- Any other stale `base_rev` answers a per-item `conflict` carrying the
+  server's current copy. The server orders; it never merges. Show the
+  user both, or take the server copy and reapply — your call, then push
+  again from the new rev.
+- The batch is never atomic: one bad item fails alone, whatever its
+  problem — a shape error (bad kind, oversized field, a color off the
+  palette) and a bad reference (unknown work, per-work cap) both come
+  back as a per-item `invalid` with the reason. Only a request nothing
+  in it can excuse is refused whole: malformed JSON, an empty or
+  oversized batch (`400`), or a body larger than any legal batch could
+  need (`413`).
+
+Delete with the rev you read; a mismatch is a 409 with the server copy:
+
+```
+DELETE /v1/annotations/{id}?rev=3
+-> { "id": "…", "status": "applied", "rev": 4, "seq": 21 }
+```
+
+Pull with a cursor, exactly like `/v1/changes` but on its own counter:
+
+```
+GET /v1/annotations/changes?since=<cursor>&limit=500
+-> { "annotations": [...], "high_water": 42, "has_more": false }
+```
+
+This feed is *state*, not history: an edit moves the record to the head
+with its current content, so key by `id` and let the highest rev win.
+Deletes appear as tombstones — `id`, `rev`, `seq`, `deleted: true`,
+`deleted_at` and nothing else. Tombstones are swept after 180 days by
+default; a device offline longer than that must reconcile its local set
+against `GET /v1/works/{id}/annotations` (the live set, sorted by
+progression) rather than trust the delta feed alone — an annotation the
+feed no longer mentions and the live set does not contain is gone.
+
+Positions and annotations never mix: `/v1/changes` stays ops-only, and
+annotation writes do not move the op high-water.
+
 ## Reading sessions
 
 Report what you measured at the time of reading:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -622,6 +622,143 @@ paths:
             to refresh its cached identity, then retry.
         "409": { $ref: "#/components/responses/Error", description: "session_id reused with different payload" }
 
+  /v1/annotations:
+    post:
+      tags: [sync]
+      summary: Push a batch of annotations (highlights, notes, bookmarks)
+      description: |
+        Annotations are the mutable kind of reading state (ADR-0028):
+        each record carries a `rev`, and every write is a compare-and-set
+        against it. A create sends `base_rev: 0`; an edit sends the rev
+        it read. A byte-identical retry of the last write is `duplicate`
+        and acknowledged with the stored rev and seq; any other stale
+        `base_rev` is a per-item `conflict` carrying the server's copy —
+        the server orders, it never merges. The batch is never atomic:
+        one bad item fails alone, whether its problem is shape (bad
+        kind, oversized excerpt or body, a color off the palette, a
+        locator on a note) or reference (unknown work, per-work cap) —
+        both come back as per-item `invalid` results with a reason.
+        Only a request nothing in it can excuse is refused whole:
+        malformed JSON, an empty batch or one over 100 items (400), or
+        a body larger than any legal batch could need (413).
+        `device_id` is taken from the token.
+      security: [{ deviceToken: [] }]  # requires sync scope
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [annotations]
+              properties:
+                annotations:
+                  type: array
+                  maxItems: 100
+                  items: { $ref: "#/components/schemas/AnnotationInput" }
+      responses:
+        "200":
+          description: Per-item results (valid items applied even if others conflict)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  results:
+                    type: array
+                    items: { $ref: "#/components/schemas/AnnotationResult" }
+        "400": { $ref: "#/components/responses/Error" }
+        "413": { $ref: "#/components/responses/Error" }
+
+  /v1/annotations/changes:
+    get:
+      tags: [sync]
+      summary: Delta-sync annotations after a seq
+      description: |
+        The annotation feed is *state*, not history: it has its own
+        per-user seq counter, separate from the op log, and an edit or
+        delete moves the record to the head of the feed with its current
+        content. Tombstones are included, carrying identity, `rev`,
+        `seq` and `deleted_at` and nothing else; after the retention
+        window they are swept, so a device offline longer than that
+        reconciles against the live set instead. `/v1/changes` remains
+        positions-only.
+      security: [{ deviceToken: [] }]  # requires sync scope
+      parameters:
+        - { name: since, in: query, schema: { type: integer, default: 0 } }
+        - { name: limit, in: query, schema: { type: integer, default: 500, maximum: 500 } }
+      responses:
+        "200":
+          description: Page of annotations with the new high-water mark
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  annotations:
+                    type: array
+                    items: { $ref: "#/components/schemas/Annotation" }
+                  high_water: { type: integer }
+                  has_more: { type: boolean }
+
+  /v1/annotations/{id}:
+    delete:
+      tags: [sync]
+      summary: Delete an annotation (tombstone, rev-checked)
+      security: [{ deviceToken: [] }]  # requires sync scope
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+        - name: rev
+          in: query
+          required: true
+          description: The rev the client read; the delete applies iff it is current.
+          schema: { type: integer, minimum: 1 }
+      responses:
+        "200":
+          description: Tombstone written (`applied`), or the record was already deleted (`duplicate`)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string }
+                  status: { type: string, enum: [applied, duplicate] }
+                  rev: { type: integer }
+                  seq: { type: integer }
+        "400": { $ref: "#/components/responses/Error" }
+        "404": { $ref: "#/components/responses/Error" }
+        "409":
+          description: Stale rev; the body carries the server's current copy under `server`.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+                  server: { $ref: "#/components/schemas/Annotation" }
+
+  /v1/works/{id}/annotations:
+    get:
+      tags: [sync]
+      summary: Live annotations for a work
+      description: |
+        The live set only — no tombstones — ordered by progression, then
+        `client_ts` (records without a progression sort last).
+      security: [{ deviceToken: [] }]  # requires sync scope
+      parameters:
+        - { name: id, in: path, required: true, schema: { type: string } }
+      responses:
+        "200":
+          description: Live annotations
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  annotations:
+                    type: array
+                    items: { $ref: "#/components/schemas/Annotation" }
+        "404": { $ref: "#/components/responses/Error" }
+
   /v1/insights/summary:
     get:
       tags: [insights]
@@ -2572,3 +2709,83 @@ components:
         start_progression: { type: number, minimum: 0, maximum: 1 }
         end_progression: { type: number, minimum: 0, maximum: 1 }
         idle_ms: { type: integer, minimum: 0, description: "Reader-visible idle time, excluded from speed" }
+    AnnotationInput:
+      type: object
+      required: [id, base_rev, work_id, kind, client_ts]
+      properties:
+        id:
+          type: string
+          maxLength: 64
+          description: |
+            Client-generated identity, opaque to the server, stable for
+            the record's whole life across edits and the delete. Unlike
+            an `op_id` it names a mutable record, not one write.
+        base_rev:
+          type: integer
+          minimum: 0
+          description: |
+            The rev this write was based on: 0 to create, the rev the
+            client read to edit. A mismatch is a per-item `conflict`.
+        work_id: { type: string, maxLength: 128, description: "From /v1/works/resolve" }
+        edition_sha: { type: string, maxLength: 128, description: "sha256 of the exact file the locator was made against, if known" }
+        kind:
+          type: string
+          enum: [highlight, note, bookmark]
+          description: |
+            A highlight anchors to the text and may carry a body; a
+            bookmark is an anchor with no body; a note is a body with no
+            anchor.
+        locator:
+          description: |
+            Any JSON reader-native anchor (for example, a Readium
+            locator), opaque to the server and replayed verbatim.
+            Required for a highlight or bookmark, refused on a note,
+            bounded by `ops.max_locator_bytes`. A JSON `null` counts
+            as absent.
+        progression: { type: number, minimum: 0, maximum: 1, description: "Position in the book, used only to sort" }
+        excerpt:
+          type: string
+          maxLength: 1024
+          description: The selected text a highlight shows in a list, bounded (1 KiB by default).
+        color:
+          type: string
+          enum: [yellow, green, blue, pink, purple, orange]
+          description: A palette token, never CSS; highlights only.
+        body:
+          type: string
+          description: The user's own words, bounded (16 KiB by default).
+        client_ts: { type: string, format: date-time, maxLength: 64 }
+    Annotation:
+      type: object
+      description: |
+        One annotation as the server holds it. A tombstone carries only
+        `id`, `rev`, `seq`, `updated_at`, `deleted` and `deleted_at`.
+      required: [id, rev]
+      properties:
+        id: { type: string }
+        rev: { type: integer }
+        seq: { type: integer, description: "Server-assigned per-user monotonic sequence, separate from the op log" }
+        work_id: { type: string }
+        edition_sha: { type: string }
+        kind: { type: string, enum: [highlight, note, bookmark] }
+        locator: { description: "The anchor, verbatim as pushed" }
+        progression: { type: number, minimum: 0, maximum: 1 }
+        excerpt: { type: string }
+        color: { type: string, enum: [yellow, green, blue, pink, purple, orange] }
+        body: { type: string }
+        device_id: { type: string }
+        client_ts: { type: string, format: date-time }
+        updated_at: { type: string, format: date-time }
+        deleted: { type: boolean }
+        deleted_at: { type: string, format: date-time }
+    AnnotationResult:
+      type: object
+      properties:
+        id: { type: string }
+        status: { type: string, enum: [applied, duplicate, conflict, invalid] }
+        rev: { type: integer, description: When applied or duplicate }
+        seq: { type: integer, description: When applied or duplicate }
+        reason: { type: string, description: When invalid }
+        server:
+          allOf: [{ $ref: "#/components/schemas/Annotation" }]
+          description: The server's current copy, carried on a conflict.

--- a/internal/api/annotations.go
+++ b/internal/api/annotations.go
@@ -1,0 +1,369 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// annotationJSON is the wire shape of an annotation (ADR-0028). A
+// tombstone carries nothing but identity, rev, seq and when, which is
+// why almost everything here is omitempty.
+type annotationJSON struct {
+	ID          string          `json:"id"`
+	Rev         int64           `json:"rev"`
+	Seq         int64           `json:"seq,omitempty"`
+	WorkID      string          `json:"work_id,omitempty"`
+	EditionSHA  *string         `json:"edition_sha,omitempty"`
+	Kind        string          `json:"kind,omitempty"`
+	Locator     json.RawMessage `json:"locator,omitempty"`
+	Progression *float64        `json:"progression,omitempty"`
+	Excerpt     string          `json:"excerpt,omitempty"`
+	Color       string          `json:"color,omitempty"`
+	Body        string          `json:"body,omitempty"`
+	DeviceID    string          `json:"device_id,omitempty"`
+	ClientTS    string          `json:"client_ts,omitempty"`
+	UpdatedAt   string          `json:"updated_at,omitempty"`
+	Deleted     bool            `json:"deleted,omitempty"`
+	DeletedAt   string          `json:"deleted_at,omitempty"`
+}
+
+const wireTimeFormat = "2006-01-02T15:04:05.999999999Z"
+
+func annotationToJSON(a store.Annotation) annotationJSON {
+	out := annotationJSON{
+		ID:        a.ID,
+		Rev:       a.Rev,
+		Seq:       a.Seq,
+		UpdatedAt: a.UpdatedAt.UTC().Format(wireTimeFormat),
+	}
+	if a.Deleted() {
+		// A tombstone carries nothing but identity, rev, seq and when
+		// — not even the work it hung on.
+		out.Deleted = true
+		out.DeletedAt = a.DeletedAt.UTC().Format(wireTimeFormat)
+		return out
+	}
+	out.WorkID = a.WorkID
+	out.EditionSHA = a.EditionSHA
+	out.Kind = string(a.Kind)
+	out.Progression = a.Progression
+	out.Excerpt = a.Excerpt
+	out.Color = a.Color
+	out.Body = a.Body
+	out.DeviceID = a.DeviceID
+	out.ClientTS = a.ClientTS.UTC().Format(wireTimeFormat)
+	if len(a.LocatorJSON) > 0 {
+		out.Locator = json.RawMessage(a.LocatorJSON)
+	}
+	return out
+}
+
+// annotationWriteJSON is one item of a batched push.
+type annotationWriteJSON struct {
+	ID          string          `json:"id"`
+	BaseRev     int64           `json:"base_rev"`
+	WorkID      string          `json:"work_id"`
+	EditionSHA  *string         `json:"edition_sha,omitempty"`
+	Kind        string          `json:"kind"`
+	Locator     json.RawMessage `json:"locator,omitempty"`
+	Progression *float64        `json:"progression,omitempty"`
+	Excerpt     string          `json:"excerpt,omitempty"`
+	Color       string          `json:"color,omitempty"`
+	Body        string          `json:"body,omitempty"`
+	ClientTS    string          `json:"client_ts"`
+}
+
+// validateAnnotationWrite bounds one push item at the handler edge.
+// Empty means valid; anything else is the 400 reason.
+func (s *Server) validateAnnotationWrite(in annotationWriteJSON) (store.AnnotationWrite, string) {
+	var out store.AnnotationWrite
+	// A JSON null is an absent locator, not an anchor: RawMessage
+	// holds "null" as four bytes, and four bytes must not satisfy a
+	// highlight's locator requirement.
+	if len(bytes.TrimSpace(in.Locator)) == 0 || bytes.Equal(bytes.TrimSpace(in.Locator), []byte("null")) {
+		in.Locator = nil
+	}
+	if in.ID == "" || len(in.ID) > 64 {
+		return out, "id required (at most 64 bytes)"
+	}
+	if in.BaseRev < 0 {
+		return out, "base_rev must be >= 0"
+	}
+	if in.WorkID == "" || len(in.WorkID) > annotationMaxRefBytes {
+		return out, "work_id required (at most 128 bytes)"
+	}
+	if in.EditionSHA != nil && len(*in.EditionSHA) > annotationMaxRefBytes {
+		return out, "edition_sha too large"
+	}
+	kind := store.AnnotationKind(in.Kind)
+	if !kind.Valid() {
+		return out, "kind must be highlight, note or bookmark"
+	}
+	switch kind {
+	case store.AnnotationNote:
+		// A standalone note is a body with no anchor.
+		if len(in.Locator) > 0 {
+			return out, "a note carries no locator"
+		}
+		if in.Body == "" {
+			return out, "a note requires a body"
+		}
+	default:
+		// A highlight or bookmark anchors to the text.
+		if len(in.Locator) == 0 {
+			return out, string(kind) + " requires a locator"
+		}
+	}
+	if kind == store.AnnotationBookmark && in.Body != "" {
+		return out, "a bookmark carries no body"
+	}
+	if len(in.Locator) > s.Cfg.Ops.MaxLocatorBytes {
+		return out, "locator too large"
+	}
+	if in.Progression != nil && (*in.Progression < 0 || *in.Progression > 1) {
+		return out, "progression out of range [0,1]"
+	}
+	if len(in.Excerpt) > s.Cfg.Ops.AnnotationMaxExcerptBytes {
+		return out, "excerpt too large"
+	}
+	if len(in.Body) > s.Cfg.Ops.AnnotationMaxBodyBytes {
+		return out, "body too large"
+	}
+	if !store.ValidAnnotationColor(in.Color) {
+		return out, "color must be one of the palette tokens"
+	}
+	if in.Color != "" && kind != store.AnnotationHighlight {
+		return out, "color belongs to a highlight"
+	}
+	ts, err := time.Parse(time.RFC3339Nano, in.ClientTS)
+	if err != nil || len(in.ClientTS) > annotationMaxClientTSBytes {
+		return out, "bad client_ts"
+	}
+	if ts.After(time.Now().Add(24 * time.Hour)) {
+		return out, "client_ts in the future"
+	}
+	return store.AnnotationWrite{
+		ID:          in.ID,
+		BaseRev:     in.BaseRev,
+		WorkID:      in.WorkID,
+		EditionSHA:  in.EditionSHA,
+		Kind:        kind,
+		LocatorJSON: in.Locator,
+		Progression: in.Progression,
+		Excerpt:     in.Excerpt,
+		Color:       in.Color,
+		Body:        in.Body,
+		ClientTS:    ts,
+	}, ""
+}
+
+// annotationMaxRefBytes bounds the identifiers a push may quote
+// (work_id, edition_sha): a sha256 hex is 64 bytes, and no id this
+// server mints is longer, so 128 is generous without letting an
+// identifier column carry a payload.
+const annotationMaxRefBytes = 128
+
+// annotationMaxClientTSBytes bounds `client_ts`: a full RFC3339 stamp
+// with nanoseconds and a zone offset is 35 bytes, but Go accepts
+// arbitrarily long fractional seconds, so without a cap the one
+// "small" field would be the unbounded one.
+const annotationMaxClientTSBytes = 64
+
+// annotationMaxRequestBytes sizes the push route's body cap from the
+// documented per-item and per-batch bounds, so a batch every one of
+// whose items obeys them always fits: the per-field caps are the
+// contract, not a shared envelope that quietly undercuts them. The
+// decoded string caps are multiplied by JSON's worst-case escaping
+// expansion (`\u00XX`, six wire bytes per decoded byte); the locator
+// cap is already measured in wire bytes and passes through as is.
+func (s *Server) annotationMaxRequestBytes() int64 {
+	const escape = 6
+	perItem := escape*int64(s.Cfg.Ops.AnnotationMaxBodyBytes+
+		s.Cfg.Ops.AnnotationMaxExcerptBytes+
+		64+2*annotationMaxRefBytes+ // id, work_id, edition_sha
+		annotationMaxClientTSBytes) +
+		int64(s.Cfg.Ops.MaxLocatorBytes) +
+		1024 // keys, revs, progression, color, punctuation
+	return int64(s.Cfg.Ops.AnnotationMaxBatch) * perItem
+}
+
+// HandlePushAnnotations implements POST /v1/annotations — batched,
+// compare-and-set on rev, never atomic: the response is 200 with one
+// result per item, and one bad item fails alone, whether its problem
+// is shape (an oversized body, a color off the palette) or reference
+// (a stale rev, an unknown work, the per-work cap). The token's
+// server-side device_id stamps every record.
+func (s *Server) HandlePushAnnotations(w http.ResponseWriter, r *http.Request) {
+	tok, _ := auth.TokenFrom(r)
+	var body struct {
+		Annotations []json.RawMessage `json:"annotations"`
+	}
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, s.annotationMaxRequestBytes())).Decode(&body); err != nil {
+		var tooBig *http.MaxBytesError
+		if errors.As(err, &tooBig) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if len(body.Annotations) == 0 {
+		writeError(w, http.StatusBadRequest, "annotations required")
+		return
+	}
+	if len(body.Annotations) > s.Cfg.Ops.AnnotationMaxBatch {
+		writeError(w, http.StatusBadRequest, "batch too large")
+		return
+	}
+
+	type item struct {
+		ID     string          `json:"id"`
+		Status string          `json:"status"`
+		Rev    int64           `json:"rev,omitempty"`
+		Seq    int64           `json:"seq,omitempty"`
+		Reason string          `json:"reason,omitempty"`
+		Server *annotationJSON `json:"server,omitempty"`
+	}
+	out := struct {
+		Results []item `json:"results"`
+	}{Results: make([]item, len(body.Annotations))}
+
+	// Shape errors are per-item results like every other failure —
+	// the ADR's contract is that one bad item fails alone. That
+	// includes an item the decoder itself chokes on (a string where a
+	// number belongs, an overflowing rev), which is why each element
+	// is unmarshalled on its own: the invalid ones are answered here
+	// and only the rest reach the store, keeping their positions in
+	// the response.
+	items := make([]store.AnnotationWrite, 0, len(body.Annotations))
+	itemPos := make([]int, 0, len(body.Annotations))
+	for i, raw := range body.Annotations {
+		var in annotationWriteJSON
+		if err := json.Unmarshal(raw, &in); err != nil {
+			// Best effort at naming the item it refuses.
+			var probe struct {
+				ID string `json:"id"`
+			}
+			_ = json.Unmarshal(raw, &probe)
+			out.Results[i] = item{ID: probe.ID, Status: "invalid", Reason: "malformed annotation"}
+			continue
+		}
+		parsed, reason := s.validateAnnotationWrite(in)
+		if reason != "" {
+			out.Results[i] = item{ID: in.ID, Status: "invalid", Reason: reason}
+			continue
+		}
+		items = append(items, parsed)
+		itemPos = append(itemPos, i)
+	}
+
+	if len(items) > 0 {
+		results, err := s.St.PushAnnotations(r.Context(), tok.UserID, tok.DeviceID, items, s.Cfg.Ops.AnnotationMaxPerWork)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "push failed")
+			return
+		}
+		for j, res := range results {
+			entry := item{ID: res.ID, Status: res.Status, Rev: res.Rev, Seq: res.Seq, Reason: res.Reason}
+			if res.Server != nil {
+				server := annotationToJSON(*res.Server)
+				entry.Server = &server
+			}
+			out.Results[itemPos[j]] = entry
+		}
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// HandleAnnotationChanges implements
+// GET /v1/annotations/changes?since=<seq>&limit=<n> — the delta pull,
+// same page contract as /v1/changes, tombstones included.
+// /v1/changes itself remains positions-only.
+func (s *Server) HandleAnnotationChanges(w http.ResponseWriter, r *http.Request) {
+	tok, _ := auth.TokenFrom(r)
+	since, _ := strconv.ParseInt(r.URL.Query().Get("since"), 10, 64)
+	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+	if limit <= 0 || limit > 500 {
+		limit = 500
+	}
+	page, err := s.St.AnnotationChanges(r.Context(), tok.UserID, since, limit)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "changes failed")
+		return
+	}
+	out := struct {
+		Annotations []annotationJSON `json:"annotations"`
+		HighWater   int64            `json:"high_water"`
+		HasMore     bool             `json:"has_more"`
+	}{HighWater: page.HighWater, HasMore: page.HasMore, Annotations: []annotationJSON{}}
+	for _, a := range page.Annotations {
+		out.Annotations = append(out.Annotations, annotationToJSON(a))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// HandleWorkAnnotations implements GET /v1/works/{id}/annotations —
+// the live set for one work, ordered by progression then client_ts.
+func (s *Server) HandleWorkAnnotations(w http.ResponseWriter, r *http.Request) {
+	tok, _ := auth.TokenFrom(r)
+	workID := r.PathValue("id")
+	if _, err := s.St.WorkByID(r.Context(), tok.UserID, workID); err != nil {
+		writeError(w, http.StatusNotFound, "work not found")
+		return
+	}
+	list, err := s.St.WorkAnnotations(r.Context(), tok.UserID, workID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "annotations failed")
+		return
+	}
+	out := struct {
+		Annotations []annotationJSON `json:"annotations"`
+	}{Annotations: []annotationJSON{}}
+	for _, a := range list {
+		out.Annotations = append(out.Annotations, annotationToJSON(a))
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// HandleDeleteAnnotation implements DELETE /v1/annotations/{id}?rev=N —
+// writes the tombstone iff rev matches, 409 with the server copy
+// otherwise; deleting a tombstone is already accepted.
+func (s *Server) HandleDeleteAnnotation(w http.ResponseWriter, r *http.Request) {
+	tok, _ := auth.TokenFrom(r)
+	id := r.PathValue("id")
+	rev, err := strconv.ParseInt(r.URL.Query().Get("rev"), 10, 64)
+	if err != nil || rev < 1 {
+		writeError(w, http.StatusBadRequest, "rev query parameter required")
+		return
+	}
+	res, err := s.St.DeleteAnnotation(r.Context(), tok.UserID, id, rev)
+	if errors.Is(err, store.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "annotation not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "delete failed")
+		return
+	}
+	if res.Status == "conflict" {
+		server := annotationToJSON(*res.Server)
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"error":  "rev conflict",
+			"server": server,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id":     id,
+		"status": res.Status,
+		"rev":    res.Rev,
+		"seq":    res.Seq,
+	})
+}

--- a/internal/api/annotations_test.go
+++ b/internal/api/annotations_test.go
@@ -1,0 +1,384 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// annotationTestUser creates a user, mints a sync-scoped device token
+// and resolves one work, returning the token and the work id.
+func annotationTestUser(t *testing.T, ts string, st store.Store, id, name string) (string, string) {
+	t.Helper()
+	ctx := t.Context()
+	if err := st.CreateUser(ctx, store.User{ID: id, Name: name, CreatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	svc := auth.NewService(st)
+	secret, _, err := svc.MintToken(ctx, id, name+"-device", store.ScopeSet{store.ScopeSync}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, out := post(t, ts+"/v1/works/resolve", secret, map[string]any{
+		"identifiers": []map[string]string{{"kind": "sha256", "value": "sha-" + id}},
+		"title":       "Book of " + name,
+	})
+	if code != 201 {
+		t.Fatalf("resolve for %s: %d %v", name, code, out)
+	}
+	return secret, out["work_id"].(string)
+}
+
+func del(t *testing.T, url, token string) (int, map[string]any) {
+	t.Helper()
+	return requestJSON(t, http.MethodDelete, url, token, nil)
+}
+
+func annItem(id, workID string, baseRev int64) map[string]any {
+	return map[string]any{
+		"id":        id,
+		"base_rev":  baseRev,
+		"work_id":   workID,
+		"kind":      "highlight",
+		"locator":   map[string]any{"href": "ch1.xhtml", "text": map[string]any{"highlight": "sea"}},
+		"excerpt":   "the sea was calm",
+		"color":     "yellow",
+		"client_ts": "2025-06-01T10:00:00Z",
+	}
+}
+
+func pushAnns(t *testing.T, ts, tok string, items ...map[string]any) (int, map[string]any) {
+	t.Helper()
+	return post(t, ts+"/v1/annotations", tok, map[string]any{"annotations": items})
+}
+
+func firstResult(t *testing.T, out map[string]any) map[string]any {
+	t.Helper()
+	results, ok := out["results"].([]any)
+	if !ok || len(results) == 0 {
+		t.Fatalf("no results in %v", out)
+	}
+	return results[0].(map[string]any)
+}
+
+// TestAnnotationFullFlow walks the whole ADR-0028 dance: create, pull,
+// idempotent retry, edit with the right rev, stale rev 409 with the
+// server copy, delete, tombstone in the feed.
+func TestAnnotationFullFlow(t *testing.T) {
+	ts, st := testServer(t)
+	tok, workID := annotationTestUser(t, ts.URL, st, "u1", "alice")
+
+	// Create.
+	code, out := pushAnns(t, ts.URL, tok, annItem("a1", workID, 0))
+	if code != 200 {
+		t.Fatalf("push: %d %v", code, out)
+	}
+	res := firstResult(t, out)
+	if res["status"] != "applied" || res["rev"].(float64) != 1 {
+		t.Fatalf("create result: %v", res)
+	}
+	seq1 := res["seq"].(float64)
+
+	// Byte-identical retry acknowledges without a new row.
+	code, out = pushAnns(t, ts.URL, tok, annItem("a1", workID, 0))
+	res = firstResult(t, out)
+	if code != 200 || res["status"] != "duplicate" || res["rev"].(float64) != 1 || res["seq"].(float64) != seq1 {
+		t.Fatalf("retry: %d %v", code, res)
+	}
+
+	// Pull since 0.
+	code, out = get(t, ts.URL+"/v1/annotations/changes?since=0", tok)
+	if code != 200 {
+		t.Fatalf("changes: %d %v", code, out)
+	}
+	anns := out["annotations"].([]any)
+	if len(anns) != 1 {
+		t.Fatalf("changes count: %v", out)
+	}
+	a := anns[0].(map[string]any)
+	if a["id"] != "a1" || a["kind"] != "highlight" || a["excerpt"] != "the sea was calm" || a["deleted"] == true {
+		t.Fatalf("changes payload: %v", a)
+	}
+	if a["device_id"] == "" || a["device_id"] == nil {
+		t.Fatalf("annotation lost its device stamp: %v", a)
+	}
+	if out["high_water"].(float64) != seq1 || out["has_more"] != false {
+		t.Fatalf("page contract: %v", out)
+	}
+
+	// Edit with the current rev.
+	edit := annItem("a1", workID, 1)
+	edit["body"] = "lovely image"
+	code, out = pushAnns(t, ts.URL, tok, edit)
+	res = firstResult(t, out)
+	if code != 200 || res["status"] != "applied" || res["rev"].(float64) != 2 {
+		t.Fatalf("edit: %d %v", code, res)
+	}
+
+	// A second device editing from the stale rev conflicts and gets
+	// the server's copy back.
+	stale := annItem("a1", workID, 1)
+	stale["body"] = "competing edit"
+	code, out = pushAnns(t, ts.URL, tok, stale)
+	res = firstResult(t, out)
+	if code != 200 || res["status"] != "conflict" {
+		t.Fatalf("stale edit: %d %v", code, res)
+	}
+	server := res["server"].(map[string]any)
+	if server["rev"].(float64) != 2 || server["body"] != "lovely image" {
+		t.Fatalf("server copy: %v", server)
+	}
+
+	// The live set for the work.
+	code, out = get(t, ts.URL+"/v1/works/"+workID+"/annotations", tok)
+	if code != 200 || len(out["annotations"].([]any)) != 1 {
+		t.Fatalf("work annotations: %d %v", code, out)
+	}
+
+	// Delete needs the current rev.
+	code, out = del(t, ts.URL+"/v1/annotations/a1?rev=1", tok)
+	if code != 409 {
+		t.Fatalf("stale delete: %d %v", code, out)
+	}
+	if out["server"].(map[string]any)["rev"].(float64) != 2 {
+		t.Fatalf("stale delete server copy: %v", out)
+	}
+	code, out = del(t, ts.URL+"/v1/annotations/a1?rev=2", tok)
+	if code != 200 || out["status"] != "applied" {
+		t.Fatalf("delete: %d %v", code, out)
+	}
+	// Deleting again is already accepted.
+	code, out = del(t, ts.URL+"/v1/annotations/a1?rev=3", tok)
+	if code != 200 || out["status"] != "duplicate" {
+		t.Fatalf("re-delete: %d %v", code, out)
+	}
+	// Unknown id is a 404; missing rev a 400.
+	if code, _ = del(t, ts.URL+"/v1/annotations/nope?rev=1", tok); code != 404 {
+		t.Fatalf("unknown delete: %d", code)
+	}
+	if code, _ = del(t, ts.URL+"/v1/annotations/a1", tok); code != 400 {
+		t.Fatalf("revless delete: %d", code)
+	}
+
+	// The feed now carries a tombstone: identity and when, nothing else.
+	code, out = get(t, ts.URL+"/v1/annotations/changes?since="+"0", tok)
+	if code != 200 {
+		t.Fatalf("changes after delete: %d %v", code, out)
+	}
+	anns = out["annotations"].([]any)
+	tomb := anns[len(anns)-1].(map[string]any)
+	if tomb["id"] != "a1" || tomb["deleted"] != true {
+		t.Fatalf("tombstone: %v", tomb)
+	}
+	for _, leak := range []string{"body", "excerpt", "locator", "color", "kind", "client_ts", "device_id", "work_id", "edition_sha"} {
+		if v, ok := tomb[leak]; ok && v != "" {
+			t.Fatalf("tombstone leaked %s: %v", leak, tomb)
+		}
+	}
+
+	// The live set no longer lists it.
+	code, out = get(t, ts.URL+"/v1/works/"+workID+"/annotations", tok)
+	if code != 200 || len(out["annotations"].([]any)) != 0 {
+		t.Fatalf("work annotations after delete: %d %v", code, out)
+	}
+
+	// The op-log feed never mentions annotations (regression: the two
+	// feeds are separate counters, separate tables, separate routes).
+	code, out = get(t, ts.URL+"/v1/changes?since=0", tok)
+	if code != 200 {
+		t.Fatalf("op changes: %d %v", code, out)
+	}
+	if _, leaked := out["annotations"]; leaked {
+		t.Fatalf("/v1/changes grew an annotations key: %v", out)
+	}
+	if out["high_water"].(float64) != 0 {
+		t.Fatalf("annotation writes moved the op high-water: %v", out)
+	}
+}
+
+// TestAnnotationBounds exercises the refusals. Shape errors are
+// per-item results — one bad item fails alone, exactly like a bad
+// reference — while only a request nothing in it can excuse (malformed
+// JSON, an empty or oversized batch, an oversized body) is a 4xx.
+// Nothing here may ever be a 5xx.
+func TestAnnotationBounds(t *testing.T) {
+	ts, st := testServer(t)
+	tok, workID := annotationTestUser(t, ts.URL, st, "u1", "alice")
+
+	refuse := func(name string, mutate func(map[string]any)) {
+		t.Helper()
+		item := annItem("b-"+name, workID, 0)
+		mutate(item)
+		// The bad item travels with a healthy neighbor to prove it
+		// fails alone.
+		code, out := pushAnns(t, ts.URL, tok, item, annItem("ok-"+name, workID, 0))
+		if code != 200 {
+			t.Fatalf("%s: want 200 with per-item results, got %d %v", name, code, out)
+		}
+		results := out["results"].([]any)
+		bad := results[0].(map[string]any)
+		if bad["status"] != "invalid" || bad["reason"] == nil || bad["reason"] == "" {
+			t.Fatalf("%s: want invalid with a reason, got %v", name, bad)
+		}
+		if good := results[1].(map[string]any); good["status"] != "applied" {
+			t.Fatalf("%s: the bad item did not fail alone: %v", name, good)
+		}
+	}
+
+	refuse("no-id", func(m map[string]any) { m["id"] = "" })
+	refuse("long-id", func(m map[string]any) { m["id"] = strings.Repeat("x", 65) })
+	refuse("bad-kind", func(m map[string]any) { m["kind"] = "scribble" })
+	refuse("no-work", func(m map[string]any) { delete(m, "work_id") })
+	refuse("negative-base-rev", func(m map[string]any) { m["base_rev"] = -1 })
+	refuse("highlight-without-locator", func(m map[string]any) { delete(m, "locator") })
+	refuse("highlight-with-null-locator", func(m map[string]any) { m["locator"] = nil })
+	refuse("long-work-id", func(m map[string]any) { m["work_id"] = strings.Repeat("w", 129) })
+	refuse("long-edition-sha", func(m map[string]any) { m["edition_sha"] = strings.Repeat("e", 129) })
+	refuse("bookmark-with-body", func(m map[string]any) {
+		m["kind"] = "bookmark"
+		m["body"] = "not allowed"
+		delete(m, "color")
+	})
+	refuse("note-with-locator", func(m map[string]any) {
+		m["kind"] = "note"
+		m["body"] = "a thought"
+		delete(m, "color")
+	})
+	refuse("note-without-body", func(m map[string]any) {
+		m["kind"] = "note"
+		delete(m, "locator")
+		delete(m, "color")
+	})
+	refuse("bad-color", func(m map[string]any) { m["color"] = "#ff0000" })
+	refuse("color-on-bookmark", func(m map[string]any) {
+		m["kind"] = "bookmark"
+		delete(m, "body")
+	})
+	refuse("progression-out-of-range", func(m map[string]any) { m["progression"] = 1.5 })
+	refuse("oversize-excerpt", func(m map[string]any) { m["excerpt"] = strings.Repeat("x", 1<<10+1) })
+	refuse("oversize-body", func(m map[string]any) { m["body"] = strings.Repeat("x", 16<<10+1) })
+	refuse("bad-ts", func(m map[string]any) { m["client_ts"] = "yesterday" })
+	refuse("long-ts", func(m map[string]any) {
+		m["client_ts"] = "2024-01-02T03:04:05." + strings.Repeat("9", 60) + "Z"
+	})
+	refuse("wrong-type", func(m map[string]any) { m["base_rev"] = "not-a-number" })
+	refuse("overflow-rev", func(m map[string]any) { m["base_rev"] = json.Number("9223372036854775808") })
+	refuse("future-ts", func(m map[string]any) {
+		m["client_ts"] = time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339)
+	})
+
+	// A JSON null locator is an absent one, so a note may carry it.
+	nullNote := annItem("null-note", workID, 0)
+	nullNote["kind"], nullNote["body"], nullNote["locator"] = "note", "a thought", nil
+	delete(nullNote, "color")
+	if code, out := pushAnns(t, ts.URL, tok, nullNote); code != 200 || firstResult(t, out)["status"] != "applied" {
+		t.Fatalf("note with null locator: %d %v", code, out)
+	}
+
+	// Empty and oversized batches.
+	if code, _ := post(t, ts.URL+"/v1/annotations", tok, map[string]any{"annotations": []any{}}); code != 400 {
+		t.Fatalf("empty batch: %d", code)
+	}
+	big := make([]map[string]any, 101)
+	for i := range big {
+		big[i] = annItem("big", workID, 0)
+	}
+	if code, _ := pushAnns(t, ts.URL, tok, big...); code != 400 {
+		t.Fatalf("oversized batch: %d", code)
+	}
+
+	// A body no legal batch could ever need is a 413, named as such —
+	// never a misleading "invalid JSON body". The cap accounts for
+	// worst-case JSON escaping, so it takes well over the decoded
+	// field limits to reach it.
+	{
+		raw := `{"annotations":[{"id":"huge","body":"` + strings.Repeat("A", 16<<20) + `"}]}`
+		req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/annotations", strings.NewReader(raw))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Authorization", "Bearer "+tok)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusRequestEntityTooLarge || body["error"] != "request body too large" {
+			t.Fatalf("oversized request: %d %v", resp.StatusCode, body)
+		}
+	}
+
+	// An unknown work is a per-item semantic outcome, not a batch 400:
+	// the shape is fine, the reference is not.
+	code, out := pushAnns(t, ts.URL, tok, annItem("orphan", "w-not-there", 0))
+	res := firstResult(t, out)
+	if code != 200 || res["status"] != "invalid" || res["reason"] == "" {
+		t.Fatalf("unknown work: %d %v", code, res)
+	}
+
+	// One bad reference fails alone: its neighbor still lands.
+	code, out = pushAnns(t, ts.URL, tok,
+		annItem("keeper", workID, 0), annItem("orphan2", "w-not-there", 0))
+	if code != 200 {
+		t.Fatalf("mixed batch: %d %v", code, out)
+	}
+	results := out["results"].([]any)
+	if results[0].(map[string]any)["status"] != "applied" ||
+		results[1].(map[string]any)["status"] != "invalid" {
+		t.Fatalf("mixed batch results: %v", results)
+	}
+}
+
+// TestAnnotationIsPrivateToItsAuthor is the tenant-isolation check:
+// on every one of the four routes, another user's records are
+// invisible and untouchable.
+func TestAnnotationIsPrivateToItsAuthor(t *testing.T) {
+	ts, st := testServer(t)
+	aliceTok, aliceWork := annotationTestUser(t, ts.URL, st, "u1", "alice")
+	bobTok, _ := annotationTestUser(t, ts.URL, st, "u2", "bob")
+
+	code, out := pushAnns(t, ts.URL, aliceTok, annItem("a1", aliceWork, 0))
+	if code != 200 || firstResult(t, out)["status"] != "applied" {
+		t.Fatalf("alice push: %d %v", code, out)
+	}
+
+	// Bob's feed is empty and his high-water untouched.
+	code, out = get(t, ts.URL+"/v1/annotations/changes?since=0", bobTok)
+	if code != 200 || len(out["annotations"].([]any)) != 0 || out["high_water"].(float64) != 0 {
+		t.Fatalf("bob's feed sees alice: %d %v", code, out)
+	}
+
+	// Alice's work does not exist for bob, so neither do its notes.
+	if code, _ = get(t, ts.URL+"/v1/works/"+aliceWork+"/annotations", bobTok); code != 404 {
+		t.Fatalf("bob read alice's work annotations: %d", code)
+	}
+
+	// Bob cannot delete alice's annotation — for him it does not exist.
+	if code, _ = del(t, ts.URL+"/v1/annotations/a1?rev=1", bobTok); code != 404 {
+		t.Fatalf("bob deleted alice's annotation: %d", code)
+	}
+
+	// Bob cannot attach an annotation to alice's work.
+	code, out = pushAnns(t, ts.URL, bobTok, annItem("b1", aliceWork, 0))
+	res := firstResult(t, out)
+	if code != 200 || res["status"] != "invalid" {
+		t.Fatalf("bob wrote into alice's work: %d %v", code, res)
+	}
+
+	// And bob pushing alice's annotation id creates his own record,
+	// never a CAS race against hers.
+	code, out = get(t, ts.URL+"/v1/annotations/changes?since=0", aliceTok)
+	if code != 200 || len(out["annotations"].([]any)) != 1 {
+		t.Fatalf("alice's record disturbed: %d %v", code, out)
+	}
+}

--- a/internal/api/materializer.go
+++ b/internal/api/materializer.go
@@ -33,8 +33,31 @@ func (s *Server) RunMaterializer(ctx context.Context) {
 			s.compactOnce(ctx, retention)
 		}
 		s.rollupSessionsOnce(ctx, retention)
+		s.sweepAnnotationsOnce(ctx,
+			time.Duration(s.Cfg.Ops.AnnotationRetentionDays)*24*time.Hour)
 		if err := s.St.Housekeep(ctx, time.Now()); err != nil {
 			slog.Warn("housekeeping", "err", err)
+		}
+	}
+}
+
+// sweepAnnotationsOnce removes annotation tombstones older than the
+// retention window (ADR-0028): kept long enough for every device to
+// learn of the deletion, then the id is simply unknown.
+func (s *Server) sweepAnnotationsOnce(ctx context.Context, retention time.Duration) {
+	users, err := s.St.UserIDs(ctx)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-retention)
+	for _, userID := range users {
+		n, err := s.St.SweepAnnotationTombstones(ctx, userID, cutoff)
+		if err != nil {
+			slog.Warn("annotation sweep", "user", userID, "err", err)
+			continue
+		}
+		if n > 0 {
+			slog.Info("annotation sweep", "user", userID, "swept", n)
 		}
 	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -328,6 +328,12 @@ func (s *Server) Routes() *http.ServeMux {
 	mux.Handle("GET /v1/heads", syncH(s.HandleHeads))
 	mux.Handle("GET /v1/works/{id}/positions", syncH(s.HandlePositions))
 	mux.Handle("POST /v1/sessions", syncH(s.HandlePushSessions))
+	// Annotations (ADR-0028) are reading state, they travel with
+	// positions, and the reader token already carries what they need.
+	mux.Handle("POST /v1/annotations", syncH(s.HandlePushAnnotations))
+	mux.Handle("GET /v1/annotations/changes", syncH(s.HandleAnnotationChanges))
+	mux.Handle("DELETE /v1/annotations/{id}", syncH(s.HandleDeleteAnnotation))
+	mux.Handle("GET /v1/works/{id}/annotations", syncH(s.HandleWorkAnnotations))
 
 	// read-insights scope.
 	insH := func(h http.HandlerFunc) http.Handler {

--- a/internal/api/token_scope_test.go
+++ b/internal/api/token_scope_test.go
@@ -162,6 +162,12 @@ var registeredRouteGates = map[string]routeGate{
 	"GET /v1/works/{id}/positions": gateSync,
 	"POST /v1/sessions":            gateSync,
 
+	// ADR-0028: annotations are reading state and travel with positions.
+	"POST /v1/annotations":           gateSync,
+	"GET /v1/annotations/changes":    gateSync,
+	"DELETE /v1/annotations/{id}":    gateSync,
+	"GET /v1/works/{id}/annotations": gateSync,
+
 	"GET /v1/insights/summary":    gateInsights,
 	"GET /v1/insights/works":      gateInsights,
 	"GET /v1/insights/works/{id}": gateInsights,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -101,6 +101,17 @@ type Config struct {
 		CompactionEnabled  bool  `toml:"compaction_enabled"`   // default true
 		InferenceGapMin    int   `toml:"inference_gap_min"`    // default 15
 		InferenceLateHours int   `toml:"inference_late_hours"` // default 24
+
+		// Annotation bounds (ADR-0028). Each refusal is a precise 4xx,
+		// nothing truncated silently. AnnotationMaxPerWork caps live
+		// records per user per work, enforced inside the store's write
+		// transaction. AnnotationRetentionDays is how long a deleted
+		// annotation's tombstone survives so every device learns of it.
+		AnnotationMaxBatch        int `toml:"annotation_max_batch"`         // default 100
+		AnnotationMaxExcerptBytes int `toml:"annotation_max_excerpt_bytes"` // default 1 KiB
+		AnnotationMaxBodyBytes    int `toml:"annotation_max_body_bytes"`    // default 16 KiB
+		AnnotationMaxPerWork      int `toml:"annotation_max_per_work"`      // default 2000
+		AnnotationRetentionDays   int `toml:"annotation_retention_days"`    // default 180
 	} `toml:"ops"`
 
 	PairingCodeTTLMin int `toml:"pairing_code_ttl_min"` // default 15
@@ -133,6 +144,11 @@ func Default() Config {
 	c.Ops.CompactionEnabled = true
 	c.Ops.InferenceGapMin = 15
 	c.Ops.InferenceLateHours = 24
+	c.Ops.AnnotationMaxBatch = 100
+	c.Ops.AnnotationMaxExcerptBytes = 1 << 10
+	c.Ops.AnnotationMaxBodyBytes = 16 << 10
+	c.Ops.AnnotationMaxPerWork = 2000
+	c.Ops.AnnotationRetentionDays = 180
 	c.PairingCodeTTLMin = 15
 	return c
 }
@@ -223,6 +239,21 @@ func (c *Config) Validate() error {
 
 	if c.Ops.RetentionDays < 1 {
 		return fmt.Errorf("ops.retention_days must be >= 1")
+	}
+	if c.Ops.AnnotationMaxBatch < 1 {
+		return fmt.Errorf("ops.annotation_max_batch must be >= 1")
+	}
+	if c.Ops.AnnotationMaxExcerptBytes < 1 {
+		return fmt.Errorf("ops.annotation_max_excerpt_bytes must be >= 1")
+	}
+	if c.Ops.AnnotationMaxBodyBytes < 1 {
+		return fmt.Errorf("ops.annotation_max_body_bytes must be >= 1")
+	}
+	if c.Ops.AnnotationMaxPerWork < 1 {
+		return fmt.Errorf("ops.annotation_max_per_work must be >= 1")
+	}
+	if c.Ops.AnnotationRetentionDays < 1 {
+		return fmt.Errorf("ops.annotation_retention_days must be >= 1")
 	}
 	if c.Ops.InferenceGapMin < 1 {
 		return fmt.Errorf("ops.inference_gap_min must be >= 1")

--- a/internal/store/postgres/annotations.go
+++ b/internal/store/postgres/annotations.go
@@ -1,0 +1,386 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+const annotationCols = `user_id, id, seq, rev, work_id, edition_sha, kind, locator_json,
+                        progression, excerpt, color, body, device_id, client_ts,
+                        updated_at, deleted_at`
+
+// scanAnnotation scans one row of the annotations table.
+func scanAnnotation(row interface{ Scan(...any) error }) (store.Annotation, error) {
+	var a store.Annotation
+	var kind string
+	var clientTS *time.Time
+	err := row.Scan(&a.UserID, &a.ID, &a.Seq, &a.Rev, &a.WorkID, &a.EditionSHA,
+		&kind, &a.LocatorJSON, &a.Progression, &a.Excerpt, &a.Color, &a.Body,
+		&a.DeviceID, &clientTS, &a.UpdatedAt, &a.DeletedAt)
+	if err != nil {
+		return a, err
+	}
+	a.Kind = store.AnnotationKind(kind)
+	if clientTS != nil {
+		a.ClientTS = *clientTS
+	}
+	return a, nil
+}
+
+// nextAnnotationSeqTx advances the per-user annotation counter — a
+// second counter beside the op one, never shared with it. Advanced
+// inside the write's transaction, holding the counter row, so seq
+// order is commit order per user.
+func nextAnnotationSeqTx(ctx context.Context, tx *sql.Tx, userID string) (int64, error) {
+	var seq int64
+	err := tx.QueryRowContext(ctx, q(
+		`INSERT INTO seq_counters (user_id, next_annotation_seq) VALUES (?, 2)
+		 ON CONFLICT(user_id) DO UPDATE SET next_annotation_seq = seq_counters.next_annotation_seq + 1
+		 RETURNING next_annotation_seq - 1`), userID).Scan(&seq)
+	return seq, err
+}
+
+func annotationByIDTx(ctx context.Context, tx *sql.Tx, userID, id string) (store.Annotation, bool, error) {
+	a, err := scanAnnotation(tx.QueryRowContext(ctx, q(
+		`SELECT `+annotationCols+` FROM annotations WHERE user_id = ? AND id = ?`),
+		userID, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return a, false, nil
+	}
+	return a, err == nil, err
+}
+
+func liveAnnotationCountTx(ctx context.Context, tx *sql.Tx, userID, workID string) (int, error) {
+	var n int
+	err := tx.QueryRowContext(ctx, q(
+		`SELECT COUNT(1) FROM annotations
+		 WHERE user_id = ? AND work_id = ? AND deleted_at IS NULL`),
+		userID, workID).Scan(&n)
+	return n, err
+}
+
+// PushAnnotations applies a batch of annotation writes, never
+// atomically: one result per item, one bad item fails alone.
+// Compare-and-set on rev; a retry of an accepted write (same id, same
+// base rev, byte-identical payload) is acknowledged, not conflicted.
+func (s *Store) PushAnnotations(ctx context.Context, userID, deviceID string, items []store.AnnotationWrite, maxLivePerWork int) ([]store.AnnotationResult, error) {
+	results := make([]store.AnnotationResult, len(items))
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := lockWorkGraph(ctx, tx, userID); err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		for i, item := range items {
+			r, err := pushAnnotationTx(ctx, tx, userID, deviceID, item, maxLivePerWork, now)
+			if err != nil {
+				return err
+			}
+			results[i] = r
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func pushAnnotationTx(ctx context.Context, tx *sql.Tx, userID, deviceID string, item store.AnnotationWrite, maxLivePerWork int, now time.Time) (store.AnnotationResult, error) {
+	r := store.AnnotationResult{ID: item.ID, Status: "applied"}
+	stored, found, err := annotationByIDTx(ctx, tx, userID, item.ID)
+	if err != nil {
+		return r, err
+	}
+	if found {
+		switch {
+		case stored.Rev == item.BaseRev+1 && store.SameAnnotationPayload(stored, item, deviceID):
+			// The accepted write, pushed again: a lost response is
+			// harmless.
+			r.Status, r.Rev, r.Seq = "duplicate", stored.Rev, stored.Seq
+			return r, nil
+		case stored.Rev != item.BaseRev || stored.WorkID != item.WorkID:
+			// Stale rev — or a record split/merge moved to another
+			// work. Either way the client resolves from the server
+			// copy; the server orders, it never merges.
+			r.Status, r.Server = "conflict", &stored
+			return r, nil
+		}
+	}
+	if !found || stored.Deleted() {
+		// A create — or a deliberate, rev-matching write onto a
+		// tombstone — adds a live record, so it answers to the cap.
+		if invalid, err := refuseAnnotationInsertTx(ctx, tx, userID, item, maxLivePerWork); err != nil {
+			return r, err
+		} else if invalid != "" {
+			r.Status, r.Reason = "invalid", invalid
+			return r, nil
+		}
+	} else {
+		// A live edit keeps its work (a mismatch was a conflict
+		// above), but its edition reference still has to exist —
+		// checked here so the composite FK never aborts the batch.
+		if invalid, err := refuseAnnotationEditionTx(ctx, tx, userID, item); err != nil {
+			return r, err
+		} else if invalid != "" {
+			r.Status, r.Reason = "invalid", invalid
+			return r, nil
+		}
+	}
+	seq, err := nextAnnotationSeqTx(ctx, tx, userID)
+	if err != nil {
+		return r, err
+	}
+	// An unknown id — including one whose tombstone was swept — starts
+	// over: new record, rev 1, whatever base the client quoted.
+	rev := int64(1)
+	if found {
+		rev = item.BaseRev + 1
+		_, err = tx.ExecContext(ctx, q(
+			`UPDATE annotations SET seq = ?, rev = ?, work_id = ?, edition_sha = ?,
+			        kind = ?, locator_json = ?, progression = ?, excerpt = ?,
+			        color = ?, body = ?, device_id = ?, client_ts = ?,
+			        updated_at = ?, deleted_at = NULL
+			 WHERE user_id = ? AND id = ?`),
+			seq, rev, item.WorkID, item.EditionSHA, string(item.Kind),
+			item.LocatorJSON, item.Progression, item.Excerpt,
+			item.Color, item.Body, deviceID, item.ClientTS.UTC(),
+			now, userID, item.ID)
+	} else {
+		_, err = tx.ExecContext(ctx, q(
+			`INSERT INTO annotations (user_id, id, seq, rev, work_id, edition_sha,
+			         kind, locator_json, progression, excerpt, color, body,
+			         device_id, client_ts, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+			userID, item.ID, seq, rev, item.WorkID, item.EditionSHA,
+			string(item.Kind), item.LocatorJSON, item.Progression,
+			item.Excerpt, item.Color, item.Body, deviceID,
+			item.ClientTS.UTC(), now)
+	}
+	if err != nil {
+		return r, err
+	}
+	r.Rev, r.Seq = rev, seq
+	return r, nil
+}
+
+// refuseAnnotationInsertTx is every reason a new live record cannot
+// land, checked inside the transaction rather than left to a foreign
+// key: a constraint violation would abort the batch, and one bad item
+// must fail alone. The cap especially belongs here — two concurrent
+// creates must not both squeeze under it.
+func refuseAnnotationInsertTx(ctx context.Context, tx *sql.Tx, userID string, item store.AnnotationWrite, maxLivePerWork int) (string, error) {
+	var dummy int
+	err := tx.QueryRowContext(ctx, q(
+		`SELECT 1 FROM works WHERE user_id = ? AND id = ?`), userID, item.WorkID).Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "unknown work", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if item.EditionSHA != nil {
+		if invalid, err := refuseAnnotationEditionTx(ctx, tx, userID, item); err != nil {
+			return "", err
+		} else if invalid != "" {
+			return invalid, nil
+		}
+	}
+	n, err := liveAnnotationCountTx(ctx, tx, userID, item.WorkID)
+	if err != nil {
+		return "", err
+	}
+	if n >= maxLivePerWork {
+		return "annotation cap reached for this work", nil
+	}
+	return "", nil
+}
+
+// refuseAnnotationEditionTx says whether the write names an edition
+// this work does not have. Checked for every accepted write, not only
+// a create: a live edit can change edition_sha too, and the composite
+// FK aborting the transaction would fail the whole batch.
+func refuseAnnotationEditionTx(ctx context.Context, tx *sql.Tx, userID string, item store.AnnotationWrite) (string, error) {
+	if item.EditionSHA == nil {
+		return "", nil
+	}
+	var dummy int
+	err := tx.QueryRowContext(ctx, q(
+		`SELECT 1 FROM editions WHERE user_id = ? AND sha256 = ? AND work_id = ?`),
+		userID, *item.EditionSHA, item.WorkID).Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "unknown edition for this work", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+// DeleteAnnotation writes the tombstone iff rev matches. The tombstone
+// keeps nothing but identity, rev, seq and when.
+func (s *Store) DeleteAnnotation(ctx context.Context, userID, id string, rev int64) (store.AnnotationResult, error) {
+	r := store.AnnotationResult{ID: id, Status: "applied"}
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := lockWorkGraph(ctx, tx, userID); err != nil {
+			return err
+		}
+		stored, found, err := annotationByIDTx(ctx, tx, userID, id)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return store.ErrNotFound
+		}
+		if stored.Deleted() {
+			r.Status, r.Rev, r.Seq = "duplicate", stored.Rev, stored.Seq
+			return nil
+		}
+		if stored.Rev != rev {
+			r.Status, r.Server = "conflict", &stored
+			return nil
+		}
+		seq, err := nextAnnotationSeqTx(ctx, tx, userID)
+		if err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		if _, err := tx.ExecContext(ctx, q(
+			`UPDATE annotations SET seq = ?, rev = rev + 1, edition_sha = NULL,
+			        locator_json = NULL, progression = NULL, excerpt = '',
+			        color = '', body = '', device_id = '', client_ts = NULL,
+			        updated_at = ?, deleted_at = ?
+			 WHERE user_id = ? AND id = ?`),
+			seq, now, now, userID, id); err != nil {
+			return err
+		}
+		r.Rev, r.Seq = stored.Rev+1, seq
+		return nil
+	})
+	if err != nil {
+		return store.AnnotationResult{}, err
+	}
+	return r, nil
+}
+
+// AnnotationChanges returns records (tombstones included) with
+// seq > since, in seq order. This is a state feed, not history: an
+// edited record reappears at the head with its current content.
+func (s *Store) AnnotationChanges(ctx context.Context, userID string, since int64, limit int) (store.AnnotationChangesPage, error) {
+	var page store.AnnotationChangesPage
+	err := s.db.QueryRowContext(ctx, q(
+		`SELECT next_annotation_seq - 1 FROM seq_counters WHERE user_id = ?`),
+		userID).Scan(&page.HighWater)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return page, err
+	}
+	rows, err := s.db.QueryContext(ctx, q(
+		`SELECT `+annotationCols+` FROM annotations
+		 WHERE user_id = ? AND seq > ? ORDER BY seq LIMIT ?`),
+		userID, since, limit+1)
+	if err != nil {
+		return page, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		a, err := scanAnnotation(rows)
+		if err != nil {
+			return page, err
+		}
+		page.Annotations = append(page.Annotations, a)
+	}
+	if err := rows.Err(); err != nil {
+		return page, err
+	}
+	if len(page.Annotations) > limit {
+		page.HasMore = true
+		page.Annotations = page.Annotations[:limit]
+	}
+	return page, nil
+}
+
+// WorkAnnotations returns the live set for one work, ordered by
+// progression then client_ts.
+func (s *Store) WorkAnnotations(ctx context.Context, userID, workID string) ([]store.Annotation, error) {
+	rows, err := s.db.QueryContext(ctx, q(
+		`SELECT `+annotationCols+` FROM annotations
+		 WHERE user_id = ? AND work_id = ? AND deleted_at IS NULL
+		 ORDER BY progression IS NULL, progression, client_ts, id`),
+		userID, workID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.Annotation
+	for rows.Next() {
+		a, err := scanAnnotation(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// SweepAnnotationTombstones removes tombstones older than the cutoff.
+// After the sweep the id is simply unknown: a device offline longer
+// than the window that pushes it again creates a new record.
+func (s *Store) SweepAnnotationTombstones(ctx context.Context, userID string, olderThan time.Time) (int64, error) {
+	res, err := s.db.ExecContext(ctx, q(
+		`DELETE FROM annotations
+		 WHERE user_id = ? AND deleted_at IS NOT NULL AND deleted_at < ?`),
+		userID, olderThan.UTC())
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// moveAnnotationsTx reassigns annotations during a split or a merge.
+// A moved annotation is a write like any other — new seq, rev
+// incremented — so every synced device learns its new work_id on the
+// next pull. editionSHA nil moves the whole work's records (a merge);
+// non-nil moves only the edition's (a split — records with no edition
+// stay with the surviving work).
+func moveAnnotationsTx(ctx context.Context, tx *sql.Tx, userID, fromWorkID, toWorkID string, editionSHA *string) error {
+	query := `SELECT id FROM annotations WHERE user_id = ? AND work_id = ?`
+	args := []any{userID, fromWorkID}
+	if editionSHA != nil {
+		query += ` AND edition_sha = ?`
+		args = append(args, *editionSHA)
+	}
+	rows, err := tx.QueryContext(ctx, q(query+` ORDER BY seq`), args...)
+	if err != nil {
+		return err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	for _, id := range ids {
+		seq, err := nextAnnotationSeqTx(ctx, tx, userID)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, q(
+			`UPDATE annotations SET work_id = ?, seq = ?, rev = rev + 1, updated_at = ?
+			 WHERE user_id = ? AND id = ?`),
+			toWorkID, seq, now, userID, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/store/postgres/annotations.go
+++ b/internal/store/postgres/annotations.go
@@ -97,9 +97,13 @@ func pushAnnotationTx(ctx context.Context, tx *sql.Tx, userID, deviceID string, 
 	}
 	if found {
 		switch {
-		case stored.Rev == item.BaseRev+1 && store.SameAnnotationPayload(stored, item, deviceID):
+		case (stored.Rev == item.BaseRev+1 || (stored.Rev == 1 && !stored.Deleted())) &&
+			store.SameAnnotationPayload(stored, item, deviceID):
 			// The accepted write, pushed again: a lost response is
-			// harmless.
+			// harmless. The rev-1 arm covers the post-sweep resurrect,
+			// whose accepted write started over at rev 1 whatever base
+			// the client quoted — its retry must be acknowledged too,
+			// not conflicted or applied twice.
 			r.Status, r.Rev, r.Seq = "duplicate", stored.Rev, stored.Seq
 			return r, nil
 		case stored.Rev != item.BaseRev || stored.WorkID != item.WorkID:

--- a/internal/store/postgres/schema.go
+++ b/internal/store/postgres/schema.go
@@ -479,5 +479,39 @@ CREATE TABLE user_folders (
 CREATE INDEX user_folders_folder ON user_folders(folder_id);
 `
 
+// annotationSync is migration 5 (ADR-0028); see the SQLite copy for
+// what an annotation is and why most of its columns are nullable.
+const annotationSync = `
+ALTER TABLE seq_counters ADD COLUMN next_annotation_seq BIGINT NOT NULL DEFAULT 1;
+
+CREATE TABLE annotations (
+    user_id      TEXT NOT NULL,
+    id           TEXT NOT NULL,
+    seq          BIGINT NOT NULL,
+    rev          BIGINT NOT NULL,
+    work_id      TEXT NOT NULL,
+    edition_sha  TEXT,
+    kind         TEXT NOT NULL CHECK (kind IN ('highlight', 'note', 'bookmark')),
+    locator_json BYTEA,
+    progression  DOUBLE PRECISION,
+    excerpt      TEXT NOT NULL DEFAULT '',
+    color        TEXT NOT NULL DEFAULT '',
+    body         TEXT NOT NULL DEFAULT '',
+    device_id    TEXT NOT NULL DEFAULT '',
+    client_ts    TIMESTAMPTZ,
+    updated_at   TIMESTAMPTZ NOT NULL,
+    deleted_at   TIMESTAMPTZ,
+    PRIMARY KEY (user_id, id),
+    UNIQUE (user_id, seq),
+    FOREIGN KEY (user_id, work_id) REFERENCES works(user_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id, edition_sha, work_id)
+        REFERENCES editions(user_id, sha256, work_id)
+        DEFERRABLE INITIALLY DEFERRED
+);
+CREATE INDEX annotations_work ON annotations(user_id, work_id, deleted_at);
+CREATE INDEX annotations_tombstones ON annotations(user_id, deleted_at)
+    WHERE deleted_at IS NOT NULL;
+`
+
 // migrations is append-only, for the reason the SQLite copy gives.
-var migrations = []string{schema, claimRevisions, folderUploads, folderAccess}
+var migrations = []string{schema, claimRevisions, folderUploads, folderAccess, annotationSync}

--- a/internal/store/postgres/store_test.go
+++ b/internal/store/postgres/store_test.go
@@ -23,11 +23,11 @@ func TestStore(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		t.Cleanup(func() { s.Close() })
 		reset(t, s)
 		if err := s.Migrate(context.Background()); err != nil {
 			t.Fatal(err)
 		}
-		t.Cleanup(func() { s.Close() })
 		return s
 	}
 	storetest.Run(t, open)
@@ -43,7 +43,7 @@ func reset(t *testing.T, s *Store) {
 		"series_name_overrides", "series_bindings", "book_series", "series",
 		"book_identifiers", "user_book_works", "user_folders",
 		"books", "folders",
-		"session_supersessions", "session_tombstones", "session_rollups", "sessions", "ops", "aliases", "editions",
+		"session_supersessions", "session_tombstones", "session_rollups", "sessions", "ops", "annotations", "aliases", "editions",
 		"works", "seq_counters", "compaction_state", "kosync_devices",
 		"koplugin_devices", "pairing_codes", "invites", "auth_sessions",
 		"token_scopes", "tokens", "users", "schema_migrations",

--- a/internal/store/postgres/works.go
+++ b/internal/store/postgres/works.go
@@ -364,6 +364,11 @@ func (s *Store) SplitWork(ctx context.Context, userID, workID, editionSHA string
 		newWork.ID, userID, editionSHA, workID); err != nil {
 		return err
 	}
+	// An annotation with this edition_sha follows its edition; one
+	// without stays with the surviving work (ADR-0028).
+	if err := moveAnnotationsTx(ctx, tx, userID, workID, newWork.ID, &editionSHA); err != nil {
+		return err
+	}
 	if errors.Is(shaAliasErr, sql.ErrNoRows) {
 		if _, err := tx.ExecContext(ctx, q(
 			`INSERT INTO aliases (user_id, kind, value, work_id) VALUES (?, 'sha256', ?, ?)`),
@@ -515,6 +520,11 @@ func (s *Store) MergeWorks(ctx context.Context, userID, fromWorkID, intoWorkID s
 	if _, err := tx.ExecContext(ctx, q(
 		`UPDATE sessions SET work_id = ? WHERE user_id = ? AND work_id = ?`),
 		intoWorkID, userID, fromWorkID); err != nil {
+		return err
+	}
+	// Every annotation — tombstones included — follows to the survivor
+	// (ADR-0028), each as a new write so synced devices learn of it.
+	if err := moveAnnotationsTx(ctx, tx, userID, fromWorkID, intoWorkID, nil); err != nil {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx, q(

--- a/internal/store/sqlite/annotations.go
+++ b/internal/store/sqlite/annotations.go
@@ -112,9 +112,13 @@ func pushAnnotationTx(ctx context.Context, tx *sql.Tx, userID, deviceID string, 
 	}
 	if found {
 		switch {
-		case stored.Rev == item.BaseRev+1 && store.SameAnnotationPayload(stored, item, deviceID):
+		case (stored.Rev == item.BaseRev+1 || (stored.Rev == 1 && !stored.Deleted())) &&
+			store.SameAnnotationPayload(stored, item, deviceID):
 			// The accepted write, pushed again: a lost response is
-			// harmless.
+			// harmless. The rev-1 arm covers the post-sweep resurrect,
+			// whose accepted write started over at rev 1 whatever base
+			// the client quoted — its retry must be acknowledged too,
+			// not conflicted or applied twice.
 			r.Status, r.Rev, r.Seq = "duplicate", stored.Rev, stored.Seq
 			return r, nil
 		case stored.Rev != item.BaseRev || stored.WorkID != item.WorkID:

--- a/internal/store/sqlite/annotations.go
+++ b/internal/store/sqlite/annotations.go
@@ -1,0 +1,408 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+const annotationCols = `user_id, id, seq, rev, work_id, edition_sha, kind, locator_json,
+                        progression, excerpt, color, body, device_id, client_ts,
+                        updated_at, deleted_at`
+
+// scanAnnotation scans one row of the annotations table.
+func scanAnnotation(row interface{ Scan(...any) error }) (store.Annotation, error) {
+	var a store.Annotation
+	var editionSHA, clientTS, deletedAt sql.NullString
+	var progression sql.NullFloat64
+	var kind, updatedAt string
+	err := row.Scan(&a.UserID, &a.ID, &a.Seq, &a.Rev, &a.WorkID, &editionSHA,
+		&kind, &a.LocatorJSON, &progression, &a.Excerpt, &a.Color, &a.Body,
+		&a.DeviceID, &clientTS, &updatedAt, &deletedAt)
+	if err != nil {
+		return a, err
+	}
+	a.Kind = store.AnnotationKind(kind)
+	if editionSHA.Valid {
+		a.EditionSHA = &editionSHA.String
+	}
+	if progression.Valid {
+		a.Progression = &progression.Float64
+	}
+	if clientTS.Valid {
+		if a.ClientTS, err = parseTime(clientTS.String); err != nil {
+			return a, err
+		}
+	}
+	if a.UpdatedAt, err = parseTime(updatedAt); err != nil {
+		return a, err
+	}
+	if a.DeletedAt, err = parseTimePtr(deletedAt); err != nil {
+		return a, err
+	}
+	return a, nil
+}
+
+// nextAnnotationSeqTx advances the per-user annotation counter — a
+// second counter beside the op one, never shared with it. Advanced
+// inside the write's transaction, holding the counter row, so seq
+// order is commit order per user.
+func nextAnnotationSeqTx(ctx context.Context, tx *sql.Tx, userID string) (int64, error) {
+	var seq int64
+	err := tx.QueryRowContext(ctx,
+		`INSERT INTO seq_counters (user_id, next_annotation_seq) VALUES (?, 2)
+		 ON CONFLICT(user_id) DO UPDATE SET next_annotation_seq = next_annotation_seq + 1
+		 RETURNING next_annotation_seq - 1`, userID).Scan(&seq)
+	return seq, err
+}
+
+func annotationByIDTx(ctx context.Context, tx *sql.Tx, userID, id string) (store.Annotation, bool, error) {
+	a, err := scanAnnotation(tx.QueryRowContext(ctx,
+		`SELECT `+annotationCols+` FROM annotations WHERE user_id = ? AND id = ?`,
+		userID, id))
+	if errors.Is(err, sql.ErrNoRows) {
+		return a, false, nil
+	}
+	return a, err == nil, err
+}
+
+func liveAnnotationCountTx(ctx context.Context, tx *sql.Tx, userID, workID string) (int, error) {
+	var n int
+	err := tx.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM annotations
+		 WHERE user_id = ? AND work_id = ? AND deleted_at IS NULL`,
+		userID, workID).Scan(&n)
+	return n, err
+}
+
+// PushAnnotations applies a batch of annotation writes, never
+// atomically: one result per item, one bad item fails alone.
+// Compare-and-set on rev; a retry of an accepted write (same id, same
+// base rev, byte-identical payload) is acknowledged, not conflicted.
+func (s *Store) PushAnnotations(ctx context.Context, userID, deviceID string, items []store.AnnotationWrite, maxLivePerWork int) ([]store.AnnotationResult, error) {
+	results := make([]store.AnnotationResult, len(items))
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := lockWorkGraph(ctx, tx, userID); err != nil {
+			return err
+		}
+		now := time.Now()
+		for i, item := range items {
+			r, err := pushAnnotationTx(ctx, tx, userID, deviceID, item, maxLivePerWork, now)
+			if err != nil {
+				return err
+			}
+			results[i] = r
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func pushAnnotationTx(ctx context.Context, tx *sql.Tx, userID, deviceID string, item store.AnnotationWrite, maxLivePerWork int, now time.Time) (store.AnnotationResult, error) {
+	r := store.AnnotationResult{ID: item.ID, Status: "applied"}
+	stored, found, err := annotationByIDTx(ctx, tx, userID, item.ID)
+	if err != nil {
+		return r, err
+	}
+	if found {
+		switch {
+		case stored.Rev == item.BaseRev+1 && store.SameAnnotationPayload(stored, item, deviceID):
+			// The accepted write, pushed again: a lost response is
+			// harmless.
+			r.Status, r.Rev, r.Seq = "duplicate", stored.Rev, stored.Seq
+			return r, nil
+		case stored.Rev != item.BaseRev || stored.WorkID != item.WorkID:
+			// Stale rev — or a record split/merge moved to another
+			// work. Either way the client resolves from the server
+			// copy; the server orders, it never merges.
+			r.Status, r.Server = "conflict", &stored
+			return r, nil
+		}
+	}
+	if !found || stored.Deleted() {
+		// A create — or a deliberate, rev-matching write onto a
+		// tombstone — adds a live record, so it answers to the cap.
+		if invalid, err := refuseAnnotationInsertTx(ctx, tx, userID, item, maxLivePerWork); err != nil {
+			return r, err
+		} else if invalid != "" {
+			r.Status, r.Reason = "invalid", invalid
+			return r, nil
+		}
+	} else {
+		// A live edit keeps its work (a mismatch was a conflict
+		// above), but its edition reference still has to exist —
+		// checked here so the composite FK never aborts the batch.
+		if invalid, err := refuseAnnotationEditionTx(ctx, tx, userID, item); err != nil {
+			return r, err
+		} else if invalid != "" {
+			r.Status, r.Reason = "invalid", invalid
+			return r, nil
+		}
+	}
+	seq, err := nextAnnotationSeqTx(ctx, tx, userID)
+	if err != nil {
+		return r, err
+	}
+	// An unknown id — including one whose tombstone was swept — starts
+	// over: new record, rev 1, whatever base the client quoted.
+	rev := int64(1)
+	if found {
+		rev = item.BaseRev + 1
+		_, err = tx.ExecContext(ctx,
+			`UPDATE annotations SET seq = ?, rev = ?, work_id = ?, edition_sha = ?,
+			        kind = ?, locator_json = ?, progression = ?, excerpt = ?,
+			        color = ?, body = ?, device_id = ?, client_ts = ?,
+			        updated_at = ?, deleted_at = NULL
+			 WHERE user_id = ? AND id = ?`,
+			seq, rev, item.WorkID, nullStr(item.EditionSHA), string(item.Kind),
+			item.LocatorJSON, nullFloat(item.Progression), item.Excerpt,
+			item.Color, item.Body, deviceID, formatTime(item.ClientTS),
+			formatTime(now), userID, item.ID)
+	} else {
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO annotations (user_id, id, seq, rev, work_id, edition_sha,
+			         kind, locator_json, progression, excerpt, color, body,
+			         device_id, client_ts, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			userID, item.ID, seq, rev, item.WorkID, nullStr(item.EditionSHA),
+			string(item.Kind), item.LocatorJSON, nullFloat(item.Progression),
+			item.Excerpt, item.Color, item.Body, deviceID,
+			formatTime(item.ClientTS), formatTime(now))
+	}
+	if err != nil {
+		return r, err
+	}
+	r.Rev, r.Seq = rev, seq
+	return r, nil
+}
+
+// refuseAnnotationInsertTx is every reason a new live record cannot
+// land, checked inside the transaction rather than left to a foreign
+// key: a constraint violation would abort the batch, and one bad item
+// must fail alone. The cap especially belongs here — two concurrent
+// creates must not both squeeze under it.
+func refuseAnnotationInsertTx(ctx context.Context, tx *sql.Tx, userID string, item store.AnnotationWrite, maxLivePerWork int) (string, error) {
+	var dummy int
+	err := tx.QueryRowContext(ctx,
+		`SELECT 1 FROM works WHERE user_id = ? AND id = ?`, userID, item.WorkID).Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "unknown work", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if item.EditionSHA != nil {
+		if invalid, err := refuseAnnotationEditionTx(ctx, tx, userID, item); err != nil {
+			return "", err
+		} else if invalid != "" {
+			return invalid, nil
+		}
+	}
+	n, err := liveAnnotationCountTx(ctx, tx, userID, item.WorkID)
+	if err != nil {
+		return "", err
+	}
+	if n >= maxLivePerWork {
+		return "annotation cap reached for this work", nil
+	}
+	return "", nil
+}
+
+// refuseAnnotationEditionTx says whether the write names an edition
+// this work does not have. Checked for every accepted write, not only
+// a create: a live edit can change edition_sha too, and the composite
+// FK aborting the transaction would fail the whole batch.
+func refuseAnnotationEditionTx(ctx context.Context, tx *sql.Tx, userID string, item store.AnnotationWrite) (string, error) {
+	if item.EditionSHA == nil {
+		return "", nil
+	}
+	var dummy int
+	err := tx.QueryRowContext(ctx,
+		`SELECT 1 FROM editions WHERE user_id = ? AND sha256 = ? AND work_id = ?`,
+		userID, *item.EditionSHA, item.WorkID).Scan(&dummy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "unknown edition for this work", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return "", nil
+}
+
+// DeleteAnnotation writes the tombstone iff rev matches. The tombstone
+// keeps nothing but identity, rev, seq and when.
+func (s *Store) DeleteAnnotation(ctx context.Context, userID, id string, rev int64) (store.AnnotationResult, error) {
+	r := store.AnnotationResult{ID: id, Status: "applied"}
+	err := s.withTx(ctx, func(tx *sql.Tx) error {
+		if err := lockWorkGraph(ctx, tx, userID); err != nil {
+			return err
+		}
+		stored, found, err := annotationByIDTx(ctx, tx, userID, id)
+		if err != nil {
+			return err
+		}
+		if !found {
+			return store.ErrNotFound
+		}
+		if stored.Deleted() {
+			r.Status, r.Rev, r.Seq = "duplicate", stored.Rev, stored.Seq
+			return nil
+		}
+		if stored.Rev != rev {
+			r.Status, r.Server = "conflict", &stored
+			return nil
+		}
+		seq, err := nextAnnotationSeqTx(ctx, tx, userID)
+		if err != nil {
+			return err
+		}
+		now := formatTime(time.Now())
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE annotations SET seq = ?, rev = rev + 1, edition_sha = NULL,
+			        locator_json = NULL, progression = NULL, excerpt = '',
+			        color = '', body = '', device_id = '', client_ts = NULL,
+			        updated_at = ?, deleted_at = ?
+			 WHERE user_id = ? AND id = ?`,
+			seq, now, now, userID, id); err != nil {
+			return err
+		}
+		r.Rev, r.Seq = stored.Rev+1, seq
+		return nil
+	})
+	if err != nil {
+		return store.AnnotationResult{}, err
+	}
+	return r, nil
+}
+
+// AnnotationChanges returns records (tombstones included) with
+// seq > since, in seq order. This is a state feed, not history: an
+// edited record reappears at the head with its current content.
+func (s *Store) AnnotationChanges(ctx context.Context, userID string, since int64, limit int) (store.AnnotationChangesPage, error) {
+	var page store.AnnotationChangesPage
+	err := s.db.QueryRowContext(ctx,
+		`SELECT next_annotation_seq - 1 FROM seq_counters WHERE user_id = ?`,
+		userID).Scan(&page.HighWater)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return page, err
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+annotationCols+` FROM annotations
+		 WHERE user_id = ? AND seq > ? ORDER BY seq LIMIT ?`,
+		userID, since, limit+1)
+	if err != nil {
+		return page, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		a, err := scanAnnotation(rows)
+		if err != nil {
+			return page, err
+		}
+		page.Annotations = append(page.Annotations, a)
+	}
+	if err := rows.Err(); err != nil {
+		return page, err
+	}
+	if len(page.Annotations) > limit {
+		page.HasMore = true
+		page.Annotations = page.Annotations[:limit]
+	}
+	return page, nil
+}
+
+// WorkAnnotations returns the live set for one work, ordered by
+// progression then client_ts.
+func (s *Store) WorkAnnotations(ctx context.Context, userID, workID string) ([]store.Annotation, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT `+annotationCols+` FROM annotations
+		 WHERE user_id = ? AND work_id = ? AND deleted_at IS NULL
+		 ORDER BY progression IS NULL, progression, client_ts, id`,
+		userID, workID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []store.Annotation
+	for rows.Next() {
+		a, err := scanAnnotation(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// SweepAnnotationTombstones removes tombstones older than the cutoff.
+// After the sweep the id is simply unknown: a device offline longer
+// than the window that pushes it again creates a new record.
+func (s *Store) SweepAnnotationTombstones(ctx context.Context, userID string, olderThan time.Time) (int64, error) {
+	res, err := s.db.ExecContext(ctx,
+		`DELETE FROM annotations
+		 WHERE user_id = ? AND deleted_at IS NOT NULL AND deleted_at < ?`,
+		userID, formatTime(olderThan))
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// moveAnnotationsTx reassigns annotations during a split or a merge.
+// A moved annotation is a write like any other — new seq, rev
+// incremented — so every synced device learns its new work_id on the
+// next pull. editionSHA nil moves the whole work's records (a merge);
+// non-nil moves only the edition's (a split — records with no edition
+// stay with the surviving work).
+func moveAnnotationsTx(ctx context.Context, tx *sql.Tx, userID, fromWorkID, toWorkID string, editionSHA *string) error {
+	query := `SELECT id FROM annotations WHERE user_id = ? AND work_id = ?`
+	args := []any{userID, fromWorkID}
+	if editionSHA != nil {
+		query += ` AND edition_sha = ?`
+		args = append(args, *editionSHA)
+	}
+	rows, err := tx.QueryContext(ctx, query+` ORDER BY seq`, args...)
+	if err != nil {
+		return err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	now := formatTime(time.Now())
+	for _, id := range ids {
+		seq, err := nextAnnotationSeqTx(ctx, tx, userID)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE annotations SET work_id = ?, seq = ?, rev = rev + 1, updated_at = ?
+			 WHERE user_id = ? AND id = ?`,
+			toWorkID, seq, now, userID, id); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func nullFloat(p *float64) sql.NullFloat64 {
+	if p == nil {
+		return sql.NullFloat64{}
+	}
+	return sql.NullFloat64{Float64: *p, Valid: true}
+}

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -553,7 +553,45 @@ CREATE TABLE user_folders (
 CREATE INDEX user_folders_folder ON user_folders(folder_id);
 `
 
+// annotationSync is migration 5 (ADR-0028). Annotations are the third
+// kind of reading state and the first mutable one: rev-based
+// compare-and-set rather than append-only, a per-user annotation
+// counter beside — never shared with — the op counter, and a bounded
+// tombstone when deleted. Content columns are cleared on the
+// tombstone, which is why most of them are nullable.
+const annotationSync = `
+ALTER TABLE seq_counters ADD COLUMN next_annotation_seq INTEGER NOT NULL DEFAULT 1;
+
+CREATE TABLE annotations (
+    user_id      TEXT NOT NULL,
+    id           TEXT NOT NULL,
+    seq          INTEGER NOT NULL,
+    rev          INTEGER NOT NULL,
+    work_id      TEXT NOT NULL,
+    edition_sha  TEXT,
+    kind         TEXT NOT NULL CHECK (kind IN ('highlight', 'note', 'bookmark')),
+    locator_json BLOB,
+    progression  REAL,
+    excerpt      TEXT NOT NULL DEFAULT '',
+    color        TEXT NOT NULL DEFAULT '',
+    body         TEXT NOT NULL DEFAULT '',
+    device_id    TEXT NOT NULL DEFAULT '',
+    client_ts    TEXT,
+    updated_at   TEXT NOT NULL,
+    deleted_at   TEXT,
+    PRIMARY KEY (user_id, id),
+    UNIQUE (user_id, seq),
+    FOREIGN KEY (user_id, work_id) REFERENCES works(user_id, id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id, edition_sha, work_id)
+        REFERENCES editions(user_id, sha256, work_id)
+        DEFERRABLE INITIALLY DEFERRED
+);
+CREATE INDEX annotations_work ON annotations(user_id, work_id, deleted_at);
+CREATE INDEX annotations_tombstones ON annotations(user_id, deleted_at)
+    WHERE deleted_at IS NOT NULL;
+`
+
 // migrations is append-only: entry n is applied to a database that has
 // applied n-1 of them, so an entry that has shipped is never edited
 // again — the baseline included.
-var migrations = []string{schema, claimRevisions, folderUploads, folderAccess}
+var migrations = []string{schema, claimRevisions, folderUploads, folderAccess, annotationSync}

--- a/internal/store/sqlite/works.go
+++ b/internal/store/sqlite/works.go
@@ -377,6 +377,11 @@ func (s *Store) SplitWork(ctx context.Context, userID, workID, editionSHA string
 		newWork.ID, userID, editionSHA, workID); err != nil {
 		return err
 	}
+	// An annotation with this edition_sha follows its edition; one
+	// without stays with the surviving work (ADR-0028).
+	if err := moveAnnotationsTx(ctx, tx, userID, workID, newWork.ID, &editionSHA); err != nil {
+		return err
+	}
 	// The edition's SHA alias is implied by the split contract.
 	if errors.Is(shaAliasErr, sql.ErrNoRows) {
 		if _, err := tx.ExecContext(ctx,
@@ -559,6 +564,11 @@ func (s *Store) MergeWorks(ctx context.Context, userID, fromWorkID, intoWorkID s
 	}
 	if _, err := tx.ExecContext(ctx,
 		`UPDATE sessions SET work_id = ? WHERE user_id = ? AND work_id = ?`, intoWorkID, userID, fromWorkID); err != nil {
+		return err
+	}
+	// Every annotation — tombstones included — follows to the survivor
+	// (ADR-0028), each as a new write so synced devices learn of it.
+	if err := moveAnnotationsTx(ctx, tx, userID, fromWorkID, intoWorkID, nil); err != nil {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1108,6 +1108,140 @@ type Heads struct {
 	SnapshotSeq int64
 }
 
+// AnnotationKind is what an annotation record is (ADR-0028). One
+// table, one API shape; kind is a column, not a schema.
+type AnnotationKind string
+
+const (
+	// AnnotationHighlight anchors to a range and may carry a body —
+	// that body is the attached note, not a second record.
+	AnnotationHighlight AnnotationKind = "highlight"
+	// AnnotationNote is a body with no anchor.
+	AnnotationNote AnnotationKind = "note"
+	// AnnotationBookmark is an anchor with no body.
+	AnnotationBookmark AnnotationKind = "bookmark"
+)
+
+// Valid reports whether k is a known annotation kind.
+func (k AnnotationKind) Valid() bool {
+	switch k {
+	case AnnotationHighlight, AnnotationNote, AnnotationBookmark:
+		return true
+	}
+	return false
+}
+
+// AnnotationColors is the fixed highlight palette. A color is a token
+// from this list, validated at the edge — never an arbitrary string a
+// page would hand to CSS.
+var AnnotationColors = []string{"yellow", "green", "blue", "pink", "purple", "orange"}
+
+// ValidAnnotationColor reports whether c is empty or a palette token.
+func ValidAnnotationColor(c string) bool {
+	if c == "" {
+		return true
+	}
+	for _, known := range AnnotationColors {
+		if c == known {
+			return true
+		}
+	}
+	return false
+}
+
+// Annotation is one per-user annotation record (ADR-0028): the third
+// kind of reading state, and the first mutable one. It is a small
+// document the reader edits, not an observation, so it lives beside
+// the append-only op log rather than inside it: server-assigned rev
+// for compare-and-set, per-user annotation seq for the delta feed,
+// and a bounded tombstone when deleted.
+type Annotation struct {
+	UserID      string
+	ID          string // client-generated, opaque, deterministic (the op_id convention)
+	Seq         int64  // per-user annotation counter; stamped on every accepted write
+	Rev         int64  // server-assigned, incremented on every accepted write
+	WorkID      string
+	EditionSHA  *string
+	Kind        AnnotationKind
+	LocatorJSON []byte   // opaque envelope, same shape as ops.locator_json
+	Progression *float64 // 0..1; read by the server only to sort a list
+	Excerpt     string
+	Color       string
+	Body        string
+	DeviceID    string
+	ClientTS    time.Time // display metadata only; never decides a winner
+	UpdatedAt   time.Time
+	DeletedAt   *time.Time
+}
+
+// Deleted reports whether the record is a tombstone.
+func (a Annotation) Deleted() bool { return a.DeletedAt != nil }
+
+// AnnotationWrite is one item of a batched annotation push. BaseRev is
+// the rev the client last saw; 0 means create.
+type AnnotationWrite struct {
+	ID          string
+	BaseRev     int64
+	WorkID      string
+	EditionSHA  *string
+	Kind        AnnotationKind
+	LocatorJSON []byte
+	Progression *float64
+	Excerpt     string
+	Color       string
+	Body        string
+	ClientTS    time.Time
+}
+
+// AnnotationResult is the per-item outcome of an annotation write.
+type AnnotationResult struct {
+	ID     string
+	Status string // "applied" | "duplicate" | "conflict" | "invalid"
+	Rev    int64  // when applied or duplicate
+	Seq    int64  // when applied or duplicate
+	Reason string // when invalid
+	// Server is the server's current copy, carried on a conflict so
+	// the client resolves: the server orders, it never merges.
+	Server *Annotation
+}
+
+// SameAnnotationPayload reports whether an incoming write is
+// byte-identical to a stored record's content — the retry comparison:
+// an accepted write pushed again must be acknowledged, not conflicted.
+func SameAnnotationPayload(stored Annotation, w AnnotationWrite, deviceID string) bool {
+	if stored.Deleted() {
+		return false
+	}
+	if stored.WorkID != w.WorkID || stored.Kind != w.Kind ||
+		stored.DeviceID != deviceID ||
+		stored.Excerpt != w.Excerpt || stored.Color != w.Color ||
+		stored.Body != w.Body ||
+		// Compared at microsecond precision: Postgres timestamptz
+		// truncates nanoseconds on write, and a retry must still match.
+		!stored.ClientTS.UTC().Truncate(time.Microsecond).
+			Equal(w.ClientTS.UTC().Truncate(time.Microsecond)) {
+		return false
+	}
+	if !equalOptionalString(stored.EditionSHA, w.EditionSHA) {
+		return false
+	}
+	if (stored.Progression == nil) != (w.Progression == nil) ||
+		(stored.Progression != nil && *stored.Progression != *w.Progression) {
+		return false
+	}
+	return string(stored.LocatorJSON) == string(w.LocatorJSON)
+}
+
+// AnnotationChangesPage is one page of the annotation delta feed. It
+// is a state feed, not history: an edited record moves to the head of
+// the stream with its current content, and may appear on two pages of
+// one pull — harmless, the client keys by id and the newest rev wins.
+type AnnotationChangesPage struct {
+	Annotations []Annotation
+	HighWater   int64 // current annotation counter high-water for the user
+	HasMore     bool
+}
+
 // Store is the storage contract. Implementations: SQLite and Postgres.
 // All methods take a userID; cross-user access is impossible by
 // construction.
@@ -1523,6 +1657,35 @@ type Store interface {
 	HeadsFor(ctx context.Context, userID string) (Heads, error)
 	CompactionHorizon(ctx context.Context, userID string) (int64, error)
 	Compact(ctx context.Context, userID string, olderThan time.Time) (newHorizon int64, err error)
+
+	// Annotations (ADR-0028): mutable per-user reading state, never
+	// part of the op log. Every accepted write — create, edit,
+	// tombstone — stamps the record with the next value of a per-user
+	// annotation counter (a second counter beside the op one, never
+	// shared with it). Concurrency is compare-and-set on rev; a stale
+	// write is a conflict carrying the server's current copy.
+	//
+	// PushAnnotations is never atomic: one result per item, one bad
+	// item fails alone. maxLivePerWork is the per-work live-record cap,
+	// enforced inside the write transaction where two concurrent
+	// creates cannot both squeeze under it.
+	PushAnnotations(ctx context.Context, userID, deviceID string, items []AnnotationWrite, maxLivePerWork int) ([]AnnotationResult, error)
+	// AnnotationChanges returns records (tombstones included) with
+	// seq > since, in seq order, plus has_more and the high-water mark.
+	AnnotationChanges(ctx context.Context, userID string, since int64, limit int) (AnnotationChangesPage, error)
+	// WorkAnnotations is the live set for one work, ordered by
+	// progression then client_ts.
+	WorkAnnotations(ctx context.Context, userID, workID string) ([]Annotation, error)
+	// DeleteAnnotation writes the tombstone iff rev matches; a stale
+	// rev is a conflict with the server copy, and deleting a tombstone
+	// is a duplicate (already accepted). The tombstone keeps nothing
+	// but identity, rev, seq and when.
+	DeleteAnnotation(ctx context.Context, userID, id string, rev int64) (AnnotationResult, error)
+	// SweepAnnotationTombstones removes tombstones deleted before the
+	// cutoff. After the sweep the id is simply unknown: a device
+	// offline longer than the window that pushes it again creates a
+	// new record, rev starting over at 1.
+	SweepAnnotationTombstones(ctx context.Context, userID string, olderThan time.Time) (int64, error)
 
 	// Sessions.
 	AppendSessions(ctx context.Context, userID string, ss []Session) error

--- a/internal/store/storetest/annotations.go
+++ b/internal/store/storetest/annotations.go
@@ -1,0 +1,577 @@
+package storetest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// annWrite is one plausible highlight write against a work.
+func annWrite(id, workID string, baseRev int64) store.AnnotationWrite {
+	return store.AnnotationWrite{
+		ID:          id,
+		BaseRev:     baseRev,
+		WorkID:      workID,
+		Kind:        store.AnnotationHighlight,
+		LocatorJSON: []byte(`{"href":"/ch1.xhtml","locations":{"progression":0.25}}`),
+		Progression: Ptr(0.25),
+		Excerpt:     "a passage worth keeping",
+		Color:       "yellow",
+		Body:        "and a thought about it",
+		ClientTS:    time.Now(),
+	}
+}
+
+func pushOne(t *testing.T, s store.Store, userID, deviceID string, w store.AnnotationWrite) store.AnnotationResult {
+	t.Helper()
+	res, err := s.PushAnnotations(context.Background(), userID, deviceID, []store.AnnotationWrite{w}, 2000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return res[0]
+}
+
+func testAnnotationPushIdempotencyAndRevConflict(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "annie")
+	w := MkWork(t, s, u, "w1", "abc123")
+
+	// Create.
+	item := annWrite("a1", w.ID, 0)
+	r := pushOne(t, s, u.ID, "d1", item)
+	if r.Status != "applied" || r.Rev != 1 || r.Seq == 0 {
+		t.Fatalf("create: %+v", r)
+	}
+
+	// The same annotation pushed twice is stored once.
+	r = pushOne(t, s, u.ID, "d1", item)
+	if r.Status != "duplicate" || r.Rev != 1 {
+		t.Fatalf("retry of create: %+v", r)
+	}
+	if list, err := s.WorkAnnotations(ctx, u.ID, w.ID); err != nil || len(list) != 1 {
+		t.Fatalf("stored more than once: %d %v", len(list), err)
+	}
+
+	// Edit with the rev the client last saw.
+	edit := item
+	edit.BaseRev, edit.Color, edit.Body = 1, "green", "reworded"
+	r = pushOne(t, s, u.ID, "d1", edit)
+	if r.Status != "applied" || r.Rev != 2 {
+		t.Fatalf("edit: %+v", r)
+	}
+	editSeq := r.Seq
+	r = pushOne(t, s, u.ID, "d1", edit)
+	if r.Status != "duplicate" || r.Rev != 2 || r.Seq != editSeq {
+		t.Fatalf("retry of edit: %+v", r)
+	}
+
+	// A push with a stale rev is a conflict carrying the server copy,
+	// and changes nothing.
+	stale := item
+	stale.BaseRev, stale.Color = 1, "pink"
+	r = pushOne(t, s, u.ID, "d1", stale)
+	if r.Status != "conflict" || r.Server == nil || r.Server.Rev != 2 || r.Server.Color != "green" {
+		t.Fatalf("stale edit: %+v", r)
+	}
+	list, err := s.WorkAnnotations(ctx, u.ID, w.ID)
+	if err != nil || len(list) != 1 || list[0].Color != "green" || list[0].Rev != 2 {
+		t.Fatalf("stale edit changed something: %+v %v", list, err)
+	}
+
+	// A delete with a stale rev is the same conflict.
+	dr, err := s.DeleteAnnotation(ctx, u.ID, "a1", 1)
+	if err != nil || dr.Status != "conflict" || dr.Server == nil || dr.Server.Rev != 2 {
+		t.Fatalf("stale delete: %+v %v", dr, err)
+	}
+
+	// The matching delete writes the tombstone; deleting a tombstone is
+	// already accepted.
+	dr, err = s.DeleteAnnotation(ctx, u.ID, "a1", 2)
+	if err != nil || dr.Status != "applied" || dr.Rev != 3 {
+		t.Fatalf("delete: %+v %v", dr, err)
+	}
+	again, err := s.DeleteAnnotation(ctx, u.ID, "a1", 99)
+	if err != nil || again.Status != "duplicate" || again.Rev != 3 || again.Seq != dr.Seq {
+		t.Fatalf("delete of tombstone: %+v %v", again, err)
+	}
+	if _, err := s.DeleteAnnotation(ctx, u.ID, "nope", 1); err != store.ErrNotFound {
+		t.Fatalf("delete unknown id: want ErrNotFound, got %v", err)
+	}
+
+	// The tombstone carries nothing but identity, rev, seq and when.
+	page, err := s.AnnotationChanges(ctx, u.ID, 0, 100)
+	if err != nil || len(page.Annotations) != 1 {
+		t.Fatalf("changes: %+v %v", page, err)
+	}
+	tomb := page.Annotations[0]
+	if !tomb.Deleted() || tomb.ID != "a1" || tomb.Rev != 3 {
+		t.Fatalf("tombstone identity: %+v", tomb)
+	}
+	if tomb.LocatorJSON != nil || tomb.Progression != nil || tomb.EditionSHA != nil ||
+		tomb.Excerpt != "" || tomb.Color != "" || tomb.Body != "" ||
+		tomb.DeviceID != "" || !tomb.ClientTS.IsZero() {
+		t.Fatalf("tombstone kept content: %+v", tomb)
+	}
+
+	// A deliberate, rev-matching write onto the tombstone recreates the
+	// record: the reader saw the deletion and decided otherwise.
+	revive := item
+	revive.BaseRev = 3
+	r = pushOne(t, s, u.ID, "d1", revive)
+	if r.Status != "applied" || r.Rev != 4 {
+		t.Fatalf("write onto tombstone: %+v", r)
+	}
+	if list, err := s.WorkAnnotations(ctx, u.ID, w.ID); err != nil || len(list) != 1 || list[0].Deleted() {
+		t.Fatalf("revived record: %+v %v", list, err)
+	}
+
+	// One bad item fails alone.
+	batch := []store.AnnotationWrite{
+		annWrite("a2", w.ID, 0),
+		annWrite("a3", "no-such-work", 0),
+	}
+	results, err := s.PushAnnotations(ctx, u.ID, "d1", batch, 2000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results[0].Status != "applied" || results[1].Status != "invalid" || results[1].Reason == "" {
+		t.Fatalf("mixed batch: %+v", results)
+	}
+}
+
+func testAnnotationCapPerWork(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "capped")
+	w := MkWork(t, s, u, "w1", "abc123")
+
+	const capN = 5
+	var items []store.AnnotationWrite
+	for i := 0; i < capN+1; i++ {
+		items = append(items, annWrite(fmt.Sprintf("a-%d", i), w.ID, 0))
+	}
+	results, err := s.PushAnnotations(ctx, u.ID, "d1", items, capN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < capN; i++ {
+		if results[i].Status != "applied" {
+			t.Fatalf("under cap refused: %+v", results[i])
+		}
+	}
+	if results[capN].Status != "invalid" {
+		t.Fatalf("over cap accepted: %+v", results[capN])
+	}
+
+	// An edit of an existing record is not a new live one.
+	edit := items[0]
+	edit.BaseRev, edit.Color = 1, "blue"
+	res, err := s.PushAnnotations(ctx, u.ID, "d1", []store.AnnotationWrite{edit}, capN)
+	if err != nil || res[0].Status != "applied" {
+		t.Fatalf("edit at cap: %+v %v", res, err)
+	}
+
+	// A live edit naming an edition the work does not have is a
+	// per-item invalid, and its neighbor is untouched by it — the
+	// reference check runs before the composite FK ever could.
+	badEdit := items[0]
+	badEdit.BaseRev, badEdit.EditionSHA = 2, Ptr("no-such-edition")
+	goodEdit := items[2]
+	goodEdit.BaseRev, goodEdit.Color = 1, "pink"
+	res, err = s.PushAnnotations(ctx, u.ID, "d1",
+		[]store.AnnotationWrite{badEdit, goodEdit}, capN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res[0].Status != "invalid" || res[0].Reason == "" {
+		t.Fatalf("edit to unknown edition: %+v", res[0])
+	}
+	if res[1].Status != "applied" {
+		t.Fatalf("neighbor of bad edition edit: %+v", res[1])
+	}
+	kept, err := s.WorkAnnotations(ctx, u.ID, w.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, a := range kept {
+		if a.ID == "a-0" && (a.Rev != 2 || a.EditionSHA != nil) {
+			t.Fatalf("refused edit changed the record: %+v", a)
+		}
+	}
+
+	// A deletion frees a slot.
+	if _, err := s.DeleteAnnotation(ctx, u.ID, "a-1", 1); err != nil {
+		t.Fatal(err)
+	}
+	res, err = s.PushAnnotations(ctx, u.ID, "d1",
+		[]store.AnnotationWrite{annWrite("a-free", w.ID, 0)}, capN)
+	if err != nil || res[0].Status != "applied" {
+		t.Fatalf("push after freeing a slot: %+v %v", res, err)
+	}
+}
+
+func testAnnotationCapUnderConcurrency(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "cap-race")
+	w := MkWork(t, s, u, "w1", "abc123")
+
+	const capN = 10
+	const writers = 4
+	var wg sync.WaitGroup
+	applied := make(chan int, writers)
+	errs := make(chan error, writers)
+	for d := 0; d < writers; d++ {
+		wg.Add(1)
+		go func(d int) {
+			defer wg.Done()
+			var items []store.AnnotationWrite
+			for i := 0; i < capN; i++ {
+				items = append(items, annWrite(fmt.Sprintf("d%d-a%d", d, i), w.ID, 0))
+			}
+			results, err := s.PushAnnotations(ctx, u.ID, fmt.Sprintf("dev-%d", d), items, capN)
+			if err != nil {
+				errs <- err
+				return
+			}
+			n := 0
+			for _, r := range results {
+				if r.Status == "applied" {
+					n++
+				} else if r.Status != "invalid" {
+					errs <- fmt.Errorf("unexpected status %q", r.Status)
+					return
+				}
+			}
+			applied <- n
+		}(d)
+	}
+	wg.Wait()
+	close(errs)
+	close(applied)
+	for err := range errs {
+		t.Fatal(err)
+	}
+	total := 0
+	for n := range applied {
+		total += n
+	}
+	if total != capN {
+		t.Fatalf("concurrent creates squeezed past the cap: %d applied, cap %d", total, capN)
+	}
+	if list, err := s.WorkAnnotations(ctx, u.ID, w.ID); err != nil || len(list) != capN {
+		t.Fatalf("live records: %d %v", len(list), err)
+	}
+}
+
+func testAnnotationChangesFeed(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "feed")
+	w := MkWork(t, s, u, "w1", "abc123")
+
+	const n = 7
+	for i := 0; i < n; i++ {
+		item := annWrite(fmt.Sprintf("a-%d", i), w.ID, 0)
+		item.Progression = Ptr(float64(i) / 10)
+		if r := pushOne(t, s, u.ID, "d1", item); r.Status != "applied" {
+			t.Fatalf("push %d: %+v", i, r)
+		}
+	}
+
+	// Page through with the /v1/changes contract: advance since to the
+	// last seq received; a pull since a cursor misses no committed
+	// write and returns records in seq order.
+	var seen []store.Annotation
+	since := int64(0)
+	for {
+		page, err := s.AnnotationChanges(ctx, u.ID, since, 3)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, a := range page.Annotations {
+			if a.Seq <= since {
+				t.Fatalf("out of order: seq %d after cursor %d", a.Seq, since)
+			}
+			since = a.Seq
+			seen = append(seen, a)
+		}
+		if !page.HasMore {
+			if page.HighWater != since {
+				t.Fatalf("high water %d, cursor %d", page.HighWater, since)
+			}
+			break
+		}
+	}
+	if len(seen) != n {
+		t.Fatalf("feed lost records: %d of %d", len(seen), n)
+	}
+
+	// An edited record moves to the head of the stream with its current
+	// content; the client keys by id and the newest rev wins.
+	edit := annWrite("a-2", w.ID, 1)
+	edit.Progression, edit.Color = Ptr(0.2), "purple"
+	r := pushOne(t, s, u.ID, "d1", edit)
+	if r.Status != "applied" {
+		t.Fatalf("edit: %+v", r)
+	}
+	page, err := s.AnnotationChanges(ctx, u.ID, since, 100)
+	if err != nil || len(page.Annotations) != 1 {
+		t.Fatalf("edited record not at head: %+v %v", page, err)
+	}
+	if got := page.Annotations[0]; got.ID != "a-2" || got.Rev != 2 || got.Color != "purple" {
+		t.Fatalf("edited record content: %+v", got)
+	}
+	since = page.Annotations[0].Seq
+
+	// A tombstone is a feed record like any other.
+	if _, err := s.DeleteAnnotation(ctx, u.ID, "a-0", 1); err != nil {
+		t.Fatal(err)
+	}
+	page, err = s.AnnotationChanges(ctx, u.ID, since, 100)
+	if err != nil || len(page.Annotations) != 1 || !page.Annotations[0].Deleted() {
+		t.Fatalf("tombstone missing from feed: %+v %v", page, err)
+	}
+}
+
+func testAnnotationTombstoneSweep(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "sweep")
+	w := MkWork(t, s, u, "w1", "abc123")
+
+	if r := pushOne(t, s, u.ID, "d1", annWrite("a1", w.ID, 0)); r.Status != "applied" {
+		t.Fatalf("push: %+v", r)
+	}
+	if r := pushOne(t, s, u.ID, "d1", annWrite("a2", w.ID, 0)); r.Status != "applied" {
+		t.Fatalf("push: %+v", r)
+	}
+	if _, err := s.DeleteAnnotation(ctx, u.ID, "a1", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// A sweep with a cutoff before the deletion keeps the tombstone.
+	n, err := s.SweepAnnotationTombstones(ctx, u.ID, time.Now().Add(-time.Hour))
+	if err != nil || n != 0 {
+		t.Fatalf("early sweep: %d %v", n, err)
+	}
+	// Past the window it goes; the live record stays.
+	n, err = s.SweepAnnotationTombstones(ctx, u.ID, time.Now().Add(time.Hour))
+	if err != nil || n != 1 {
+		t.Fatalf("sweep: %d %v", n, err)
+	}
+	page, err := s.AnnotationChanges(ctx, u.ID, 0, 100)
+	if err != nil || len(page.Annotations) != 1 || page.Annotations[0].ID != "a2" {
+		t.Fatalf("after sweep: %+v %v", page, err)
+	}
+
+	// After the sweep the id is simply unknown: pushing it again
+	// creates a new record, rev starting over at 1.
+	r := pushOne(t, s, u.ID, "d1", annWrite("a1", w.ID, 0))
+	if r.Status != "applied" || r.Rev != 1 {
+		t.Fatalf("push after sweep: %+v", r)
+	}
+	if _, err := s.DeleteAnnotation(ctx, u.ID, "a2", 99); err != nil {
+		// a2 is live at rev 1; this stale delete must conflict, not error.
+		t.Fatal(err)
+	}
+}
+
+func testAnnotationSplitMergeReassignment(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "mover")
+	w := MkWork(t, s, u, "w1", "abc123")
+
+	anchored := annWrite("with-edition", w.ID, 0)
+	anchored.EditionSHA = Ptr("abc123")
+	if r := pushOne(t, s, u.ID, "d1", anchored); r.Status != "applied" {
+		t.Fatalf("push: %+v", r)
+	}
+	loose := annWrite("no-edition", w.ID, 0)
+	if r := pushOne(t, s, u.ID, "d1", loose); r.Status != "applied" {
+		t.Fatalf("push: %+v", r)
+	}
+	before, err := s.AnnotationChanges(ctx, u.ID, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cursor := before.HighWater
+
+	// In a split, one with an edition_sha follows its edition; one
+	// without stays with the surviving work.
+	if err := s.SplitWork(ctx, u.ID, w.ID, "abc123", nil,
+		store.Work{ID: "w2", UserID: u.ID, Title: "split", CreatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	moved, err := s.WorkAnnotations(ctx, u.ID, "w2")
+	if err != nil || len(moved) != 1 || moved[0].ID != "with-edition" || moved[0].Rev != 2 {
+		t.Fatalf("split move: %+v %v", moved, err)
+	}
+	stayed, err := s.WorkAnnotations(ctx, u.ID, w.ID)
+	if err != nil || len(stayed) != 1 || stayed[0].ID != "no-edition" || stayed[0].Rev != 1 {
+		t.Fatalf("split keep: %+v %v", stayed, err)
+	}
+
+	// A moved annotation is a write like any other: it resurfaces in
+	// the feed with its new work_id.
+	page, err := s.AnnotationChanges(ctx, u.ID, cursor, 100)
+	if err != nil || len(page.Annotations) != 1 {
+		t.Fatalf("moved record not in feed: %+v %v", page, err)
+	}
+	if got := page.Annotations[0]; got.ID != "with-edition" || got.WorkID != "w2" {
+		t.Fatalf("feed record after split: %+v", got)
+	}
+	cursor = page.HighWater
+
+	// In a merge, all of them follow to the survivor.
+	if err := s.MergeWorks(ctx, u.ID, "w2", w.ID); err != nil {
+		t.Fatal(err)
+	}
+	all, err := s.WorkAnnotations(ctx, u.ID, w.ID)
+	if err != nil || len(all) != 2 {
+		t.Fatalf("merge: %+v %v", all, err)
+	}
+	page, err = s.AnnotationChanges(ctx, u.ID, cursor, 100)
+	if err != nil || len(page.Annotations) != 1 || page.Annotations[0].ID != "with-edition" ||
+		page.Annotations[0].WorkID != w.ID || page.Annotations[0].Rev != 3 {
+		t.Fatalf("feed record after merge: %+v %v", page, err)
+	}
+}
+
+func testAnnotationCrossUserIsolation(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	alice := MkUser(t, s, "iso-alice")
+	eve := MkUser(t, s, "iso-eve")
+	w := MkWork(t, s, alice, "w1", "abc123")
+	MkWork(t, s, eve, "w1", "def456") // same work id, different reader
+
+	if r := pushOne(t, s, alice.ID, "d1", annWrite("a1", w.ID, 0)); r.Status != "applied" {
+		t.Fatalf("push: %+v", r)
+	}
+
+	// No route, ever, returns another reader's annotations.
+	if list, err := s.WorkAnnotations(ctx, eve.ID, w.ID); err != nil || len(list) != 0 {
+		t.Fatalf("cross-user work list: %+v %v", list, err)
+	}
+	if page, err := s.AnnotationChanges(ctx, eve.ID, 0, 100); err != nil ||
+		len(page.Annotations) != 0 || page.HighWater != 0 {
+		t.Fatalf("cross-user feed: %+v %v", page, err)
+	}
+	if _, err := s.DeleteAnnotation(ctx, eve.ID, "a1", 1); err != store.ErrNotFound {
+		t.Fatalf("cross-user delete: want ErrNotFound, got %v", err)
+	}
+	// Eve pushing the same id creates her own record — it cannot see,
+	// conflict with, or edit Alice's.
+	r := pushOne(t, s, eve.ID, "d9", annWrite("a1", w.ID, 0))
+	if r.Status != "applied" || r.Rev != 1 || r.Seq != 1 {
+		t.Fatalf("same id, other user: %+v", r)
+	}
+	got, err := s.WorkAnnotations(ctx, alice.ID, w.ID)
+	if err != nil || len(got) != 1 || got[0].DeviceID != "d1" {
+		t.Fatalf("alice's record touched: %+v %v", got, err)
+	}
+}
+
+func testAnnotationDeleteWorkCascade(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "cascade")
+	w := MkWork(t, s, u, "w1", "abc123")
+
+	if r := pushOne(t, s, u.ID, "d1", annWrite("live", w.ID, 0)); r.Status != "applied" {
+		t.Fatalf("push: %+v", r)
+	}
+	if r := pushOne(t, s, u.ID, "d1", annWrite("gone", w.ID, 0)); r.Status != "applied" {
+		t.Fatalf("push: %+v", r)
+	}
+	if _, err := s.DeleteAnnotation(ctx, u.ID, "gone", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// DeleteWork removes the work's annotations and tombstones in the
+	// same transaction as everything else.
+	if err := s.DeleteWork(ctx, u.ID, w.ID); err != nil {
+		t.Fatal(err)
+	}
+	page, err := s.AnnotationChanges(ctx, u.ID, 0, 100)
+	if err != nil || len(page.Annotations) != 0 {
+		t.Fatalf("annotations survived DeleteWork: %+v %v", page, err)
+	}
+}
+
+// testConcurrentAnnotationPush is the annotation counter's own
+// concurrency property, with the weaker guarantee a state feed needs:
+// seq values are unique and assigned in commit order — gaps are
+// harmless. The op counter's gap-free property test is untouched.
+func testConcurrentAnnotationPush(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "ann-prop")
+	w := MkWork(t, s, u, "w1", "abc123")
+
+	const devices = 8
+	const perDevice = 25
+
+	var wg sync.WaitGroup
+	errs := make(chan error, devices)
+	for d := 0; d < devices; d++ {
+		wg.Add(1)
+		go func(d int) {
+			defer wg.Done()
+			dev := fmt.Sprintf("dev-%d", d)
+			for b := 0; b < perDevice; b += 5 {
+				var batch []store.AnnotationWrite
+				for i := 0; i < 5 && b+i < perDevice; i++ {
+					batch = append(batch, annWrite(fmt.Sprintf("%s-a-%d", dev, b+i), w.ID, 0))
+				}
+				results, err := s.PushAnnotations(ctx, u.ID, dev, batch, 10_000)
+				if err != nil {
+					errs <- err
+					return
+				}
+				for _, r := range results {
+					if r.Status != "applied" {
+						errs <- fmt.Errorf("%s: %s status %s", dev, r.ID, r.Status)
+						return
+					}
+				}
+			}
+		}(d)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+
+	page, err := s.AnnotationChanges(ctx, u.ID, 0, devices*perDevice+10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := devices * perDevice
+	if len(page.Annotations) != want {
+		t.Fatalf("want %d records, got %d", want, len(page.Annotations))
+	}
+	seen := map[int64]bool{}
+	last := int64(0)
+	for _, a := range page.Annotations {
+		if seen[a.Seq] {
+			t.Fatalf("seq %d assigned twice", a.Seq)
+		}
+		seen[a.Seq] = true
+		if a.Seq <= last {
+			t.Fatalf("feed not in seq order: %d after %d", a.Seq, last)
+		}
+		last = a.Seq
+	}
+	if page.HighWater < last {
+		t.Fatalf("high water %d below last seq %d", page.HighWater, last)
+	}
+}

--- a/internal/store/storetest/annotations.go
+++ b/internal/store/storetest/annotations.go
@@ -380,6 +380,33 @@ func testAnnotationTombstoneSweep(t *testing.T, open OpenFunc) {
 		// a2 is live at rev 1; this stale delete must conflict, not error.
 		t.Fatal(err)
 	}
+
+	// The post-sweep resurrect quoting an old base is accepted at rev 1
+	// — and its byte-identical retry is a duplicate, never a conflict
+	// and never a second application, whatever base it quoted.
+	if _, err := s.DeleteAnnotation(ctx, u.ID, "a1", 1); err != nil {
+		t.Fatal(err)
+	}
+	if n, err := s.SweepAnnotationTombstones(ctx, u.ID, time.Now().Add(time.Hour)); err != nil || n != 1 {
+		t.Fatalf("second sweep: %d %v", n, err)
+	}
+	for _, base := range []int64{1, 3} {
+		resurrect := annWrite("a1", w.ID, base)
+		first := pushOne(t, s, u.ID, "d1", resurrect)
+		if first.Status != "applied" || first.Rev != 1 {
+			t.Fatalf("resurrect at base %d: %+v", base, first)
+		}
+		retry := pushOne(t, s, u.ID, "d1", resurrect)
+		if retry.Status != "duplicate" || retry.Rev != first.Rev || retry.Seq != first.Seq {
+			t.Fatalf("resurrect retry at base %d: %+v (first %+v)", base, retry, first)
+		}
+		if _, err := s.DeleteAnnotation(ctx, u.ID, "a1", 1); err != nil {
+			t.Fatal(err)
+		}
+		if n, err := s.SweepAnnotationTombstones(ctx, u.ID, time.Now().Add(time.Hour)); err != nil || n != 1 {
+			t.Fatalf("sweep between resurrects: %d %v", n, err)
+		}
+	}
 }
 
 func testAnnotationSplitMergeReassignment(t *testing.T, open OpenFunc) {

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -234,6 +234,33 @@ func Run(t *testing.T, open OpenFunc) {
 	t.Run("SessionRollups", func(t *testing.T) { testSessionRollups(t, open) })
 	t.Run("Housekeeping", func(t *testing.T) { testHousekeeping(t, open) })
 	t.Run("ConcurrentAppendGapFreeSeq", func(t *testing.T) { testConcurrentAppend(t, open) })
+	t.Run("AnnotationPushIdempotencyAndRevConflict", func(t *testing.T) {
+		testAnnotationPushIdempotencyAndRevConflict(t, open)
+	})
+	t.Run("AnnotationCapPerWork", func(t *testing.T) {
+		testAnnotationCapPerWork(t, open)
+	})
+	t.Run("AnnotationCapUnderConcurrency", func(t *testing.T) {
+		testAnnotationCapUnderConcurrency(t, open)
+	})
+	t.Run("AnnotationChangesFeed", func(t *testing.T) {
+		testAnnotationChangesFeed(t, open)
+	})
+	t.Run("AnnotationTombstoneSweep", func(t *testing.T) {
+		testAnnotationTombstoneSweep(t, open)
+	})
+	t.Run("AnnotationSplitMergeReassignment", func(t *testing.T) {
+		testAnnotationSplitMergeReassignment(t, open)
+	})
+	t.Run("AnnotationCrossUserIsolation", func(t *testing.T) {
+		testAnnotationCrossUserIsolation(t, open)
+	})
+	t.Run("AnnotationDeleteWorkCascade", func(t *testing.T) {
+		testAnnotationDeleteWorkCascade(t, open)
+	})
+	t.Run("ConcurrentAnnotationPushMonotonicSeq", func(t *testing.T) {
+		testConcurrentAnnotationPush(t, open)
+	})
 	t.Run("PairingCodeSingleUse", func(t *testing.T) { testPairingRedeem(t, open) })
 	t.Run("KopluginSupersession", func(t *testing.T) { testKopluginUpsert(t, open) })
 	t.Run("LegacyAliasWritesAtomic", func(t *testing.T) { testLegacyAliasWritesAtomic(t, open) })

--- a/internal/webui/annotations_webui_test.go
+++ b/internal/webui/annotations_webui_test.go
@@ -1,0 +1,64 @@
+package webui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// TestWorkPageAnnotationsPanel covers ADR-0028's work-page panel: the
+// reader's own annotations render — as text, never as markup — and
+// the panel is simply absent when there are none.
+func TestWorkPageAnnotationsPanel(t *testing.T) {
+	ts, st := testServer(t)
+	ctx := t.Context()
+	if err := st.CreateWork(ctx,
+		store.Work{ID: "wa", UserID: "u1", Title: "Annotated Book", CreatedAt: time.Now()},
+		nil, []store.Identifier{{Kind: "sha256", Value: "aaaa"}}); err != nil {
+		t.Fatal(err)
+	}
+	cookie := loginCookie(t, ts)
+
+	// No annotations: no panel.
+	code, body := page(t, ts, cookie, "/ui/works/wa")
+	if code != 200 {
+		t.Fatalf("work page: %d", code)
+	}
+	if strings.Contains(body, `id="annotations"`) {
+		t.Fatal("annotations panel rendered with nothing to show")
+	}
+
+	prog := 0.25
+	if _, err := st.PushAnnotations(ctx, "u1", "dev1", []store.AnnotationWrite{{
+		ID: "a1", WorkID: "wa", Kind: store.AnnotationHighlight,
+		LocatorJSON: []byte(`{"href":"c1"}`), Progression: &prog,
+		Excerpt: "the sea was <calm>", Color: "green",
+		Body:     "a note with <script>alert(1)</script> in it",
+		ClientTS: time.Now(),
+	}}, 100); err != nil {
+		t.Fatal(err)
+	}
+
+	_, body = page(t, ts, cookie, "/ui/works/wa")
+	if !strings.Contains(body, `id="annotations"`) {
+		t.Fatal("annotations panel missing")
+	}
+	// Text, never markup: the store holds the raw string, the page
+	// shows it escaped.
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Fatal("annotation body reached the page as markup")
+	}
+	if !strings.Contains(body, "the sea was &lt;calm&gt;") {
+		t.Fatal("annotation excerpt missing or unescaped")
+	}
+	if !strings.Contains(body, "ann-color-green") {
+		t.Fatal("palette token did not map to its fixed class")
+	}
+
+	// Another reader's page never shows it: the work itself is
+	// per-user, so for bob it does not exist at all — the same 404
+	// TestCrossUserIsolation pins. This test only adds the panel's
+	// data to that story.
+}

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -344,7 +344,26 @@ func (s *Server) handleWork(w http.ResponseWriter, r *http.Request, a store.Auth
 		}
 		opRows = append(opRows, row)
 	}
-	workPage(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a), d, opRows, sessionRows).
+	// The reader's own highlights and notes for this work (ADR-0028),
+	// view-only: excerpts and bodies render as text, and the panel is
+	// simply absent when there are none.
+	var annRows []AnnotationRow
+	if anns, err := s.St.WorkAnnotations(r.Context(), u.ID, workID); err == nil {
+		for _, an := range anns {
+			row := AnnotationRow{
+				Kind:    string(an.Kind),
+				Color:   an.Color,
+				Excerpt: an.Excerpt,
+				Body:    an.Body,
+				When:    an.ClientTS.In(loc).Format("Jan 2 15:04"),
+			}
+			if an.Progression != nil {
+				row.Where = fmt.Sprintf("%d%%", int(*an.Progression*100))
+			}
+			annRows = append(annRows, row)
+		}
+	}
+	workPage(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a), d, opRows, sessionRows, annRows).
 		Render(r.Context(), w)
 }
 

--- a/internal/webui/reader.templ
+++ b/internal/webui/reader.templ
@@ -156,6 +156,16 @@ templ readerPage(v ReaderView, csrf string) {
 			<aside id="reader-toc" class="reader-toc" aria-label="Table of contents" hidden>
 				<h2>Contents</h2>
 				<nav id="reader-toc-list"></nav>
+				// Annotations, view-only (ADR-0028): bookmarks, notes, and
+				// highlights the engine could not anchor, at their
+				// progression. Filled in from the sync API with the same
+				// derived token positions use; excerpts and bodies arrive
+				// as text nodes only — an annotation is reader-authored,
+				// but it is displayed as inertly as publisher content.
+				<section id="reader-annotations" class="reader-annotations" hidden>
+					<h2>Annotations</h2>
+					<nav id="reader-annotations-list"></nav>
+				</section>
 			</aside>
 			<div class="reader-stage">
 				<button id="reader-prev" class="reader-turn" type="button" aria-label="Previous page">&lsaquo;</button>

--- a/internal/webui/readerbrowser_ext_test.go
+++ b/internal/webui/readerbrowser_ext_test.go
@@ -267,6 +267,54 @@ func seedStalePosition(t *testing.T, base string, cookie *http.Cookie, bookID st
 	}
 	payload, _ := json.Marshal(map[string]any{"ops": []any{op}})
 	api("/v1/ops", string(payload))
+
+	// Annotations (ADR-0028), through the same route a device uses:
+	// one highlight whose range CFI anchors in the title page the
+	// reader opens on, and two that cannot draw — a note (no anchor by
+	// definition) and a highlight whose locator carries no CFI — which
+	// must degrade to sidebar entries rather than errors.
+	ts := time.Now().UTC().Format(time.RFC3339)
+	anns, _ := json.Marshal(map[string]any{"annotations": []any{
+		map[string]any{
+			"id": "00000000-0000-4000-8000-0000000000a1", "base_rev": 0,
+			"work_id": workID, "kind": "highlight", "color": "green",
+			"excerpt": "title page, absolut", "progression": 0.001,
+			"client_ts": ts,
+			"locator": map[string]any{
+				"href": "pagetitre.xhtml", "type": "application/xhtml+xml",
+				"locations": map[string]any{
+					"fragments":        []string{"epubcfi(/6/2!/4/2/2,/1:2,/1:20)"},
+					"totalProgression": 0.001,
+				},
+			},
+		},
+		map[string]any{
+			"id": "00000000-0000-4000-8000-0000000000a2", "base_rev": 0,
+			"work_id": workID, "kind": "note",
+			"body": "A thought about the whale", "progression": 0.5,
+			"client_ts": ts,
+		},
+		map[string]any{
+			"id": "00000000-0000-4000-8000-0000000000a3", "base_rev": 0,
+			"work_id": workID, "kind": "highlight",
+			"excerpt": "an unanchored highlight", "progression": 0.9,
+			"client_ts": ts,
+			"locator": map[string]any{
+				"href":      "chapter5.xhtml",
+				"locations": map[string]any{"totalProgression": 0.9},
+			},
+		},
+	}})
+	out := api("/v1/annotations", string(anns))
+	if results, ok := out["results"].([]any); !ok || len(results) != 3 {
+		t.Fatalf("annotation seeding: %v", out)
+	} else {
+		for _, r := range results {
+			if r.(map[string]any)["status"] != "applied" {
+				t.Fatalf("annotation seeding: %v", out)
+			}
+		}
+	}
 }
 
 // TestReaderOpensInARealBrowser is the only test that can judge whether
@@ -311,6 +359,7 @@ func TestReaderOpensInARealBrowser(t *testing.T) {
 		"SMOKE_URL="+ts.URL+"/ui/books/"+bookID+"/read",
 		"SMOKE_COOKIE="+cookie.Name+"="+cookie.Value,
 		"SMOKE_HOST="+strings.TrimPrefix(ts.URL, "http://"),
+		"SMOKE_ANNOTATIONS=1",
 		"SMOKE_SHOT="+os.Getenv("LISEUR_READER_SCREENSHOT"),
 	)
 	out, err := cmd.CombinedOutput()

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -13,6 +13,7 @@
 // POST /ui/reader/token. It gets no special treatment from the server.
 
 import "./vendor/foliate/view.js";
+import { Overlayer } from "./vendor/foliate/overlayer.js";
 
 const el = document.getElementById("reader-config");
 // Every URL is relative, computed server-side, so the reader keeps
@@ -139,6 +140,137 @@ async function lastPosition() {
   if (!resp.ok) return null;
   const ops = (await resp.json()).ops || [];
   return ops.length ? ops[0] : null;
+}
+
+// ------------------------------------------------------ annotations
+
+// View-only annotation rendering (ADR-0028). The live set comes from
+// the same sync API every client uses; highlights whose CFI the engine
+// can anchor draw through the vendored overlayer, and the rest — every
+// bookmark, every note, and any highlight whose locator no longer
+// resolves against this copy — degrade to a sidebar entry at their
+// progression. Best-effort display, never an error.
+const annPanel = document.getElementById("reader-annotations");
+const annList = document.getElementById("reader-annotations-list");
+
+// The palette is tokens on the wire, always; this table is the only
+// place a token becomes CSS, so nothing a client pushed reaches the
+// overlayer as a style.
+const ANNOTATION_COLORS = {
+  yellow: "#ffd54f",
+  green: "#81c784",
+  blue: "#64b5f6",
+  pink: "#f06292",
+  purple: "#ba68c8",
+  orange: "#ffb74d",
+};
+
+let annotations = []; // the live set, in the server's progression order
+const annColorByCFI = new Map(); // overlayer key -> validated palette token
+const annFailed = new Set(); // annotation ids whose CFI did not anchor
+
+function annotationCFI(a) {
+  const fragments =
+    (a && a.locator && a.locator.locations && a.locator.locations.fragments) ||
+    [];
+  for (const fragment of fragments) {
+    if (typeof fragment === "string" && fragment.indexOf("epubcfi(") === 0) {
+      return fragment;
+    }
+  }
+  return null;
+}
+
+// drawAnnotations (re)offers every drawable highlight to the engine.
+// addAnnotation draws into any chapter that is on screen and is a
+// no-op for the ones that are not, so this runs once after the fetch
+// and again on every create-overlay as chapters arrive. A CFI that
+// fails to anchor moves its annotation to the sidebar instead.
+async function drawAnnotations() {
+  if (!view) return;
+  let degraded = false;
+  for (const a of annotations) {
+    if (a.kind !== "highlight" || annFailed.has(a.id)) continue;
+    const cfi = annotationCFI(a);
+    if (!cfi) continue;
+    annColorByCFI.set(cfi, a.color);
+    try {
+      await view.addAnnotation({ value: cfi });
+    } catch (err) {
+      annFailed.add(a.id);
+      degraded = true;
+    }
+  }
+  if (degraded) buildAnnotationList();
+}
+
+// buildAnnotationList fills the sidebar with the entries that do not
+// draw over the text. Excerpts and bodies are set as text nodes only.
+function buildAnnotationList() {
+  if (!annPanel || !annList) return;
+  annList.textContent = "";
+  const listed = annotations.filter(
+    (a) =>
+      a.kind !== "highlight" || !annotationCFI(a) || annFailed.has(a.id),
+  );
+  annPanel.hidden = !listed.length;
+  if (!listed.length) return;
+  const ul = document.createElement("ul");
+  for (const a of listed) {
+    const li = document.createElement("li");
+    const cfi = a.kind === "highlight" ? null : annotationCFI(a);
+    const canNavigate =
+      !!cfi || (typeof a.progression === "number" && a.progression >= 0);
+    const entry = document.createElement(canNavigate ? "a" : "span");
+    if (canNavigate) {
+      entry.href = "#";
+      entry.addEventListener("click", (e) => {
+        e.preventDefault();
+        toggleTOC(false);
+        if (!view) return;
+        const fall = () => {
+          if (typeof a.progression === "number") {
+            view.goToFraction(Math.min(0.999, a.progression)).catch(() => {});
+          }
+        };
+        if (cfi) view.goTo(cfi).catch(fall);
+        else fall();
+      });
+    }
+    const kind = document.createElement("span");
+    kind.className = "reader-ann-kind";
+    kind.textContent = a.kind;
+    entry.append(kind);
+    const text = document.createElement("span");
+    text.className = "reader-ann-text";
+    text.textContent =
+      a.excerpt ||
+      a.body ||
+      (typeof a.progression === "number"
+        ? Math.round(a.progression * 100) + "%"
+        : "");
+    entry.append(text);
+    li.append(entry);
+    ul.append(li);
+  }
+  annList.append(ul);
+}
+
+// loadAnnotations is best-effort like every other sync call: a reader
+// on a server without the routes, or offline, still reads the book.
+async function loadAnnotations() {
+  if (!workID || !view) return;
+  try {
+    const resp = await api(
+      "v1/works/" + encodeURIComponent(workID) + "/annotations",
+    );
+    if (!resp.ok) return;
+    annotations = (await resp.json()).annotations || [];
+  } catch (err) {
+    return; /* offline: the book reads without its annotations */
+  }
+  buildAnnotationList();
+  await drawAnnotations();
 }
 
 // bookTitle is read from the package document rather than from the
@@ -885,6 +1017,20 @@ window.addEventListener("beforeunload", () => {
     view.addEventListener("load", (e) => {
       e.detail.doc.addEventListener("keydown", handleKeys);
     });
+    // Highlight drawing (ADR-0028): the engine asks how to draw each
+    // annotation it anchors, and asks again for every chapter it
+    // creates an overlay for. The color is resolved from the palette
+    // table above — a token in, a CSS value out, nothing pass-through.
+    view.addEventListener("draw-annotation", (e) => {
+      const { draw, annotation } = e.detail;
+      const color =
+        ANNOTATION_COLORS[annColorByCFI.get(annotation.value)] ||
+        ANNOTATION_COLORS.yellow;
+      draw(Overlayer.highlight, { color });
+    });
+    view.addEventListener("create-overlay", () => {
+      drawAnnotations().catch(() => {});
+    });
     await view.open(
       new File([blob], "book.epub", { type: "application/epub+zip" }),
     );
@@ -928,6 +1074,9 @@ window.addEventListener("beforeunload", () => {
       }
     }
     if (!opened) await view.init({ lastLocation: null });
+    // The annotations arrive after the book is on screen: they are
+    // decoration on the text, never the reason the text waits.
+    loadAnnotations().catch(() => {});
     say("");
   } catch (err) {
     say((err && err.message) || "this book could not be opened", true);

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -856,6 +856,22 @@ button.linkish:hover, button.linkish:focus-visible {
 .reader-toc span{opacity:.65}
 .reader-toc a:hover,.reader-toc a:focus-visible{background:var(--surface-3)}
 .reader-toc a.current{background:var(--surface-3);color:var(--primary);font-weight:600}
+.reader-annotations{margin-top:1rem;border-top:1px solid var(--line);padding-top:.75rem}
+.reader-ann-kind{display:block;font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;opacity:.65}
+.reader-ann-text{display:block;font-size:.85rem;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.annlist{list-style:none;margin:0;padding:0}
+.annlist li{padding:.6rem 0;border-bottom:1px solid var(--line)}
+.annlist li:last-child{border-bottom:none}
+.annlist .ann-kind{font-size:.72rem;text-transform:uppercase;letter-spacing:.04em;opacity:.75;
+  padding:.1rem .45rem;border-radius:999px;border:1px solid var(--line)}
+.annlist .ann-excerpt{margin:.35rem 0;padding-left:.75rem;border-left:3px solid var(--line);font-style:italic}
+.annlist .ann-body{margin:.35rem 0;white-space:pre-wrap}
+.ann-color-yellow{border-left:4px solid #ffd54f}
+.ann-color-green{border-left:4px solid #81c784}
+.ann-color-blue{border-left:4px solid #64b5f6}
+.ann-color-pink{border-left:4px solid #f06292}
+.ann-color-purple{border-left:4px solid #ba68c8}
+.ann-color-orange{border-left:4px solid #ffb74d}
 .reader-stage{flex:1;display:flex;min-height:0}
 #reader-view{flex:1;min-width:0;height:100%;background:#fff;overflow:hidden}
 .reader-turn{border:0;background:transparent;cursor:pointer;font-size:2rem;

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -13,6 +13,7 @@ const host = process.env.SMOKE_HOST;
 // somewhere, and it is not in DNS. Chrome will map it for us.
 const mapHost = process.env.SMOKE_MAP;
 const detached = process.env.SMOKE_DETACHED === '1';
+const withAnnotations = process.env.SMOKE_ANNOTATIONS === '1';
 
 const profile = mkdtempSync(join(tmpdir(), 'smoke-'));
 const proc = spawn(chrome, [
@@ -146,6 +147,15 @@ const probe = `(() => {
     ran: doc ? !!doc.documentElement.dataset.publicationRan : null,
     svgRan: doc ? !!doc.documentElement.dataset.svgRan : null,
     extRan: doc ? typeof doc.defaultView.htmx !== 'undefined' : null,
+    overlay: (() => {
+      const o = contents[0]?.overlayer;
+      if (!o) return null;
+      const g = o.element.querySelector('g');
+      return {
+        rects: o.element.querySelectorAll('rect').length,
+        fill: g ? g.getAttribute('fill') : '',
+      };
+    })(),
     pageTitle: document.title,
     fontSize: body ? doc.defaultView.getComputedStyle(body).fontSize : '',
     wrapWidth: body && body.firstElementChild
@@ -181,6 +191,35 @@ check('publication stylesheet was applied',
 // what stripping might miss. This is the promise the vendored engine
 // had to keep.
 check('publication script did not run', diag.ran === false, String(diag.ran));
+
+// Annotations (ADR-0028), when the harness seeded them: the highlight
+// whose CFI anchors in this very chapter must have actually drawn —
+// rects in the overlayer SVG, filled with the palette's green, never
+// raw CSS from the wire — and the two that cannot draw must be listed
+// in the sidebar rather than reported as errors.
+if (withAnnotations) {
+  check('a synced highlight draws over the text',
+    !!diag.overlay && diag.overlay.rects > 0 && diag.overlay.fill === '#81c784',
+    JSON.stringify(diag.overlay));
+  const anns = JSON.parse(await evalIn(`JSON.stringify((() => {
+    const panel = document.getElementById('reader-annotations');
+    return {
+      hidden: panel ? panel.hidden : null,
+      entries: [...(panel?.querySelectorAll('.reader-ann-text') ?? [])]
+        .map((s) => s.textContent),
+    };
+  })())`));
+  check('the sidebar lists the note',
+    anns.hidden === false &&
+      anns.entries.some((t) => t.includes('A thought about the whale')),
+    JSON.stringify(anns));
+  check('an unanchorable highlight degrades to a sidebar entry',
+    anns.entries.some((t) => t.includes('an unanchored highlight')),
+    JSON.stringify(anns));
+  check('the drawn highlight is not duplicated in the sidebar',
+    !anns.entries.some((t) => t.includes('title page, absolut')),
+    JSON.stringify(anns));
+}
 
 // It must have actually painted: an engine that renders nothing still
 // reports a chapter.

--- a/internal/webui/works.templ
+++ b/internal/webui/works.templ
@@ -60,11 +60,34 @@ type OpRow struct {
 	ForeignPos  string
 }
 
-templ workPage(prefix string, u userCtx, csrf string, d WorkDetail, ops []OpRow, sessions []SessionRow) {
-	@layout(orPlaceholder(d.Work.Title), prefix, u, csrf, workBody(prefix, csrf, d, ops, sessions))
+// AnnotationRow is one annotation on the work page (ADR-0028): the
+// excerpt and the reader's own words, rendered as text — never markup
+// — with the where and when beside them.
+type AnnotationRow struct {
+	Kind    string
+	Color   string
+	Excerpt string
+	Body    string
+	Where   string
+	When    string
 }
 
-templ workBody(prefix, csrf string, d WorkDetail, ops []OpRow, sessions []SessionRow) {
+// annColorClass maps a stored palette token to a fixed CSS class. The
+// token was validated at write time, but the class list is still a
+// closed table here: nothing from the wire names a style.
+func annColorClass(color string) string {
+	switch color {
+	case "yellow", "green", "blue", "pink", "purple", "orange":
+		return "ann-color-" + color
+	}
+	return ""
+}
+
+templ workPage(prefix string, u userCtx, csrf string, d WorkDetail, ops []OpRow, sessions []SessionRow, anns []AnnotationRow) {
+	@layout(orPlaceholder(d.Work.Title), prefix, u, csrf, workBody(prefix, csrf, d, ops, sessions, anns))
+}
+
+templ workBody(prefix, csrf string, d WorkDetail, ops []OpRow, sessions []SessionRow, anns []AnnotationRow) {
 	<h1>{ orPlaceholder(d.Work.Title) }</h1>
 	if d.Work.Author != "" {
 		<p class="muted">{ d.Work.Author }</p>
@@ -88,6 +111,36 @@ templ workBody(prefix, csrf string, d WorkDetail, ops []OpRow, sessions []Sessio
 			<div class="stat"><span class="num">{ d.ETAHuman }</span><span class="lbl">left (est.)</span></div>
 		}
 	</section>
+	// Highlights and notes synced from the reader's devices (ADR-0028),
+	// view-only here. Each links back into the book when the viewer's
+	// folder grants reach one to open; otherwise it is simply listed.
+	if len(anns) > 0 {
+		<section class="card" id="annotations">
+			<h2>Annotations</h2>
+			<ul class="annlist">
+				for _, an := range anns {
+					<li>
+						<span class={ "ann-kind", annColorClass(an.Color) }>{ an.Kind }</span>
+						if an.Excerpt != "" {
+							<blockquote class="ann-excerpt">{ an.Excerpt }</blockquote>
+						}
+						if an.Body != "" {
+							<p class="ann-body">{ an.Body }</p>
+						}
+						<span class="muted small">
+							{ an.When }
+							if an.Where != "" {
+								&nbsp;·&nbsp;{ an.Where }
+							}
+						</span>
+						if d.CanRead && d.BookID != "" {
+							<a class="small" href={ prefix + "books/" + d.BookID + "/read" }>Open in reader</a>
+						}
+					</li>
+				}
+			</ul>
+		</section>
+	}
 	// The sessions this work still has in full. Older ones have been
 	// rolled up into daily totals (they are counted in the statistics
 	// above but no longer exist one by one), which is why this list can


### PR DESCRIPTION
## What

Implements ADR-0028: highlights, notes and bookmarks sync as mutable reading state. Store layer on both backends, four native API routes, and a view-only web UI. The design record itself merged earlier; this is the code.

## How it works

Each annotation carries a server-assigned `rev`, and every write is a compare-and-set against it. A byte-identical retry of the last write answers `duplicate`; any other stale `base_rev` answers a per-item `conflict` carrying the server copy. The server orders writes; it never merges.

- Store: an `annotations` table with its own per-user seq counter (migration 5, SQLite and Postgres), batched push in one transaction under the work-graph lock, a delta feed with tombstones, a per-work cap on live records, split/merge reassignment, DeleteWork cascade, and an hourly sweep that drops tombstones after the retention window.
- API: `POST /v1/annotations`, `GET /v1/annotations/changes`, `GET /v1/works/{id}/annotations`, `DELETE /v1/annotations/{id}?rev=N`, all under the `sync` scope. The batch is never atomic: a bad item fails alone, whether its problem is shape, reference, or a value the decoder cannot type. The request cap is computed from the documented field bounds with worst-case JSON escaping; exceeding it is a 413. Tombstones carry identity, rev, seq and timestamps, nothing else.
- Web UI: the reader draws synced highlights through the foliate overlayer, with palette tokens mapped to fixed CSS (color names never travel as CSS). Notes, bookmarks and highlights that no longer anchor appear in the drawer. The work page gains a read-only annotations panel.

`docs/openapi.yaml` and `docs/integrating.md` document the routes and the rev dance; `docs/DESIGN.md` §11 records the feature as shipped.

## Proof

- Ten shared storetest subtests run on SQLite and on a real Postgres server: CAS and idempotency, the per-work cap under concurrency, the feed contract, tombstone sweep and id reuse, split/merge reassignment, cross-user isolation, DeleteWork cascade.
- API tests cover the full push/pull/delete flow, every validation bound (each bad item travels with a healthy neighbor to prove it fails alone), the 413 path, and tenant isolation on all four routes.
- The real-browser check seeds three annotations and verifies the highlight renders as an overlay rect with the palette color, the drawer lists the note and the degraded highlight, and the drawn one is not listed twice.
- `go vet`, `golangci-lint` (0 issues), full `go test -race ./...`, and redocly against the OpenAPI document all pass.

## Review

The implementation went through three rounds of independent model review (gpt-5.6-sol via Copilot CLI). All findings were folded in: per-item invalid results instead of whole-batch 400s, in-transaction edition checks so a foreign key can never abort a batch, an escaping-aware request cap with bounded identifiers, `locator: null` treated as absent, per-item JSON decoding, and a byte limit on `client_ts`.
