### PR TITLE
feat: Name each work in the insights API

### DIFF
--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -420,6 +420,14 @@ Give the works endpoints the same span as the summary if the two are
 shown on one screen: a headline covering thirty days above rows covering
 a lifetime is a dashboard whose numbers cannot be added up.
 
+Each work carries `title` and `author` when the server has them. They
+are there so a client can list a work it holds no file for: reading done
+on another device is in the totals whether it can be named or not, and a
+list that silently omits it is smaller than the headline above it for no
+reason the reader can see. Both are absent rather than empty when the
+server has nothing to say, and a work you cannot name is better left out
+of a list than shown blank.
+
 `streak_days` is deliberately **not** narrowed by the span. It counts
 consecutive days ending today or yesterday, looking back up to ten
 years, so asking about the last week does not report a hundred-day run

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -860,6 +860,8 @@ paths:
                   from: { type: string, format: date }
                   to: { type: string, format: date }
                   work_id: { type: string }
+                  title: { type: string, description: "The work's title; absent when the server has none" }
+                  author: { type: string, description: "The work's author; absent when the server has none" }
                   sessions: { type: integer }
                   total_active_minutes: { type: number }
                   total_pages: { type: number }
@@ -905,7 +907,8 @@ paths:
             Per-work aggregates, ordered by active time descending.
             `range_days` is always present, and `from`/`to` whenever the
             span was bounded; both must be checked before the rows are
-            labelled with a span.
+            labelled with a span. `title` and `author` name each work so
+            that a client can list one it holds no local file for.
           content:
             application/json:
               schema:
@@ -922,6 +925,8 @@ paths:
                       required: [work_id, sessions, total_active_minutes, total_pages, current_progression]
                       properties:
                         work_id: { type: string }
+                        title: { type: string, description: "The work's title; absent when the server has none" }
+                        author: { type: string, description: "The work's author; absent when the server has none" }
                         sessions: { type: integer }
                         total_active_minutes: { type: number }
                         total_pages: { type: number }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -488,7 +488,7 @@ func TestSessionsAndInsights(t *testing.T) {
 	roSecret, _, _ := svc.MintToken(ctx, u.ID, "ro", store.ScopeSet{store.ScopeReadInsights}, nil)
 
 	// Work with a known page count.
-	w := store.Work{ID: "w1", UserID: u.ID, CreatedAt: time.Now()}
+	w := store.Work{ID: "w1", UserID: u.ID, Title: "Dune", Author: "Frank Herbert", CreatedAt: time.Now()}
 	ed := &store.Edition{UserID: u.ID, SHA256: "abc123", WorkID: "w1", PageCount: ptrI64(300)}
 	if err := st.CreateWork(ctx, w, ed, []store.Identifier{{Kind: "sha256", Value: "abc123"}}); err != nil {
 		t.Fatal(err)
@@ -558,6 +558,12 @@ func TestSessionsAndInsights(t *testing.T) {
 	work := works[0].(map[string]any)
 	if work["work_id"] != "w1" || work["sessions"].(float64) != 2 || work["last_read_at"] == nil {
 		t.Fatalf("work aggregate: %v", work)
+	}
+	// The name travels with the figures, so a client can list a book it
+	// holds no file for rather than dropping it out of a list whose
+	// total already counts it.
+	if work["title"] != "Dune" || work["author"] != "Frank Herbert" {
+		t.Fatalf("work name: %v", work)
 	}
 
 	// Summary over 30d.

--- a/internal/api/insights.go
+++ b/internal/api/insights.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sort"
 	"time"
@@ -34,8 +35,19 @@ type dayStat struct {
 	Pages   float64 `json:"pages"`
 }
 
+// workInsight is one work's aggregate.
+//
+// Title and Author are here so that a client can name a book it has
+// never seen. A reader's dashboard lists what it can put a local file
+// against, and a work read only on another device falls out of that
+// list while still counting towards the total above it — a list that is
+// smaller than its own headline and gives no reason. The name is the
+// only thing needed to show the row; both are omitted when the server
+// has nothing to say rather than sent empty.
 type workInsight struct {
 	WorkID             string     `json:"work_id"`
+	Title              string     `json:"title,omitempty"`
+	Author             string     `json:"author,omitempty"`
 	Sessions           int        `json:"sessions"`
 	TotalActiveMinutes float64    `json:"total_active_minutes"`
 	TotalPages         float64    `json:"total_pages"`
@@ -298,8 +310,26 @@ func (s *Server) workInsightFrom(
 			}
 		}
 	}
+	// The name, when the server has one. A missing work is not an error
+	// here: the aggregate is built from sessions and rollups that name
+	// the work themselves, so a record that has gone stays a row with
+	// figures on it and no title, rather than failing the whole request.
+	// Any other failure is a real store problem and must propagate,
+	// rather than being swallowed into the same silent blank.
+	title, author := "", ""
+	work, err := s.St.WorkByID(ctx, userID, workID)
+	switch {
+	case err == nil:
+		title, author = work.Title, work.Author
+	case errors.Is(err, store.ErrNotFound):
+		// Nothing to do: title and author stay empty.
+	default:
+		return workInsight{}, err
+	}
 	return workInsight{
 		WorkID:             workID,
+		Title:              title,
+		Author:             author,
 		Sessions:           sessionCount,
 		TotalActiveMinutes: totalActive / 60,
 		TotalPages:         totalPages,


### PR DESCRIPTION
## Summary

Part of implementing [ADR-0021](https://github.com/chmouel/liseur/blob/main/docs/adr/0021-cross-device-reading-statistics.md) in the client (`chmouel/liseur`). That ADR asks a reader's dashboard to list a work the server knows about even when the client has no local file for it — but `GET /v1/insights/works` returned no name, so such a work could not be shown at all.

## Changes

- `workInsight` (both `/v1/insights/works/{id}` and the `/v1/insights/works` collection) now carries `title` and `author`, looked up per work via the existing `WorkByID` query. A missing work record is tolerated — the aggregate is still returned, just nameless — rather than failing the request.
- `docs/openapi.yaml` and `docs/integrating.md` updated to describe the new fields.
- `internal/api/api_test.go` asserts both fields travel through the collection endpoint.

## Testing

```
go build ./...
go test ./internal/api/
```
Both pass.

No deployment from this PR.