### PR TITLE
refactor: Reduce continue reading limit on the dashboard

### DIFF
--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -197,7 +197,7 @@ func (s *Server) streakFor(
 // continueReadingLimit is a shelf, not a list: the point is to get back
 // into the book you put down, and a wall of half-read books is a guilt
 // trip rather than a shortcut.
-const continueReadingLimit = 8
+const continueReadingLimit = 4
 
 // continueReading is the works that are started and not finished, newest
 // first. It reads nothing extra — the dashboard has already listed the


### PR DESCRIPTION
Decreased the maximum number of unfinished books displayed in the continue
reading section from eight to four to prevent clutter and reduce visual
overwhelm on the main page.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
