### PR TITLE
fix: Increase continue reading limit from four to six items

### DIFF
--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -197,7 +197,7 @@ func (s *Server) streakFor(
 // continueReadingLimit is a shelf, not a list: the point is to get back
 // into the book you put down, and a wall of half-read books is a guilt
 // trip rather than a shortcut.
-const continueReadingLimit = 4
+const continueReadingLimit = 6
 
 // continueReading is the works that are started and not finished, newest
 // first. It reads nothing extra — the dashboard has already listed the


### PR DESCRIPTION
Increased the maximum number of books displayed in the continue reading
section to show more active reads on the dashboard.

Signed-off-by: Chmouel Boudjnah <chmouel@chmouel.com>
