### PR TITLE
Scan a library on demand from the shelf, the settings page or the shell

### DIFF
--- a/cmd/liseur-sync/main.go
+++ b/cmd/liseur-sync/main.go
@@ -18,6 +18,8 @@ import (
 
 	_ "time/tzdata" // IANA timezones in FROM scratch images
 
+	"golang.org/x/term"
+
 	"github.com/chmouel/liseur-sync/internal/adapter/koplugin"
 	"github.com/chmouel/liseur-sync/internal/adapter/kosync"
 	"github.com/chmouel/liseur-sync/internal/admin"
@@ -86,6 +88,7 @@ func runMain(args []string, stderr io.Writer) int {
 const topUsage = `usage: liseur-sync <command> [flags]
 
   serve [-config <file>]   run the sync and content server
+  scan [-config <file>]    scan watched folders now
   admin [-config <file>]   manage users, tokens, and folders;
                            run "liseur-sync admin help" for subcommands
 `
@@ -99,11 +102,13 @@ func run(args []string) error {
 		return usageExit{text: topUsage, code: 0}
 	case "serve":
 		return cmdServe(args[1:])
+	case "scan":
+		return cmdTopScan(args[1:])
 	case "admin":
 		return cmdAdmin(args[1:])
 	default:
 		return usageExit{
-			text: fmt.Sprintf("unknown subcommand %q (want serve|admin)\n%s",
+			text: fmt.Sprintf("unknown subcommand %q (want serve|scan|admin)\n%s",
 				args[0], topUsage),
 			code: 1,
 		}
@@ -315,10 +320,10 @@ func cmdAdmin(args []string) error {
 	if err := st.Migrate(context.Background()); err != nil {
 		return fmt.Errorf("migrate database: %w", err)
 	}
-	// scan-folder needs the reconciler, which lives in internal/content
+	// scan and scan-folder need the reconciler, which lives in internal/content
 	// and is Linux-only; internal/admin is not, so it is wired here.
-	if rest[0] == "scan-folder" {
-		return cmdScanFolder(cfg, st, rest[1:])
+	if rest[0] == "scan" || rest[0] == "scan-folder" {
+		return cmdScan(cfg, st, "liseur-sync admin "+rest[0], rest[1:])
 	}
 	if err := admin.Run(st, rest); err != nil {
 		var usage admin.UsageError
@@ -330,64 +335,207 @@ func cmdAdmin(args []string) error {
 	return nil
 }
 
-// cmdScanFolder runs the watcher's pass over one folder on demand. It is
-// the same code path, so it can do nothing the watcher could not, and it
-// is the only way to reconcile from a shell or a cron job (the other
-// trigger is the web UI's scan button).
-func cmdScanFolder(cfg config.Config, st store.Store, args []string) error {
-	if len(args) != 1 {
-		return usageExit{text: "usage: liseur-sync admin scan-folder <name|folder-id>\n" + admin.Usage, code: 2}
+type cliSpinner struct {
+	msg    string
+	stopCh chan struct{}
+	doneCh chan struct{}
+	isTerm bool
+}
+
+func startSpinner(msg string, isTerm bool) *cliSpinner {
+	s := &cliSpinner{
+		msg:    msg,
+		stopCh: make(chan struct{}),
+		doneCh: make(chan struct{}),
+		isTerm: isTerm,
+	}
+	if !isTerm {
+		fmt.Printf("%s...\n", msg)
+		close(s.doneCh)
+		return s
+	}
+	go func() {
+		defer close(s.doneCh)
+		frames := []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+		i := 0
+		ticker := time.NewTicker(80 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-s.stopCh:
+				fmt.Print("\r\033[K")
+				return
+			case <-ticker.C:
+				fmt.Printf("\r\033[K%s %s...", frames[i%len(frames)], s.msg)
+				i++
+			}
+		}
+	}()
+	return s
+}
+
+func (s *cliSpinner) stop() {
+	if !s.isTerm {
+		return
+	}
+	close(s.stopCh)
+	<-s.doneCh
+}
+
+func cmdTopScan(args []string) error {
+	fs := flag.NewFlagSet("scan", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	cfgPath := fs.String("config", defaultConfigPath(),
+		"path to TOML config file (default liseur-sync.toml, override with LISEUR_CONFIG)")
+	if err := fs.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return usageExit{text: flagUsage(fs), code: 0}
+		}
+		return usageExit{text: err.Error() + "\n" + flagUsage(fs), code: 1}
+	}
+	cfg, err := config.Load(*cfgPath)
+	if err != nil {
+		return err
+	}
+	st, err := openStore(cfg)
+	if err != nil {
+		return fmt.Errorf("open database: %w", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(context.Background()); err != nil {
+		return fmt.Errorf("migrate database: %w", err)
+	}
+	return cmdScan(cfg, st, "liseur-sync scan", fs.Args())
+}
+
+// cmdScan runs a reconcile pass on demand over one folder or all of
+// them. It is the same code path the watcher runs, so it can do nothing
+// the watcher could not, and it is the only way to reconcile from a
+// shell or a cron job (the other triggers are the web UI's scan
+// buttons).
+//
+// invocation is how the caller spelled it, so that the usage a mistake
+// prints is the command the person actually typed.
+func cmdScan(cfg config.Config, st store.Store, invocation string, args []string) error {
+	needsFolder := strings.HasSuffix(invocation, "scan-folder")
+	usage := invocation + " [name|folder-id]"
+	if needsFolder {
+		usage = invocation + " <name|folder-id>"
+	}
+	if needsFolder && len(args) != 1 {
+		return usageExit{text: "usage: " + usage + "\n" + admin.Usage, code: 2}
+	}
+	if len(args) > 1 {
+		return usageExit{text: "usage: " + usage + "\n" + admin.Usage, code: 2}
 	}
 	ctx := context.Background()
-	// An id wins outright; a name is accepted only when exactly one
-	// folder bears it, because names are not unique and a pass over the
-	// wrong folder is a real write.
-	var byID *store.Folder
-	var byName []store.Folder
+	var allFolders []store.Folder
 	cursor := ""
 	for {
 		page, err := st.ListFolders(ctx, "", cursor, 200)
 		if err != nil {
 			return fmt.Errorf("list folders: %w", err)
 		}
-		for i := range page {
-			switch args[0] {
-			case page[i].ID:
-				byID = &page[i]
-			case page[i].Name:
-				byName = append(byName, page[i])
-			}
-		}
+		allFolders = append(allFolders, page...)
 		if len(page) < 200 {
 			break
 		}
 		cursor = store.FolderCursor(page[len(page)-1])
 	}
-	folder := byID
-	switch {
-	case folder != nil:
-	case len(byName) == 1:
-		folder = &byName[0]
-	case len(byName) > 1:
-		ids := make([]string, 0, len(byName))
-		for _, f := range byName {
-			ids = append(ids, f.ID)
+
+	var targets []store.Folder
+	if len(args) == 1 {
+		targetName := args[0]
+		var byID *store.Folder
+		var byName []store.Folder
+		for i := range allFolders {
+			switch targetName {
+			case allFolders[i].ID:
+				byID = &allFolders[i]
+			case allFolders[i].Name:
+				byName = append(byName, allFolders[i])
+			}
 		}
-		return fmt.Errorf("%d folders are named %q; use an id: %s",
-			len(byName), args[0], strings.Join(ids, " "))
-	default:
-		return fmt.Errorf("no folder named %q", args[0])
+		switch {
+		case byID != nil:
+			targets = []store.Folder{*byID}
+		case len(byName) == 1:
+			targets = []store.Folder{byName[0]}
+		case len(byName) > 1:
+			ids := make([]string, 0, len(byName))
+			for _, f := range byName {
+				ids = append(ids, f.ID)
+			}
+			return fmt.Errorf("%d folders are named %q; use an id: %s",
+				len(byName), targetName, strings.Join(ids, " "))
+		default:
+			return fmt.Errorf("no folder named %q", targetName)
+		}
+	} else {
+		targets = allFolders
+		if len(targets) == 0 {
+			fmt.Println("no watched folders found to scan")
+			return nil
+		}
 	}
+
+	isTerm := term.IsTerminal(int(os.Stdout.Fd())) && os.Getenv("TERM") != "dumb"
 	reconciler := content.NewReconciler(st, content.ScanLimits{
 		MaxFiles: cfg.Content.ScanMaxFiles,
 		MaxDepth: cfg.Content.ScanMaxDepth,
 	}, cfg.EPUBLimits(), slog.Default())
-	result, err := reconciler.Reconcile(ctx, *folder)
-	if err != nil {
-		return fmt.Errorf("reconcile %s: %w", folder.Name, err)
+
+	start := time.Now()
+	var total store.ReconcileResult
+	var scanErrors []string
+
+	for _, folder := range targets {
+		sp := startSpinner(fmt.Sprintf("Scanning folder %q", folder.Name), isTerm)
+		result, err := reconciler.Reconcile(ctx, folder)
+		sp.stop()
+
+		if err != nil {
+			scanErrors = append(scanErrors, fmt.Sprintf("%s: %v", folder.Name, err))
+			if isTerm {
+				fmt.Printf("\033[31m✖\033[0m folder %s (%s) failed: %v\n", folder.Name, folder.ID, err)
+			} else {
+				fmt.Printf("folder %s (%s) failed: %v\n", folder.Name, folder.ID, err)
+			}
+			continue
+		}
+
+		total.Added += result.Added
+		total.Updated += result.Updated
+		total.Replaced += result.Replaced
+		total.Missing += result.Missing
+		total.Returned += result.Returned
+		total.Purged += result.Purged
+		total.Rekeyed += result.Rekeyed
+
+		if isTerm {
+			fmt.Printf("\033[32m✔\033[0m folder %s (%s) reconciled: added=%d updated=%d replaced=%d missing=%d returned=%d purged=%d rekeyed=%d\n",
+				folder.Name, folder.ID, result.Added, result.Updated, result.Replaced,
+				result.Missing, result.Returned, result.Purged, result.Rekeyed)
+		} else {
+			fmt.Printf("folder %s (%s) reconciled: added=%d updated=%d replaced=%d missing=%d returned=%d purged=%d rekeyed=%d\n",
+				folder.Name, folder.ID, result.Added, result.Updated, result.Replaced,
+				result.Missing, result.Returned, result.Purged, result.Rekeyed)
+		}
 	}
-	fmt.Printf("folder %s (%s) reconciled: added=%d updated=%d replaced=%d missing=%d returned=%d purged=%d rekeyed=%d\n",
-		folder.Name, folder.ID, result.Added, result.Updated, result.Replaced,
-		result.Missing, result.Returned, result.Purged, result.Rekeyed)
+
+	if len(targets) > 1 {
+		elapsed := time.Since(start).Round(time.Millisecond)
+		if isTerm {
+			fmt.Printf("\033[32m✔\033[0m Scanned %d folder(s) in %s: %d added, %d updated, %d missing, %d purged\n",
+				len(targets), elapsed, total.Added, total.Updated, total.Missing, total.Purged)
+		} else {
+			fmt.Printf("Scanned %d folder(s) in %s: %d added, %d updated, %d missing, %d purged\n",
+				len(targets), elapsed, total.Added, total.Updated, total.Missing, total.Purged)
+		}
+	}
+
+	if len(scanErrors) > 0 {
+		return fmt.Errorf("%d scan(s) failed: %s", len(scanErrors), strings.Join(scanErrors, "; "))
+	}
 	return nil
 }

--- a/cmd/liseur-sync/main.go
+++ b/cmd/liseur-sync/main.go
@@ -416,6 +416,17 @@ func cmdTopScan(args []string) error {
 //
 // invocation is how the caller spelled it, so that the usage a mistake
 // prints is the command the person actually typed.
+// reconcileCounts renders what a pass changed. Every counter is named,
+// including the zeroes, so the per-folder lines and the total below them
+// say the same thing in the same order and one of them cannot quietly
+// fall behind the other when a counter is added.
+func reconcileCounts(res store.ReconcileResult) string {
+	return fmt.Sprintf(
+		"added=%d updated=%d replaced=%d missing=%d returned=%d purged=%d rekeyed=%d",
+		res.Added, res.Updated, res.Replaced,
+		res.Missing, res.Returned, res.Purged, res.Rekeyed)
+}
+
 func cmdScan(cfg config.Config, st store.Store, invocation string, args []string) error {
 	needsFolder := strings.HasSuffix(invocation, "scan-folder")
 	usage := invocation + " [name|folder-id]"
@@ -513,24 +524,22 @@ func cmdScan(cfg config.Config, st store.Store, invocation string, args []string
 		total.Rekeyed += result.Rekeyed
 
 		if isTerm {
-			fmt.Printf("\033[32m✔\033[0m folder %s (%s) reconciled: added=%d updated=%d replaced=%d missing=%d returned=%d purged=%d rekeyed=%d\n",
-				folder.Name, folder.ID, result.Added, result.Updated, result.Replaced,
-				result.Missing, result.Returned, result.Purged, result.Rekeyed)
+			fmt.Printf("\033[32m✔\033[0m folder %s (%s) reconciled: %s\n",
+				folder.Name, folder.ID, reconcileCounts(result))
 		} else {
-			fmt.Printf("folder %s (%s) reconciled: added=%d updated=%d replaced=%d missing=%d returned=%d purged=%d rekeyed=%d\n",
-				folder.Name, folder.ID, result.Added, result.Updated, result.Replaced,
-				result.Missing, result.Returned, result.Purged, result.Rekeyed)
+			fmt.Printf("folder %s (%s) reconciled: %s\n",
+				folder.Name, folder.ID, reconcileCounts(result))
 		}
 	}
 
 	if len(targets) > 1 {
 		elapsed := time.Since(start).Round(time.Millisecond)
 		if isTerm {
-			fmt.Printf("\033[32m✔\033[0m Scanned %d folder(s) in %s: %d added, %d updated, %d missing, %d purged\n",
-				len(targets), elapsed, total.Added, total.Updated, total.Missing, total.Purged)
+			fmt.Printf("\033[32m✔\033[0m Scanned %d folder(s) in %s: %s\n",
+				len(targets), elapsed, reconcileCounts(total))
 		} else {
-			fmt.Printf("Scanned %d folder(s) in %s: %d added, %d updated, %d missing, %d purged\n",
-				len(targets), elapsed, total.Added, total.Updated, total.Missing, total.Purged)
+			fmt.Printf("Scanned %d folder(s) in %s: %s\n",
+				len(targets), elapsed, reconcileCounts(total))
 		}
 	}
 

--- a/cmd/liseur-sync/main_test.go
+++ b/cmd/liseur-sync/main_test.go
@@ -84,3 +84,39 @@ func TestAbsoluteCacheDirIsLeftAlone(t *testing.T) {
 		t.Fatalf("cacheDirFor = %q, want /srv/cache", got)
 	}
 }
+
+func TestAdminUsageContainsScan(t *testing.T) {
+	var stderr bytes.Buffer
+	code := runMain([]string{"admin", "-h"}, &stderr)
+	if code != 0 {
+		t.Fatalf("runMain exited %d, want 0", code)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "scan [name|folder-id]") {
+		t.Fatalf("admin usage does not document scan:\n%s", out)
+	}
+}
+
+func TestTopUsageContainsScan(t *testing.T) {
+	var stderr bytes.Buffer
+	code := runMain([]string{"-h"}, &stderr)
+	if code != 0 {
+		t.Fatalf("runMain exited %d, want 0", code)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "scan [-config <file>]") {
+		t.Fatalf("top usage does not document scan:\n%s", out)
+	}
+}
+
+func TestTopScanHelpFlagExitsZero(t *testing.T) {
+	var stderr bytes.Buffer
+	code := runMain([]string{"scan", "-h"}, &stderr)
+	if code != 0 {
+		t.Fatalf("runMain exited %d, want 0", code)
+	}
+	out := stderr.String()
+	if !strings.Contains(out, "Usage of scan:") && !strings.Contains(out, "-config") {
+		t.Fatalf("scan -h output unexpected:\n%s", out)
+	}
+}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -216,14 +216,24 @@ liseur-sync admin -config liseur-sync.toml unassign-folder alice <folder-id>
 liseur-sync admin -config liseur-sync.toml list-user-folders alice
 liseur-sync admin -config liseur-sync.toml assign-all-folders alice
 liseur-sync admin -config liseur-sync.toml scan-folder <folder-id>
+liseur-sync admin -config liseur-sync.toml scan [name|folder-id]
+liseur-sync -config liseur-sync.toml scan [name|folder-id]
 ```
 
-`scan-folder` runs one reconcile pass over a folder right now, the same
-pass the watcher runs, and prints what it changed. It takes a folder id,
-or a name when exactly one folder bears it. It is the shell
-equivalent of the Scan button and the way to make a cron job or a repair
-script (see [Auditing a Calibre library](#auditing-a-calibre-library))
-finish with a catalog that agrees with the disk.
+`scan` runs a reconcile pass right now — the same pass the watcher runs —
+and prints what it changed. Named with a folder id, or a name when
+exactly one folder bears it, it does that one folder; with no argument it
+does every watched folder in turn and prints a total. `scan-folder` is
+the older spelling of the one-folder case and still works. The top-level
+`liseur-sync scan` is the same command without the `admin` word, for a
+cron job or a repair script (see
+[Auditing a Calibre library](#auditing-a-calibre-library)) that only ever
+wants this.
+
+On a terminal it draws a spinner per folder; piped to a file or run from
+cron it writes plain lines and no escape sequences. A folder that fails
+does not stop the rest — every failure is reported and the exit status is
+non-zero.
 
 The per-account checkboxes under Settings > Administration > Users submit
 the account's complete grant set, so the page lists every watched folder
@@ -271,11 +281,25 @@ start and the folder does not become unusable.
 
 A network mount is the case where this matters. NFS and SMB report
 nothing to inotify, so such a folder is only ever read by the periodic
-pass, which is up to half an hour behind. **Settings > Administration > Folders**
-has a
-*Scan now* for each folder that runs a pass immediately. It is safe to
-press at any time and safe to press twice: a pass is idempotent, so
-asking again is asking once.
+pass, which is up to half an hour behind.
+
+There are three buttons for this, and they differ only in what they cover
+and whether they wait:
+
+- **Settings > Administration > Folders** has a *Scan now* per folder. It
+  asks for a pass and returns immediately, so the page says a pass was
+  asked for rather than what it found.
+- The same page has *Scan all*, which runs a pass over every watched
+  folder and waits for them, so the page that comes back is the one those
+  passes produced.
+- The library page has a *Scan* button for everybody, covering the
+  folders that reader has been granted (every folder, for an
+  administrator). It also waits.
+
+The two that wait give up after two minutes and say so; the pass they
+started is not undone, and the watcher's periodic pass finishes the job.
+All of them are safe to press at any time and safe to press twice: a pass
+is idempotent, so asking again is asking once.
 
 `scan_max_files` and `scan_max_depth` bound one pass. They are guards
 against pointing at too much, not tuning knobs. A pass that hits either

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -283,23 +283,24 @@ A network mount is the case where this matters. NFS and SMB report
 nothing to inotify, so such a folder is only ever read by the periodic
 pass, which is up to half an hour behind.
 
-There are three buttons for this, and they differ only in what they cover
-and whether they wait:
+There are three buttons for this, and they differ only in what they
+cover. All of them run the passes and wait, so the page that comes back
+reports what those passes changed:
 
-- **Settings > Administration > Folders** has a *Scan now* per folder. It
-  asks for a pass and returns immediately, so the page says a pass was
-  asked for rather than what it found.
-- The same page has *Scan all*, which runs a pass over every watched
-  folder and waits for them, so the page that comes back is the one those
-  passes produced.
-- The library page has a *Scan* button for everybody, covering the
-  folders that reader has been granted (every folder, for an
-  administrator). It also waits.
+- **Settings > Administration > Folders** has a *Scan now* per folder.
+- The same page has *Scan all*, for every watched folder.
+- The library page has a *Scan* for everybody, covering the folders that
+  reader has been granted — every folder, for an administrator.
 
-The two that wait give up after two minutes and say so; the pass they
-started is not undone, and the watcher's periodic pass finishes the job.
-All of them are safe to press at any time and safe to press twice: a pass
-is idempotent, so asking again is asking once.
+A scan gives up after two minutes and says so. Nothing it managed is
+undone, and the watcher's periodic pass finishes the job. All of them are
+safe to press at any time and safe to press twice: a pass is idempotent,
+so asking again is asking once.
+
+Adding a folder is bounded the same way, and it is the pass that can
+actually reach the limit: a library nothing has read yet is hashed and
+parsed book by book. If it does, the folder is still watched and its
+books keep appearing as the periodic pass reads them.
 
 `scan_max_files` and `scan_max_depth` bound one pass. They are guards
 against pointing at too much, not tuning knobs. A pass that hits either

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -127,6 +127,9 @@ const Usage = `usage: liseur-sync admin [-config <file>] <subcommand>
                                 account; without it nobody can read it
                                 and the command says so
   list-folders                  list the folders this server watches
+  scan [name|folder-id]         run a reconcile pass now; scans all folders
+                                if none specified, or the named folder
+                                (Linux only)
   scan-folder <name|folder-id>  run one reconcile pass over a folder now,
                                 the same pass the watcher runs, and print
                                 what it changed (Linux only)

--- a/internal/content/pass_linux_test.go
+++ b/internal/content/pass_linux_test.go
@@ -429,13 +429,16 @@ func TestWatcherReconcilesAFolderAddedAtRuntime(t *testing.T) {
 	}
 }
 
-// TestScanRunsAPassWithoutAnEvent. The watcher's other two triggers are
-// inotify and a half-hourly timer, and inotify is not the whole truth:
-// it reports nothing at all on NFS or SMB. On such a share the only way
-// a person can make the catalog current is to ask, so asking has to
-// work — this test drives it with notifications deliberately unhooked,
-// which is what a network mount looks like from here.
-func TestScanRunsAPassWithoutAnEvent(t *testing.T) {
+// TestQueuedFolderRunsOnePassPerBurst covers the debounced queue: the
+// channel every inotify notification lands in, and the ticker that turns
+// a burst of them into one pass.
+//
+// It drives the queue directly, with notifications deliberately unhooked
+// — which is also what a network mount looks like from here, since
+// inotify reports nothing at all on NFS or SMB. What matters is the
+// collapsing: copying a book in is many events, and a pass per event
+// would read the same half-written file over and over.
+func TestQueuedFolderRunsOnePassPerBurst(t *testing.T) {
 	folder := plainFolder(t)
 	writeBook(t, folder.RootPath, "one.epub", "One")
 	catalog := newFakeCatalog()
@@ -454,13 +457,13 @@ func TestScanRunsAPassWithoutAnEvent(t *testing.T) {
 
 	// Nothing here can tell the server this happened.
 	writeBook(t, folder.RootPath, "two.epub", "Two")
-	w.Scan(folder.ID)
+	w.events <- folder.ID
 	waitForObserved(t, catalog, 2)
 
-	// Asking again is free: a pass is idempotent, so a person leaning on
-	// the button gets one more pass, not a queue of them.
-	w.Scan(folder.ID)
-	w.Scan(folder.ID)
+	// A burst collapses: a pass is idempotent, so three notifications
+	// about one folder are one more pass, not a queue of them.
+	w.events <- folder.ID
+	w.events <- folder.ID
 	waitForReconcile(t, catalog)
 
 	cancel()

--- a/internal/content/watch_linux.go
+++ b/internal/content/watch_linux.go
@@ -4,6 +4,8 @@ package content
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -54,6 +56,7 @@ type Watcher struct {
 	notify      *fsnotify.Watcher
 	events      chan string
 	mu          sync.Mutex
+	reconcileMu sync.Mutex
 	watched     map[string]store.Folder
 	watchedDirs map[string]string
 }
@@ -140,7 +143,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 			}
 			for _, folder := range folders {
 				w.Add(ctx, folder)
-				w.reconcile(ctx, folder)
+				_, _ = w.reconcile(ctx, folder)
 			}
 		}
 	}
@@ -156,7 +159,7 @@ func (w *Watcher) Add(ctx context.Context, folder store.Folder) {
 
 	w.watchTree(folder)
 	if !already {
-		w.reconcile(ctx, folder)
+		_, _ = w.reconcile(ctx, folder)
 	}
 }
 
@@ -305,22 +308,66 @@ func (w *Watcher) reconcileOne(ctx context.Context, folderID string) {
 	if !ok {
 		return
 	}
-	w.reconcile(ctx, folder)
+	_, _ = w.reconcile(ctx, folder)
+}
+
+// ScanFolders runs a pass over each of these folders in turn and waits
+// for all of them, returning what they changed between them.
+//
+// One folder that fails does not stop the rest: an unreachable mount is
+// exactly the situation somebody presses a scan button in, and leaving
+// every other folder unscanned because of it would be the wrong answer.
+// The failures come back joined, so the caller can still say so.
+func (w *Watcher) ScanFolders(
+	ctx context.Context, folders []store.Folder,
+) (store.ReconcileResult, error) {
+	var total store.ReconcileResult
+	var failures []error
+	for _, folder := range folders {
+		if err := ctx.Err(); err != nil {
+			return total, errors.Join(append(failures, err)...)
+		}
+		res, err := w.reconcile(ctx, folder)
+		if err != nil {
+			failures = append(failures, fmt.Errorf("%s: %w", folder.Name, err))
+			continue
+		}
+		total.Added += res.Added
+		total.Updated += res.Updated
+		total.Replaced += res.Replaced
+		total.Missing += res.Missing
+		total.Returned += res.Returned
+		total.Purged += res.Purged
+		total.Rekeyed += res.Rekeyed
+	}
+	return total, errors.Join(failures...)
+}
+
+// ScanAll runs a pass over all watched folders synchronously and waits for all
+// passes to complete.
+func (w *Watcher) ScanAll(ctx context.Context) (store.ReconcileResult, error) {
+	folders, err := w.allFolders(ctx)
+	if err != nil {
+		return store.ReconcileResult{}, err
+	}
+	return w.ScanFolders(ctx, folders)
 }
 
 // reconcile runs one pass and logs what changed. A pass that changed
 // nothing is logged at debug, because the common case is a folder nobody
 // touched and a line per folder per half hour is noise.
-func (w *Watcher) reconcile(ctx context.Context, folder store.Folder) {
+func (w *Watcher) reconcile(ctx context.Context, folder store.Folder) (store.ReconcileResult, error) {
+	w.reconcileMu.Lock()
+	defer w.reconcileMu.Unlock()
 	result, err := w.reconciler.Reconcile(ctx, folder)
 	if err != nil {
 		w.log.Warn("folder pass failed",
 			"folder", folder.ID, "name", folder.Name, "error", err)
-		return
+		return store.ReconcileResult{}, err
 	}
 	if !result.Changed() {
 		w.log.Debug("folder unchanged", "folder", folder.ID, "name", folder.Name)
-		return
+		return result, nil
 	}
 	w.log.Info("folder reconciled",
 		"folder", folder.ID, "name", folder.Name,
@@ -328,6 +375,7 @@ func (w *Watcher) reconcile(ctx context.Context, folder store.Folder) {
 		"replaced", result.Replaced, "missing", result.Missing,
 		"returned", result.Returned,
 		"purged", result.Purged, "rekeyed", result.Rekeyed)
+	return result, nil
 }
 
 func (w *Watcher) allFolders(ctx context.Context) ([]store.Folder, error) {

--- a/internal/content/watch_linux.go
+++ b/internal/content/watch_linux.go
@@ -163,28 +163,6 @@ func (w *Watcher) Add(ctx context.Context, folder store.Folder) {
 	}
 }
 
-// Scan asks for a pass over one folder now, without waiting for an
-// event or for the safety timer.
-//
-// This exists because inotify is not the whole truth: it sees nothing on
-// NFS or SMB, and it drops events under pressure. In both cases the
-// catalog is wrong and the only other recourse is to wait up to half an
-// hour. A pass is idempotent, so the button is free to press — asking
-// twice is asking once.
-//
-// It returns without waiting for the pass to finish. Reading a large
-// folder takes longer than a request should, and the answer a person
-// wants is "yes, I heard you", which is what the page then says.
-func (w *Watcher) Scan(folderID string) {
-	select {
-	case w.events <- folderID:
-	default:
-		// The channel is a signal, not a queue. A full one means a pass
-		// is already pending for something, and a pass reads the whole
-		// folder anyway.
-	}
-}
-
 // Remove unregisters a folder. Its catalog rows go with the folder row;
 // nothing under its root is touched.
 func (w *Watcher) Remove(folderID string) {
@@ -341,16 +319,6 @@ func (w *Watcher) ScanFolders(
 		total.Rekeyed += res.Rekeyed
 	}
 	return total, errors.Join(failures...)
-}
-
-// ScanAll runs a pass over all watched folders synchronously and waits for all
-// passes to complete.
-func (w *Watcher) ScanAll(ctx context.Context) (store.ReconcileResult, error) {
-	folders, err := w.allFolders(ctx)
-	if err != nil {
-		return store.ReconcileResult{}, err
-	}
-	return w.ScanFolders(ctx, folders)
 }
 
 // reconcile runs one pass and logs what changed. A pass that changed

--- a/internal/webui/adminfolders.go
+++ b/internal/webui/adminfolders.go
@@ -85,8 +85,17 @@ func (s *Server) handleAdminCreateFolder(
 	// safety pass would mean an administrator adds a folder, is told it
 	// is being watched, and then stares at an empty shelf for half an
 	// hour.
+	//
+	// Add reconciles inline, and this is the one pass that is genuinely
+	// expensive: a folder nothing has read yet is hashed and parsed book
+	// by book. So it is bounded like the scan buttons are. Giving up
+	// costs nothing — the folder is registered and watched by then, so
+	// the safety pass finishes the reading, which is exactly what the
+	// notice below already promises.
 	if s.Watching != nil {
-		s.Watching.Add(r.Context(), folder)
+		ctx, cancel := context.WithTimeout(r.Context(), scanBudget)
+		defer cancel()
+		s.Watching.Add(ctx, folder)
 	}
 	s.renderAdminFolders(w, r, a, u, Flash{
 		Notice: "Watching " + folder.Name +
@@ -95,7 +104,8 @@ func (s *Server) handleAdminCreateFolder(
 	})
 }
 
-// handleAdminScanFolder asks for a pass over one folder now.
+// handleAdminScanFolder runs a pass over one folder now and waits for
+// it.
 //
 // The watcher already reconciles on filesystem events and on a slow
 // timer, so this is not how a folder normally stays current. It is here
@@ -103,6 +113,15 @@ func (s *Server) handleAdminCreateFolder(
 // pressure: in both cases the catalog is wrong and the alternative is
 // waiting half an hour for the safety pass. A pass is idempotent, so
 // pressing this twice is pressing it once.
+//
+// It waits, like the other two scan buttons, because the question a
+// person presses it with is "what is in there?" and "a pass was asked
+// for" is not an answer to it. It used to hand the folder id to the
+// watcher and return, on the grounds that a request should not wait for
+// a pass — but a repeat pass is a walk and one stat per file (see
+// unchanged() in internal/content), the wait is bounded by scanBudget,
+// and on a server watching one folder this button and "Scan all" were
+// the same act reported two different ways.
 func (s *Server) handleAdminScanFolder(
 	w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User,
 ) {
@@ -114,21 +133,28 @@ func (s *Server) handleAdminScanFolder(
 	folder, err := s.St.FolderByID(r.Context(), "", folderID)
 	logAdminAction(r, u, "scan-folder", folderID, err)
 	if err != nil {
-		s.renderAdminFolders(w, r, a, u, Flash{Error: "no such folder"})
+		s.adminFoldersDone(w, r, a, u, Flash{Error: "no such folder"})
 		return
 	}
 	if s.Watching == nil {
 		// A server started without a watcher has nothing to ask. Saying
 		// so is better than a notice claiming a pass that will not run.
-		s.renderAdminFolders(w, r, a, u, Flash{
+		s.adminFoldersDone(w, r, a, u, Flash{
 			Error: "this server is running without a folder watcher",
 		})
 		return
 	}
-	s.Watching.Scan(folderID)
+	ctx, cancel := context.WithTimeout(r.Context(), scanBudget)
+	defer cancel()
+	res, err := s.Watching.ScanFolders(ctx, []store.Folder{folder})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "scan failed",
+			"actor_id", u.ID, "folder", folder.ID, "error", err)
+		s.adminFoldersDone(w, r, a, u, Flash{Error: scanProblem(ctx, err, true)})
+		return
+	}
 	s.adminFoldersDone(w, r, a, u, Flash{
-		Notice: "Reading " + folder.Name +
-			" again. Any change appears as the pass finishes.",
+		Notice: scanNotice(res, folder.Name+" is up to date."),
 	})
 }
 

--- a/internal/webui/adminfolders.go
+++ b/internal/webui/adminfolders.go
@@ -1,6 +1,8 @@
 package webui
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -124,10 +126,84 @@ func (s *Server) handleAdminScanFolder(
 		return
 	}
 	s.Watching.Scan(folderID)
-	s.renderAdminFolders(w, r, a, u, Flash{
+	s.adminFoldersDone(w, r, a, u, Flash{
 		Notice: "Reading " + folder.Name +
 			" again. Any change appears as the pass finishes.",
 	})
+}
+
+// handleAdminScanAllFolders runs a pass over every watched folder and
+// waits for it, which is what makes the button worth pressing: the page
+// that comes back is the one the passes produced.
+//
+// It is bounded by scanBudget for the same reason the library button is
+// — a pass holds the watcher's reconcile lock — and it does not stop at
+// the first folder that fails, because one unreadable mount is not a
+// reason to leave every other folder unscanned.
+func (s *Server) handleAdminScanAllFolders(
+	w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User,
+) {
+	if !s.checkCSRF(r, a) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	logAdminAction(r, u, "scan-all-folders", "", nil)
+	if s.Watching == nil {
+		s.adminFoldersDone(w, r, a, u, Flash{
+			Error: "this server is running without a folder watcher",
+		})
+		return
+	}
+	folders, err := s.allFolders(r.Context())
+	if err != nil {
+		s.adminFoldersDone(w, r, a, u, Flash{
+			Error: "could not list folders: " + err.Error(),
+		})
+		return
+	}
+	if len(folders) == 0 {
+		s.adminFoldersDone(w, r, a, u, Flash{Notice: "No watched folders to scan."})
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), scanBudget)
+	defer cancel()
+	res, err := s.Watching.ScanFolders(ctx, folders)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "scan-all failed", "actor_id", u.ID, "error", err)
+		s.adminFoldersDone(w, r, a, u, Flash{Error: scanProblem(ctx, err, true)})
+		return
+	}
+	s.adminFoldersDone(w, r, a, u, Flash{
+		Notice: scanNotice(res, "All folders are up to date."),
+	})
+}
+
+// adminFoldersDone finishes a folder mutation, for htmx and for a plain
+// form post.
+//
+// The two need different spellings of the same destination. A 303's
+// Location is resolved by the browser against the request URL, which is
+// what settingsRedirect writes; htmx assigns HX-Redirect to
+// location.href, which is resolved against the page the reader is on.
+// The admin views always live at /ui/settings, one segment under /ui/,
+// so the page-relative spelling is the bare href — and being relative is
+// what keeps it right behind a proxy serving this UI under a subpath.
+//
+// A flash carrying a one-time secret never travels in a URL, so it falls
+// through to being rendered in place, exactly as settingsRedirect does.
+func (s *Server) adminFoldersDone(
+	w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User, flash Flash,
+) {
+	if isHTMXRequest(r) && flash.Secret == "" {
+		target := settingsAdminHref("", settingsAdminFolders)
+		if q := flashQuery(flash); q != "" {
+			target += "&" + q
+		}
+		w.Header().Set("HX-Redirect", target)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	s.renderAdminFolders(w, r, a, u, flash)
 }
 
 // handleAdminDeleteFolder forgets a folder and everything catalogued

--- a/internal/webui/adminfolders.templ
+++ b/internal/webui/adminfolders.templ
@@ -25,7 +25,25 @@ templ adminFoldersBody(prefix string, csrf string, folders []adminFolderView, ne
 	</p>
 	@adminFlash(flash)
 	<section class="card">
-		<h2>Watched</h2>
+		<div class="cardhead">
+			<h2>Watched</h2>
+			if len(folders) > 0 {
+				<form
+					class="scanform"
+					method="post"
+					action={ prefix + "admin/folders/scan-all" }
+					hx-post={ prefix + "admin/folders/scan-all" }
+					hx-disabled-elt="find button"
+				>
+					<input type="hidden" name="csrf" value={ csrf }/>
+					<button type="submit" class="scanbtn" title="Scan all folders now">
+						<span class="scanicon" aria-hidden="true">↻</span>
+						<span class="scanlabel">Scan all</span>
+						<span class="scanspinner" aria-hidden="true"></span>
+					</button>
+				</form>
+			}
+		</div>
 		if len(folders) == 0 {
 			<p class="muted">
 				No folders yet. Add one below and its books appear as the
@@ -65,9 +83,18 @@ templ adminFoldersBody(prefix string, csrf string, folders []adminFolderView, ne
 									<button type="submit">Accept uploads</button>
 								}
 							</form>
-							<form method="post" action={ prefix + "admin/folders/" + f.Folder.ID + "/scan" }>
+							<form
+								class="scanform"
+								method="post"
+								action={ prefix + "admin/folders/" + f.Folder.ID + "/scan" }
+								hx-post={ prefix + "admin/folders/" + f.Folder.ID + "/scan" }
+								hx-disabled-elt="find button"
+							>
 								<input type="hidden" name="csrf" value={ csrf }/>
-								<button type="submit">Scan now</button>
+								<button type="submit" class="scanbtn">
+									<span class="scanicon" aria-hidden="true">↻</span>
+									<span>Scan now</span>
+								</button>
 							</form>
 							<form method="post" action={ prefix + "admin/folders/" + f.Folder.ID + "/delete" }
 								hx-confirm="Stop watching this folder? Its books stay on disk but leave the catalog."

--- a/internal/webui/adminfolders.templ
+++ b/internal/webui/adminfolders.templ
@@ -94,6 +94,7 @@ templ adminFoldersBody(prefix string, csrf string, folders []adminFolderView, ne
 								<button type="submit" class="scanbtn">
 									<span class="scanicon" aria-hidden="true">↻</span>
 									<span>Scan now</span>
+									<span class="scanspinner" aria-hidden="true"></span>
 								</button>
 							</form>
 							<form method="post" action={ prefix + "admin/folders/" + f.Folder.ID + "/delete" }

--- a/internal/webui/adminfolders_watch_test.go
+++ b/internal/webui/adminfolders_watch_test.go
@@ -21,7 +21,6 @@ type recordingWatcher struct {
 	mu          sync.Mutex
 	added       []store.Folder
 	removed     []string
-	scanned     []string
 	scanFolders []store.Folder
 	scanResult  store.ReconcileResult
 	scanErr     error
@@ -32,12 +31,6 @@ func (w *recordingWatcher) ScanFolders(_ context.Context, folders []store.Folder
 	defer w.mu.Unlock()
 	w.scanFolders = append(w.scanFolders, folders...)
 	return w.scanResult, w.scanErr
-}
-
-func (w *recordingWatcher) Scan(folderID string) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	w.scanned = append(w.scanned, folderID)
 }
 
 func (w *recordingWatcher) Add(_ context.Context, folder store.Folder) {
@@ -136,13 +129,14 @@ func TestAFolderCanBeAddedWithoutAWatcher(t *testing.T) {
 	}
 }
 
-// TestScanNowAsksTheWatcher: the button exists because inotify sees
-// nothing on NFS or SMB and drops events under pressure, so an operator
-// whose catalog is wrong has no other recourse but to wait half an hour.
-// If the press does not reach the watcher, the page tells a comfortable
-// lie and the wait happens anyway.
-func TestScanNowAsksTheWatcher(t *testing.T) {
-	watcher := &recordingWatcher{}
+// TestScanNowRunsAPassAndReportsIt: the button exists because inotify
+// sees nothing on NFS or SMB and drops events under pressure, so an
+// operator whose catalog is wrong has no other recourse but to wait half
+// an hour. If the press does not reach the watcher, the page tells a
+// comfortable lie and the wait happens anyway — so this pins both that
+// it ran and that the page says what it found.
+func TestScanNowRunsAPassAndReportsIt(t *testing.T) {
+	watcher := &recordingWatcher{scanResult: store.ReconcileResult{Added: 1}}
 	ts, st := testServerCfg(t, nil, func(s *Server) {
 		generousReauth(s)
 		s.Watching = watcher
@@ -166,14 +160,16 @@ func TestScanNowAsksTheWatcher(t *testing.T) {
 
 	_, body = postForm(t, ts, cookie,
 		"/ui/admin/folders/"+folders[0].ID+"/scan", url.Values{"csrf": {csrf}})
-	if !strings.Contains(body, "Reading Books again") {
-		t.Fatalf("the scan was not acknowledged: %s", body)
+	// The button waits, so the page says what the pass found rather
+	// than that one was asked for.
+	if !strings.Contains(body, "1 added") {
+		t.Fatalf("the scan did not report what it changed: %s", body)
 	}
 	watcher.mu.Lock()
-	scanned := append([]string(nil), watcher.scanned...)
+	scanned := append([]store.Folder(nil), watcher.scanFolders...)
 	watcher.mu.Unlock()
-	if len(scanned) != 1 || scanned[0] != folders[0].ID {
-		t.Fatalf("watcher was asked to scan %v, want [%s]", scanned, folders[0].ID)
+	if len(scanned) != 1 || scanned[0].ID != folders[0].ID {
+		t.Fatalf("watcher was asked to scan %v, want just %s", scanned, folders[0].ID)
 	}
 
 	// A folder that is not there cannot be scanned, and saying so beats
@@ -184,7 +180,7 @@ func TestScanNowAsksTheWatcher(t *testing.T) {
 		t.Fatalf("an unknown folder was accepted: %s", body)
 	}
 	watcher.mu.Lock()
-	count := len(watcher.scanned)
+	count := len(watcher.scanFolders)
 	watcher.mu.Unlock()
 	if count != 1 {
 		t.Fatalf("an unknown folder reached the watcher: %d calls", count)

--- a/internal/webui/adminfolders_watch_test.go
+++ b/internal/webui/adminfolders_watch_test.go
@@ -2,21 +2,36 @@ package webui
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/chmouel/liseur-sync/internal/auth"
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
 // recordingWatcher stands in for the running folder watcher.
 type recordingWatcher struct {
-	mu      sync.Mutex
-	added   []store.Folder
-	removed []string
-	scanned []string
+	mu          sync.Mutex
+	added       []store.Folder
+	removed     []string
+	scanned     []string
+	scanFolders []store.Folder
+	scanResult  store.ReconcileResult
+	scanErr     error
+}
+
+func (w *recordingWatcher) ScanFolders(_ context.Context, folders []store.Folder) (store.ReconcileResult, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.scanFolders = append(w.scanFolders, folders...)
+	return w.scanResult, w.scanErr
 }
 
 func (w *recordingWatcher) Scan(folderID string) {
@@ -272,5 +287,269 @@ func TestFoldersPageMarksOneNobodyCanRead(t *testing.T) {
 	_, body = page(t, ts, cookie, "/ui/settings?section=admin&view=folders")
 	if strings.Contains(body, "No account can read this folder") {
 		t.Fatalf("a granted folder is still marked unreadable:\n%s", body)
+	}
+}
+
+// scanPost posts to a scan route the way a browser or htmx would, and
+// hands back the raw response: what these tests are about is the
+// redirect header, which the browser-shaped helpers follow and discard.
+func scanPost(
+	t *testing.T, ts *httptest.Server, cookie *http.Cookie,
+	path string, form url.Values, htmx bool,
+) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, ts.URL+path, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if htmx {
+		req.Header.Set("HX-Request", "true")
+	}
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	resp, err := noRedirect().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func adminWithFolder(t *testing.T, watcher *recordingWatcher) (*httptest.Server, store.Store, *http.Cookie, string) {
+	t.Helper()
+	ts, st := testServerCfg(t, nil, func(s *Server) {
+		generousReauth(s)
+		s.Watching = watcher
+	})
+	if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
+		t.Fatal(err)
+	}
+	cookie := loginCookie(t, ts)
+	_, body := page(t, ts, cookie, "/ui/settings?section=admin&view=folders")
+	csrf := extractCSRF(t, body)
+	_, body = postForm(t, ts, cookie, "/ui/admin/folders", url.Values{
+		"csrf": {csrf}, "name": {"Books"}, "root": {t.TempDir()},
+	})
+	if !strings.Contains(body, "Watching Books") {
+		t.Fatalf("the folder was not added: %s", body)
+	}
+	return ts, st, cookie, csrf
+}
+
+// TestLibraryScanRedirectsWhereTheReaderWas pins the one thing about
+// this route that is easy to get wrong and invisible in a unit test that
+// only greps for "notice".
+//
+// The same destination has to be spelled two different ways. A 303's
+// Location is resolved by the browser against the request URL —
+// /ui/library/scan — so it needs the hop back out; htmx assigns
+// HX-Redirect to location.href, resolved against the page the reader is
+// on — /ui/library — so it needs the target the page itself would write.
+// Swapping them lands on /ui/library/library and /library respectively,
+// and both are 404s.
+func TestLibraryScanRedirectsWhereTheReaderWas(t *testing.T) {
+	watcher := &recordingWatcher{scanResult: store.ReconcileResult{Added: 3}}
+	ts, _, cookie, csrf := adminWithFolder(t, watcher)
+
+	// "library?folder=f1" is what the page writes into the hidden field.
+	form := url.Values{"csrf": {csrf}, "back": {"library?folder=f1"}}
+
+	resp := scanPost(t, ts, cookie, "/ui/library/scan", form, false)
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("plain POST status = %d, want 303", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	if !strings.HasPrefix(loc, "../library?folder=f1&notice=") {
+		t.Fatalf("Location = %q, want a target relative to /ui/library/scan", loc)
+	}
+	// The browser's own resolution, which is the thing that matters.
+	base, _ := url.Parse(ts.URL + "/ui/library/scan")
+	landed, err := base.Parse(loc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if landed.Path != "/ui/library" {
+		t.Fatalf("a browser following that lands on %q, want /ui/library", landed.Path)
+	}
+
+	resp = scanPost(t, ts, cookie, "/ui/library/scan", form, true)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("htmx POST status = %d, want 200", resp.StatusCode)
+	}
+	hx := resp.Header.Get("HX-Redirect")
+	if !strings.HasPrefix(hx, "library?folder=f1&notice=") {
+		t.Fatalf("HX-Redirect = %q, want a target relative to /ui/library", hx)
+	}
+	base, _ = url.Parse(ts.URL + "/ui/library")
+	landed, err = base.Parse(hx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if landed.Path != "/ui/library" {
+		t.Fatalf("htmx sets location.href to %q, want /ui/library", landed.Path)
+	}
+
+	watcher.mu.Lock()
+	scanned := len(watcher.scanFolders)
+	watcher.mu.Unlock()
+	if scanned != 2 {
+		t.Fatalf("ScanFolders saw %d folders over two requests, want 2", scanned)
+	}
+}
+
+// TestLibraryScanRefusesAnOffsiteBack. back arrives in a form field, so
+// it is somewhere to send a browser that a request chose. Every other
+// place this UI takes one (prefs.go) runs it through safeUIPath first,
+// and a scan button is not the place to stop.
+func TestLibraryScanRefusesAnOffsiteBack(t *testing.T) {
+	ts, _, cookie, csrf := adminWithFolder(t, &recordingWatcher{})
+	for _, back := range []string{
+		"//evil.example/", "https://evil.example/", "/ui/library",
+	} {
+		resp := scanPost(t, ts, cookie, "/ui/library/scan",
+			url.Values{"csrf": {csrf}, "back": {back}}, true)
+		hx := resp.Header.Get("HX-Redirect")
+		if !strings.HasPrefix(hx, "library?") {
+			t.Errorf("back=%q produced HX-Redirect %q, want the library page", back, hx)
+		}
+	}
+}
+
+// TestLibraryScanHidesTheRootPathFromAReader. A reconcile failure names
+// the folder's root path (ErrRootUnavailable wraps it), and root_path is
+// a filesystem oracle no non-administrator is ever shown. The
+// administrator who can act on it still gets the error itself.
+func TestLibraryScanHidesTheRootPathFromAReader(t *testing.T) {
+	const secret = "/srv/private/books"
+	watcher := &recordingWatcher{scanErr: errors.New("root unavailable: " + secret)}
+	ts, st := testServerCfg(t, nil, func(s *Server) {
+		generousReauth(s)
+		s.Watching = watcher
+	})
+	hash, _ := auth.HashPassword("hunter2hunter")
+	if err := st.CreateUser(t.Context(), store.User{
+		ID: "u2", Name: "bob", Argon2Hash: hash, Timezone: "UTC",
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CreateFolder(t.Context(), store.Folder{
+		ID: "f1", Name: "Books", RootPath: secret, Kind: store.FolderPlain,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AssignUserFolder(t.Context(), "u2", "f1"); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := loginCookieAs(t, ts, "bob", "hunter2hunter")
+	_, body := page(t, ts, reader, "/ui/library")
+	resp := scanPost(t, ts, reader, "/ui/library/scan",
+		url.Values{"csrf": {extractCSRF(t, body)}, "back": {"library"}}, true)
+	hx := resp.Header.Get("HX-Redirect")
+	if strings.Contains(hx, "srv") || strings.Contains(hx, url.QueryEscape(secret)) {
+		t.Fatalf("a reader was told the root path: %q", hx)
+	}
+	if !strings.Contains(hx, "problem=") {
+		t.Fatalf("a failed scan did not report a problem: %q", hx)
+	}
+
+	// The same failure, to an administrator, keeps the detail.
+	if err := st.SetUserAdmin(t.Context(), "u1", true); err != nil {
+		t.Fatal(err)
+	}
+	admin := loginCookie(t, ts)
+	_, body = page(t, ts, admin, "/ui/library")
+	resp = scanPost(t, ts, admin, "/ui/library/scan",
+		url.Values{"csrf": {extractCSRF(t, body)}, "back": {"library"}}, true)
+	if hx := resp.Header.Get("HX-Redirect"); !strings.Contains(hx, url.QueryEscape(secret)) {
+		t.Fatalf("an administrator was not told why the scan failed: %q", hx)
+	}
+}
+
+// TestAdminScanAllFoldersRedirectsToTheFoldersView. The admin views live
+// at /ui/settings, so the page-relative spelling htmx needs is the bare
+// href — not one computed from /ui/admin/folders/scan-all, which would
+// send location.href three directories above /ui.
+func TestAdminScanAllFoldersRedirectsToTheFoldersView(t *testing.T) {
+	watcher := &recordingWatcher{scanResult: store.ReconcileResult{Added: 1, Updated: 2}}
+	ts, _, cookie, csrf := adminWithFolder(t, watcher)
+	_, _ = postForm(t, ts, cookie, "/ui/admin/folders", url.Values{
+		"csrf": {csrf}, "name": {"More"}, "root": {t.TempDir()},
+	})
+
+	resp := scanPost(t, ts, cookie, "/ui/admin/folders/scan-all",
+		url.Values{"csrf": {csrf}}, true)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("htmx POST status = %d, want 200", resp.StatusCode)
+	}
+	hx := resp.Header.Get("HX-Redirect")
+	base, _ := url.Parse(ts.URL + "/ui/settings?section=admin&view=folders")
+	landed, err := base.Parse(hx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if landed.Path != "/ui/settings" {
+		t.Fatalf("htmx sets location.href to %q (from %q), want /ui/settings",
+			landed.Path, hx)
+	}
+	if landed.Query().Get("view") != settingsAdminFolders {
+		t.Fatalf("HX-Redirect %q does not return to the folders view", hx)
+	}
+	if !strings.Contains(landed.Query().Get("notice"), "1 added") ||
+		!strings.Contains(landed.Query().Get("notice"), "2 updated") {
+		t.Fatalf("notice %q does not say what the pass changed", landed.Query().Get("notice"))
+	}
+
+	watcher.mu.Lock()
+	scanned := len(watcher.scanFolders)
+	watcher.mu.Unlock()
+	if scanned != 2 {
+		t.Fatalf("ScanFolders saw %d folders, want both", scanned)
+	}
+}
+
+// TestAdminScanFolderAnswersHTMX. The per-folder button posts through
+// htmx, and htmx swaps a 200 into the element that made the request. A
+// handler that renders a whole settings page there puts a document
+// inside a <form>; this route has to redirect instead.
+func TestAdminScanFolderAnswersHTMX(t *testing.T) {
+	watcher := &recordingWatcher{}
+	ts, st, cookie, csrf := adminWithFolder(t, watcher)
+	folders, err := st.ListFolders(t.Context(), "", "", 10)
+	if err != nil || len(folders) != 1 {
+		t.Fatalf("folders = %+v, %v", folders, err)
+	}
+	resp := scanPost(t, ts, cookie,
+		"/ui/admin/folders/"+folders[0].ID+"/scan", url.Values{"csrf": {csrf}}, true)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if hx := resp.Header.Get("HX-Redirect"); hx == "" {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("no HX-Redirect; htmx would swap this into the form:\n%s", body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if strings.Contains(string(body), "<html") {
+		t.Fatalf("an htmx scan answered with a whole page:\n%s", body)
+	}
+}
+
+// TestScanNoticeNamesEveryCounter. A pass that only purged or only
+// rekeyed changed something, and a sentence that lists three of the
+// seven counters reports it as nothing.
+func TestScanNoticeNamesEveryCounter(t *testing.T) {
+	if got := scanNotice(store.ReconcileResult{}, "up to date"); got != "Scan complete. up to date" {
+		t.Fatalf("an unchanged pass said %q", got)
+	}
+	got := scanNotice(store.ReconcileResult{Purged: 2}, "up to date")
+	if !strings.Contains(got, "2 purged") {
+		t.Fatalf("a purge-only pass said %q", got)
+	}
+	got = scanNotice(store.ReconcileResult{Added: 1, Rekeyed: 4}, "up to date")
+	if !strings.Contains(got, "1 added") || !strings.Contains(got, "4 rekeyed") {
+		t.Fatalf("notice %q dropped a counter", got)
 	}
 }

--- a/internal/webui/adminfolders_watch_test.go
+++ b/internal/webui/adminfolders_watch_test.go
@@ -549,3 +549,32 @@ func TestScanNoticeNamesEveryCounter(t *testing.T) {
 		t.Fatalf("notice %q dropped a counter", got)
 	}
 }
+
+// TestScanProblemDoesNotPromiseABackgroundScan. The budget cancels the
+// pass; it does not detach it. A message saying the scan carries on
+// would tell a reader to wait for something that is not running, and
+// the honest answer is that it stopped and the periodic pass will
+// finish. This pins the distinction, because it is easy to write the
+// reassuring version by accident.
+func TestScanProblemDoesNotPromiseABackgroundScan(t *testing.T) {
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+	if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		t.Fatalf("test setup: context error is %v", ctx.Err())
+	}
+
+	for _, admin := range []bool{true, false} {
+		got := scanProblem(ctx, errors.New("root unavailable: /srv/books"), admin)
+		if strings.Contains(got, "background") || strings.Contains(got, "will finish") {
+			t.Errorf("timeout message promises a background scan (admin=%v): %q", admin, got)
+		}
+		if !strings.Contains(got, "stopped") {
+			t.Errorf("timeout message does not say it stopped (admin=%v): %q", admin, got)
+		}
+		// A timeout is reported before the error is, so the root path
+		// never reaches the page by this route either.
+		if strings.Contains(got, "/srv/books") {
+			t.Errorf("timeout message leaked the root path (admin=%v): %q", admin, got)
+		}
+	}
+}

--- a/internal/webui/library.templ
+++ b/internal/webui/library.templ
@@ -24,29 +24,34 @@ templ libraryBody(prefix, csrf string, admin bool, v LibraryView) {
 			<p class="eyebrow">Your shelves</p>
 			<h1>Library</h1>
 		</div>
-		if v.HasGrant() {
-			<form class="folderpick" method="get" action={ prefix + "library" }>
-				<label class="visually-hidden" for="folder-pick">Folder</label>
-				<select id="folder-pick" name="folder">
-					for _, f := range v.Folders {
-						if f.Selected {
-							<option value={ f.ID } selected>{ f.Name }</option>
-						} else {
-							<option value={ f.ID }>{ f.Name }</option>
+		if v.HasGrant() || (admin && v.ServerHasFolders) {
+			<div class="librarycontrols">
+				@scanButton(prefix, csrf, v.Back)
+				if v.HasGrant() {
+					<form class="folderpick" method="get" action={ prefix + "library" }>
+						<label class="visually-hidden" for="folder-pick">Folder</label>
+						<select id="folder-pick" name="folder">
+							for _, f := range v.Folders {
+								if f.Selected {
+									<option value={ f.ID } selected>{ f.Name }</option>
+								} else {
+									<option value={ f.ID }>{ f.Name }</option>
+								}
+							}
+						</select>
+						if v.Filter != filterAll {
+							<input type="hidden" name="filter" value={ v.Filter }/>
 						}
-					}
-				</select>
-				if v.Filter != filterAll {
-					<input type="hidden" name="filter" value={ v.Filter }/>
+						if v.Sort != sortRecent {
+							<input type="hidden" name="sort" value={ v.Sort }/>
+						}
+						if v.Dir != sortDirDesc {
+							<input type="hidden" name="dir" value={ v.Dir }/>
+						}
+						<noscript><button type="submit">Show</button></noscript>
+					</form>
 				}
-				if v.Sort != sortRecent {
-					<input type="hidden" name="sort" value={ v.Sort }/>
-				}
-				if v.Dir != sortDirDesc {
-					<input type="hidden" name="dir" value={ v.Dir }/>
-				}
-				<noscript><button type="submit">Show</button></noscript>
-			</form>
+			</div>
 		}
 	</header>
 	if !v.HasGrant() {
@@ -541,5 +546,29 @@ templ uploadForm(prefix, csrf, folder string) {
 		<label class="visually-hidden" for="upload-file">EPUB to add</label>
 		<input id="upload-file" type="file" name="file" accept=".epub,application/epub+zip" required/>
 		<button type="submit">Send a book</button>
+	</form>
+}
+
+// scanButton asks for a pass over the libraries this reader can see and
+// waits for it, so the shelf that comes back is the one the pass made.
+//
+// back is where to land afterwards, written the way this page would
+// write it — relative, so it survives a proxy serving the UI under a
+// subpath, and carrying the folder, filter and sort the reader had.
+templ scanButton(prefix, csrf, back string) {
+	<form
+		class="scanform"
+		method="post"
+		action={ prefix + "library/scan" }
+		hx-post={ prefix + "library/scan" }
+		hx-disabled-elt="find button"
+	>
+		<input type="hidden" name="csrf" value={ csrf }/>
+		<input type="hidden" name="back" value={ back }/>
+		<button type="submit" class="scanbtn" title="Scan for new books">
+			<span class="scanicon" aria-hidden="true">↻</span>
+			<span class="scanlabel">Scan</span>
+			<span class="scanspinner" aria-hidden="true"></span>
+		</button>
 	</form>
 }

--- a/internal/webui/libraryscan.go
+++ b/internal/webui/libraryscan.go
@@ -1,0 +1,190 @@
+package webui
+
+// Asking for a pass from the library page (the ↻ button).
+//
+// The admin page has had a per-folder "Scan now" since folders existed,
+// and it does not wait: it drops a signal in the watcher's channel and
+// says "reading it again". This one does wait, because it answers a
+// different question. A reader who just copied a book in wants the
+// shelf to have it when the page comes back, and a page that says
+// "asked for" and then shows the same shelf is not an answer.
+//
+// Waiting is bounded (scanBudget) and every error is generalised before
+// it reaches the page: a reconcile failure names the folder's root path,
+// and root_path is an administrator's to see.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// scanBudget bounds how long a scan requested from a page may run. A
+// pass holds the watcher's reconcile lock, so an unbounded one started
+// by any signed-in reader would stall the watcher, the periodic pass and
+// folder creation for as long as a slow mount takes to walk. Giving up
+// is cheap: a pass is idempotent and the safety timer runs anyway.
+const scanBudget = 2 * time.Minute
+
+// handleLibraryScan scans the libraries visible to the caller: every
+// folder on the server for an administrator, every granted folder for
+// everyone else.
+func (s *Server) handleLibraryScan(
+	w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User,
+) {
+	if !s.checkCSRF(r, a) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	// back is relative to the library page, not to this route, and it
+	// arrives from a form: an open redirect through a scan button would
+	// be a silly way to lose the property that every /ui link stays here.
+	back := r.FormValue("back")
+	if !safeUIPath(back) {
+		back = "library"
+	}
+	if s.Watching == nil {
+		s.scanDone(w, r, back, "", "this server is running without a folder watcher")
+		return
+	}
+
+	var folders []store.Folder
+	var err error
+	if u.IsAdmin {
+		folders, err = s.allFolders(r.Context())
+	} else {
+		folders, err = s.grantedFolders(r.Context(), u.ID)
+	}
+	if err != nil {
+		slog.ErrorContext(r.Context(), "scan could not list folders",
+			"actor_id", u.ID, "error", err)
+		s.scanDone(w, r, back, "", "the folder list could not be read; try again")
+		return
+	}
+	if len(folders) == 0 {
+		s.scanDone(w, r, back, "No watched folders to scan.", "")
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), scanBudget)
+	defer cancel()
+	res, err := s.Watching.ScanFolders(ctx, folders)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "scan failed",
+			"actor_id", u.ID, "error", err)
+		s.scanDone(w, r, back, "", scanProblem(ctx, err, u.IsAdmin))
+		return
+	}
+	s.scanDone(w, r, back, scanNotice(res, "Catalog is up to date."), "")
+}
+
+// scanProblem turns a failed pass into a sentence. An administrator gets
+// the error itself, because they are the person who can act on "no such
+// directory". Everybody else gets a sentence with no filesystem in it:
+// a reconcile error names the folder's root path, and that path is a
+// filesystem oracle a reader is never shown.
+func scanProblem(ctx context.Context, err error, admin bool) string {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return "that scan is taking too long; it will finish in the background"
+	}
+	if admin {
+		// A joined error is newline-separated, and this ends up in one
+		// line of a flash.
+		return "scan failed: " + strings.ReplaceAll(err.Error(), "\n", "; ")
+	}
+	return "that scan could not finish; an administrator can see why"
+}
+
+// scanNotice says what a pass changed. Every counter is named, because
+// "up to date" and "nothing you asked about changed" are different
+// answers and a purge-only pass is not the former.
+func scanNotice(res store.ReconcileResult, quiet string) string {
+	if !res.Changed() {
+		return "Scan complete. " + quiet
+	}
+	parts := make([]string, 0, 7)
+	for _, c := range []struct {
+		n     int
+		label string
+	}{
+		{res.Added, "added"},
+		{res.Updated, "updated"},
+		{res.Replaced, "replaced"},
+		{res.Missing, "missing"},
+		{res.Returned, "returned"},
+		{res.Purged, "purged"},
+		{res.Rekeyed, "rekeyed"},
+	} {
+		if c.n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", c.n, c.label))
+		}
+	}
+	return "Scan complete: " + strings.Join(parts, ", ") + "."
+}
+
+// allFolders returns every folder watched by this server. The empty
+// viewer id is the trusted-administration read; every caller of this is
+// behind an administrator check.
+func (s *Server) allFolders(ctx context.Context) ([]store.Folder, error) {
+	return listAllFolders(ctx, s.St, "")
+}
+
+// grantedFolders returns every folder one reader may see, which is what
+// bounds a scan they asked for.
+func (s *Server) grantedFolders(ctx context.Context, userID string) ([]store.Folder, error) {
+	return listAllFolders(ctx, s.St, userID)
+}
+
+func listAllFolders(ctx context.Context, st store.Store, viewerID string) ([]store.Folder, error) {
+	const page = 200
+	var all []store.Folder
+	cursor := ""
+	for {
+		batch, err := st.ListFolders(ctx, viewerID, cursor, page)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, batch...)
+		if len(batch) < page {
+			return all, nil
+		}
+		cursor = store.FolderCursor(batch[len(batch)-1])
+	}
+}
+
+// scanDone sends the browser back to the page the button was on, with
+// what happened in the query string.
+//
+// The two ways out need different targets for the same destination,
+// because they are resolved against different URLs. A 303's Location is
+// resolved against the request (/ui/library/scan), so it needs the hop
+// back out of this route; htmx's HX-Redirect is assigned to
+// location.href and resolved against the page the reader is on
+// (/ui/library), so it needs the target exactly as the page would write
+// it. Sending one to the other lands on /ui/library/library or /library.
+func (s *Server) scanDone(w http.ResponseWriter, r *http.Request, back, notice, problem string) {
+	target := back
+	sep := "?"
+	if strings.Contains(target, "?") {
+		sep = "&"
+	}
+	switch {
+	case problem != "":
+		target += sep + "problem=" + url.QueryEscape(problem)
+	case notice != "":
+		target += sep + "notice=" + url.QueryEscape(notice)
+	}
+	if isHTMXRequest(r) {
+		w.Header().Set("HX-Redirect", target)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	redirectRel(w, relPrefix(r.URL.Path)+target, http.StatusSeeOther)
+}

--- a/internal/webui/scan.go
+++ b/internal/webui/scan.go
@@ -1,17 +1,22 @@
 package webui
 
-// Asking for a pass from the library page (the ↻ button).
+// Asking for a pass from a page: the library's ↻ button, and the two
+// buttons on the admin folders panel that share the vocabulary below.
 //
-// The admin page has had a per-folder "Scan now" since folders existed,
-// and it does not wait: it drops a signal in the watcher's channel and
-// says "reading it again". This one does wait, because it answers a
-// different question. A reader who just copied a book in wants the
-// shelf to have it when the page comes back, and a page that says
-// "asked for" and then shows the same shelf is not an answer.
+// All three wait. A person presses scan because the shelf disagrees
+// with the disk, and a page that says "asked for" and then shows the
+// same shelf has not answered them — it has only moved the question to
+// whether they should press it again. So a scan reports what it found,
+// which means holding the request until it has.
 //
-// Waiting is bounded (scanBudget) and every error is generalised before
-// it reaches the page: a reconcile failure names the folder's root path,
-// and root_path is an administrator's to see.
+// Waiting is bounded (scanBudget), which is safe because a pass checks
+// for cancellation before it reconciles: giving up early leaves the
+// catalog untouched rather than half-applied, and the pass is
+// idempotent, so the next one picks up where this one stopped.
+//
+// Every error is generalised before it reaches a page. A reconcile
+// failure names the folder's root path, and root_path is an
+// administrator's to see.
 
 import (
 	"context"

--- a/internal/webui/scan.go
+++ b/internal/webui/scan.go
@@ -97,7 +97,12 @@ func (s *Server) handleLibraryScan(
 // filesystem oracle a reader is never shown.
 func scanProblem(ctx context.Context, err error, admin bool) string {
 	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		return "that scan is taking too long; it will finish in the background"
+		// The deadline cancels the pass rather than detaching it, so
+		// this must not promise that it carries on. A folder it did not
+		// finish is left exactly as it was, because a pass gives up
+		// before it writes anything; folders it did finish are saved.
+		return "that scan ran out of time and stopped; " +
+			"what it finished is saved, and the next pass picks up the rest"
 	}
 	if admin {
 		// A joined error is newline-separated, and this ends up in one

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -94,12 +94,14 @@ func (s *Server) generateSecret() (string, error) {
 type FolderWatcher interface {
 	Add(ctx context.Context, folder store.Folder)
 	Remove(folderID string)
-	// Scan asks for a pass over one folder now. It returns before the
-	// pass finishes: reading a large folder takes longer than a request
-	// should.
-	Scan(folderID string)
-	// ScanFolders runs a pass over the specified folders synchronously and
-	// returns the aggregated reconcile results.
+	// ScanFolders runs a pass over each of these folders and waits for
+	// all of them, returning what they changed between them.
+	//
+	// Every scan this UI offers waits. A pass asked for and not waited
+	// on cannot say what it found, and "a pass was asked for" is not an
+	// answer to the question the button is pressed with. The wait is
+	// bounded by the caller (scanBudget), which is what makes it safe to
+	// do from a request.
 	ScanFolders(ctx context.Context, folders []store.Folder) (store.ReconcileResult, error)
 }
 

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -98,6 +98,9 @@ type FolderWatcher interface {
 	// pass finishes: reading a large folder takes longer than a request
 	// should.
 	Scan(folderID string)
+	// ScanFolders runs a pass over the specified folders synchronously and
+	// returns the aggregated reconcile results.
+	ScanFolders(ctx context.Context, folders []store.Folder) (store.ReconcileResult, error)
 }
 
 const cookieName = "liseur_session"
@@ -292,6 +295,7 @@ func (s *Server) Mount(mux *http.ServeMux, secure func(http.Handler) http.Handle
 	mux.Handle("POST /ui/kosync/{slot}/revoke", sec(s.requireAuth(s.handleRevokeKosync)))
 	mux.Handle("POST /ui/preferences", sec(s.requireAuth(s.handlePreferences)))
 	mux.Handle("POST /ui/library/upload", sec(s.requireAuth(s.handleLibraryUpload)))
+	mux.Handle("POST /ui/library/scan", sec(s.requireAuth(s.handleLibraryScan)))
 	mux.Handle("POST /ui/books/{id}/series", sec(s.requireAuth(s.handleSeriesAssign)))
 	mux.Handle("POST /ui/books/{id}/reading-status", sec(s.requireAuth(s.handleBookReadingStatus)))
 	// Deleting (ADR-0024). A work is the reader's own, so it is
@@ -353,6 +357,8 @@ func (s *Server) Mount(mux *http.ServeMux, secure func(http.Handler) http.Handle
 	mux.Handle("POST /ui/admin/users/{id}/backfill",
 		sec(s.requireAdmin(s.handleAdminBackfillWorks)))
 	mux.Handle("POST /ui/admin/folders", sec(s.requireAdmin(s.handleAdminCreateFolder)))
+	mux.Handle("POST /ui/admin/folders/scan-all",
+		sec(s.requireAdmin(s.handleAdminScanAllFolders)))
 	mux.Handle("POST /ui/admin/folders/{id}/scan",
 		sec(s.requireAdmin(s.handleAdminScanFolder)))
 	mux.Handle("POST /ui/admin/folders/{id}/uploads",

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -299,6 +299,11 @@ main { grid-area: main; padding: 1.4rem 1.5rem 4rem; min-width: 0; }
 	margin: 0 0 var(--gap);
 	box-shadow: var(--shadow-sm);
 }
+.cardhead {
+	display: flex; align-items: center; justify-content: space-between;
+	gap: 1rem; margin: 0 0 1rem;
+}
+.cardhead h2 { margin: 0; }
 details.card > summary {
 	cursor: pointer; font-weight: 600; color: var(--ink);
 	list-style: none; display: flex; align-items: center; gap: .5rem;
@@ -583,6 +588,7 @@ a.chip:hover { background: var(--primary); border-color: var(--primary); color: 
 }
 .libraryhead h1 { font-size: 2rem; line-height: 1.1; margin: 0; }
 .libraryhead .eyebrow { margin: 0 0 .15rem; }
+.librarycontrols { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; }
 .folderpick { margin: 0; }
 .folderpick select { min-width: min(18rem, 52vw); }
 .librarytools {
@@ -758,6 +764,7 @@ button.linkish:hover, button.linkish:focus-visible {
 
 @media (max-width: 38em) {
 	.libraryhead { align-items: flex-start; flex-direction: column; }
+	.librarycontrols { width: 100%; justify-content: space-between; }
 	.folderpick, .folderpick select { width: 100%; }
 	.librarytools { align-items: stretch; }
 	.librarytools form:first-child, .librarytools input[type="search"] { width: 100%; }
@@ -926,6 +933,36 @@ button.linkish:hover, button.linkish:focus-visible {
 .htmx-indicator { opacity: 0 }
 .htmx-request .htmx-indicator { opacity: 1; transition: opacity 200ms ease-in }
 .htmx-request.htmx-indicator { opacity: 1; transition: opacity 200ms ease-in }
+
+/* The scan buttons. htmx puts htmx-request on the element that made the
+   request — the form — for as long as the pass runs, which is what the
+   icon and the spinner hang off. There is no hx-indicator: naming one
+   would move the class onto that element instead, and the icon inside
+   the button would never see it. */
+.scanform { margin: 0; display: inline-flex; }
+.scanbtn {
+	display: inline-flex; align-items: center; gap: .35rem;
+	cursor: pointer;
+}
+.scanbtn:disabled { opacity: .6; cursor: not-allowed; }
+.scanicon {
+	display: inline-block; font-size: 1.05em; line-height: 1;
+	transition: transform 150ms ease;
+}
+.htmx-request .scanicon {
+	animation: spin 800ms linear infinite;
+}
+@keyframes spin {
+	from { transform: rotate(0deg); }
+	to { transform: rotate(360deg); }
+}
+.scanspinner {
+	display: none; width: .75rem; height: .75rem;
+	border: 2px solid currentColor; border-right-color: transparent;
+	border-radius: 50%;
+	animation: spin 600ms linear infinite;
+}
+.htmx-request .scanspinner { display: inline-block; }
 
 /* ------------------------------------------------------------- library */
 

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -67,8 +67,16 @@ func noRedirect() *http.Client {
 
 func loginCookie(t *testing.T, ts *httptest.Server) *http.Cookie {
 	t.Helper()
+	return loginCookieAs(t, ts, "alice", "hunter2hunter")
+}
+
+// loginCookieAs signs in as somebody other than the account
+// testServerCfg makes, which is what a test about what a reader may see
+// needs: alice is usually the administrator.
+func loginCookieAs(t *testing.T, ts *httptest.Server, name, password string) *http.Cookie {
+	t.Helper()
 	resp, err := noRedirect().PostForm(ts.URL+"/ui/login", url.Values{
-		"username": {"alice"}, "password": {"hunter2hunter"},
+		"username": {name}, "password": {password},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -79,7 +87,7 @@ func loginCookie(t *testing.T, ts *httptest.Server) *http.Cookie {
 			return c
 		}
 	}
-	t.Fatal("no session cookie")
+	t.Fatalf("no session cookie for %s", name)
 	return nil
 }
 
@@ -262,7 +270,7 @@ func TestAuthFlowAndPages(t *testing.T) {
 		"/ui/admin/users/u1/tokens/t1/revoke", "/ui/admin/users/u1/kosync/s1/revoke",
 		"/ui/admin/users/u1/koplugin/k1/revoke",
 		"/ui/admin/folders", "/ui/admin/folders/f1/delete",
-		"/ui/admin/folders/f1/scan",
+		"/ui/admin/folders/f1/scan", "/ui/admin/folders/scan-all",
 		"/ui/admin/users/u1/tokens", "/ui/admin/users/u1/pairing",
 		"/ui/admin/users/u1/koplugin", "/ui/admin/users/u1/backfill",
 	} {
@@ -624,11 +632,12 @@ func TestSecureTransportOnAllUIRoutes(t *testing.T) {
 		"/ui/admin/users/u1/tokens/t1/revoke", "/ui/admin/users/u1/kosync/s1/revoke",
 		"/ui/admin/users/u1/koplugin/k1/revoke",
 		"/ui/admin/folders", "/ui/admin/folders/f1/delete",
-		"/ui/admin/folders/f1/scan",
+		"/ui/admin/folders/f1/scan", "/ui/admin/folders/scan-all",
 		"/ui/admin/users/u1/tokens", "/ui/admin/users/u1/pairing",
 		"/ui/admin/users/u1/koplugin", "/ui/admin/users/u1/backfill",
 		"/ui/reader/token",
 		"/ui/preferences",
+		"/ui/library/scan",
 	} {
 		if code, _ := postForm(t, ts, nil, p, url.Values{}); code != http.StatusForbidden {
 			t.Errorf("POST %s over plain HTTP: want 403, got %d", p, code)


### PR DESCRIPTION
## What this does

The catalog normally keeps itself current from filesystem events and a
half-hourly safety pass. Neither helps when the events never arrive: an
NFS or SMB share reports nothing at all, so a book copied in is invisible
until the timer comes round. This adds a way to ask.

- A `scan` command that reconciles one folder or the whole catalog and
  prints what it found.
- A scan button on the library shelf, scoped to the folders that reader
  is granted.
- Per-folder and "Scan all" buttons on the admin folders panel.

All three buttons wait for the pass and report what changed, because the
question someone presses scan with is "what is in there now?", and "a
pass was asked for" is not an answer to it. Waiting is bounded by a
two-minute budget. Cutting a pass short is safe: it checks for
cancellation before it writes anything, so an abandoned scan leaves the
catalog untouched rather than half-applied, and a pass is idempotent.

Creating a folder is bounded by that same budget. It reads the folder in
full before the page comes back, and on a first read every book is
hashed and parsed.

## Notes

A failed scan tells an administrator what went wrong and tells everyone
else that it did not finish. Reconcile errors name the folder's root
path, and that path is an administrator's to see.

## Testing

- `go test -race ./...` on Linux, all packages passing, including new
  tests covering where each button sends the browser back to, the root
  path staying hidden from a reader, and the counts a pass reports.
- `go vet ./...` and `golangci-lint run ./...` clean.