### PR TITLE
Make the series dialog work in the browser

### DIFF
--- a/internal/webui/books.templ
+++ b/internal/webui/books.templ
@@ -66,6 +66,13 @@ type BookView struct {
 	Deletable bool
 	Notice    string
 	Problem   string
+	// SeriesAssign is the assign dialog rendered into the page rather
+	// than fetched. It is nil in the ordinary case: with scripting on,
+	// htmx swaps the dialog in where the placeholder sits, and building
+	// it costs three store reads a reader who is not editing does not
+	// need. It is set when the fragment route is reached without htmx,
+	// which is what the placeholder's plain link does.
+	SeriesAssign *SeriesAssignView
 	// Chips are the book's entities as links: the fastest way from one
 	// book to the rest of its author or its series.
 	Authors []ChipLink
@@ -172,19 +179,23 @@ templ bookBody(prefix, csrf string, b BookView) {
 		// The dialog is fetched rather than rendered: it is three store
 		// reads a reader who is not editing does not need, and htmx swaps it
 		// in where this placeholder sits. With scripting off the link is a
-		// plain link to the same fragment.
-		<div id="series-assign" class="book-organization-section">
-			<h2>Series</h2>
-			<p>
-				<a
-					class="btn"
-					href={ prefix + "books/" + b.ID + "/series" }
-					hx-get={ prefix + "books/" + b.ID + "/series" }
-					hx-target="#series-assign"
-					hx-swap="outerHTML"
-				>Change this book's series</a>
-			</p>
-		</div>
+		// plain link that comes back here with the dialog already open.
+		if b.SeriesAssign != nil {
+			@seriesAssignForm(prefix, csrf, *b.SeriesAssign)
+		} else {
+			<div id="series-assign" class="book-organization-section">
+				<h2>Series</h2>
+				<p>
+					<a
+						class="btn"
+						href={ prefix + "books/" + b.ID + "/series" }
+						hx-get={ prefix + "books/" + b.ID + "/series" }
+						hx-target="#series-assign"
+						hx-swap="outerHTML"
+					>Change this book's series</a>
+				</p>
+			</div>
+		}
 		<div class="book-organization-section">
 			<h2>File</h2>
 		if !b.Present {

--- a/internal/webui/helpers.go
+++ b/internal/webui/helpers.go
@@ -28,6 +28,32 @@ func relPrefix(p string) string {
 	return strings.Repeat("../", strings.Count(rest, "/")+1)
 }
 
+// bookPagePrefix is relPrefix for the book page at /ui/books/{id}.
+//
+// An htmx fragment has to be rendered with the prefix of the page it is
+// swapped into, not of the route that served it: the browser resolves
+// the URLs inside it against the page's own URL. The series dialog is
+// served from /ui/books/{id}/series and /ui/books/{id}/series/reset,
+// one and two segments deeper than the page it lands on, so using its
+// own request path would climb past the UI root.
+func bookPagePrefix(bookID string) string {
+	return relPrefix("/ui/books/" + url.PathEscape(bookID))
+}
+
+// fragmentHTML declares an htmx fragment as HTML before it is written.
+//
+// A full page needs no such thing: it starts with a doctype and Go
+// sniffs it correctly. A fragment is a bare run of elements, and
+// http.DetectContentType only recognises a short list of tags — a
+// fragment opening with <div> is called text/html, one opening with
+// <option> is called text/plain. The typeahead's <option> list is the
+// second kind, and this UI also sends X-Content-Type-Options: nosniff,
+// which makes whatever is declared the browser's final answer. So the
+// fragments say what they are rather than hoping to be guessed right.
+func fragmentHTML(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+}
+
 // userCtx carries the signed-in user and everything the shell needs to
 // draw itself: which palette to render, which browse view to use, which
 // rail entry is the current one, and where a preference form should

--- a/internal/webui/series.go
+++ b/internal/webui/series.go
@@ -640,7 +640,43 @@ func (s *Server) handleSeriesAssignForm(
 		return
 	}
 	v.Problem = r.URL.Query().Get("problem")
-	seriesAssignForm(relPrefix(r.URL.Path), csrfFor(a), v).Render(r.Context(), w)
+	if !isHTMXRequest(r) {
+		// The placeholder's plain link, followed with scripting off.
+		// Answering it with the bare fragment would make an unstyled
+		// run of form controls the whole document, so the dialog is
+		// rendered into the book page it belongs to instead.
+		s.bookPageWithDialog(w, r, a, u, v)
+		return
+	}
+	fragmentHTML(w)
+	seriesAssignForm(bookPagePrefix(v.BookID), csrfFor(a), v).Render(r.Context(), w)
+}
+
+// bookPageWithDialog draws the whole book page with the series dialog
+// open in it, which is what these routes owe a request that did not
+// come from htmx: a page, not a piece of one.
+//
+// The prefix is the request's own, not the book page's, because this is
+// a whole document served at the fragment's URL — that is what the
+// address bar will say, and every link in the page is resolved against
+// it. The dialog inside inherits the same prefix for the same reason,
+// which is the opposite of what it needs when it is swapped into a page
+// already at /ui/books/{id}.
+func (s *Server) bookPageWithDialog(
+	w http.ResponseWriter, r *http.Request,
+	a store.AuthSession, u *store.User, v SeriesAssignView,
+) {
+	page, ok := s.bookView(r, u, v.BookID)
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+	page.SeriesAssign = &v
+	if v.Problem != "" {
+		w.WriteHeader(http.StatusBadRequest)
+	}
+	bookPage(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a), page).
+		Render(r.Context(), w)
 }
 
 func (s *Server) assignView(
@@ -723,7 +759,7 @@ func (s *Server) handleSeriesAssign(
 		s.assignProblem(w, r, u, a, bookID, "That could not be saved.")
 		return
 	}
-	s.renderAssign(w, r, u, a, bookID)
+	s.renderAssign(w, r, u, a, bookID, "series saved")
 }
 
 // handleSeriesReset drops a claim so the book goes back to what the
@@ -752,19 +788,30 @@ func (s *Server) handleSeriesReset(
 		s.assignProblem(w, r, u, a, bookID, "That could not be undone.")
 		return
 	}
-	s.renderAssign(w, r, u, a, bookID)
+	s.renderAssign(w, r, u, a, bookID, "back to what the folder says")
 }
 
 func (s *Server) renderAssign(
 	w http.ResponseWriter, r *http.Request,
-	u *store.User, a store.AuthSession, bookID string,
+	u *store.User, a store.AuthSession, bookID, notice string,
 ) {
 	v, ok := s.assignView(r, u, bookID)
 	if !ok {
 		http.NotFound(w, r)
 		return
 	}
-	seriesAssignForm(relPrefix(r.URL.Path), csrfFor(a), v).Render(r.Context(), w)
+	if !isHTMXRequest(r) {
+		// A plain form post, so a plain redirect back to the book page:
+		// the reader gets a whole page, and reloading it does not save
+		// the same claim twice.
+		redirectRel(w,
+			relPrefix(r.URL.Path)+"books/"+url.PathEscape(bookID)+
+				"?notice="+url.QueryEscape(notice),
+			http.StatusSeeOther)
+		return
+	}
+	fragmentHTML(w)
+	seriesAssignForm(bookPagePrefix(bookID), csrfFor(a), v).Render(r.Context(), w)
 }
 
 // assignProblem re-renders the dialog carrying its complaint, rather
@@ -780,8 +827,13 @@ func (s *Server) assignProblem(
 		return
 	}
 	v.Problem = problem
+	if !isHTMXRequest(r) {
+		s.bookPageWithDialog(w, r, a, u, v)
+		return
+	}
+	fragmentHTML(w)
 	w.WriteHeader(http.StatusBadRequest)
-	seriesAssignForm(relPrefix(r.URL.Path), csrfFor(a), v).Render(r.Context(), w)
+	seriesAssignForm(bookPagePrefix(bookID), csrfFor(a), v).Render(r.Context(), w)
 }
 
 // handleSeriesSuggest is the typeahead behind the name field. It offers
@@ -818,6 +870,7 @@ func (s *Server) handleSeriesSuggest(
 			}
 		}
 	}
+	fragmentHTML(w)
 	seriesSuggestions(out).Render(r.Context(), w)
 }
 

--- a/internal/webui/series_ext_test.go
+++ b/internal/webui/series_ext_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -19,8 +20,11 @@ import (
 // that only an admin writes the shared layer, and that the mutations are
 // CSRF-checked like every other web UI write.
 
-// postFragment is postForm that keeps the body, which every one of these
-// assertions is about: the assign dialog answers with itself.
+// postFragment is postForm as htmx sends it, and it keeps the body,
+// which most of these assertions are about: the assign dialog answers
+// with itself. The HX-Request header is what tells the server the
+// answer is going to be swapped into a page that already exists rather
+// than becoming one.
 func (f *booksFixture) postFragment(
 	t *testing.T, path string, cookie *http.Cookie, form url.Values,
 ) (*http.Response, string) {
@@ -28,6 +32,27 @@ func (f *booksFixture) postFragment(
 	req, _ := http.NewRequest(http.MethodPost, f.ts.URL+path,
 		strings.NewReader(form.Encode()))
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	if cookie != nil {
+		req.AddCookie(cookie)
+	}
+	resp, err := noRedirectClient().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return resp, string(body)
+}
+
+// getFragment fetches the dialog the way htmx does. Plain f.get is the
+// reader with scripting off, and gets a whole page instead.
+func (f *booksFixture) getFragment(
+	t *testing.T, path string, cookie *http.Cookie,
+) (*http.Response, string) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, f.ts.URL+path, nil)
+	req.Header.Set("HX-Request", "true")
 	if cookie != nil {
 		req.AddCookie(cookie)
 	}
@@ -116,7 +141,7 @@ func TestSeriesShelfIsPerReader(t *testing.T) {
 	bob := f.login(t, "bob")
 
 	// Alice takes the book out of the series, for herself.
-	_, form := f.get(t, "/ui/books/"+bookID+"/series", f.cookie)
+	_, form := f.getFragment(t, "/ui/books/"+bookID+"/series", f.cookie)
 	csrf := csrfFrom(t, form)
 	resp, _ := f.postFragment(t, "/ui/books/"+bookID+"/series", f.cookie,
 		url.Values{"csrf": {csrf}, "name": {""}, "position": {""}})
@@ -151,7 +176,7 @@ func TestSeriesAssignAddsAndResets(t *testing.T) {
 	f := newBooksFixture(t)
 	bookID := seriesBook(t, f, "one", "Foundation", 1)
 
-	_, form := f.get(t, "/ui/books/"+bookID+"/series", f.cookie)
+	_, form := f.getFragment(t, "/ui/books/"+bookID+"/series", f.cookie)
 	if !strings.Contains(form, "Foundation") {
 		t.Fatalf("the dialog does not show what the folder said:\n%s", form)
 	}
@@ -196,12 +221,91 @@ func TestSeriesAssignAddsAndResets(t *testing.T) {
 	}
 }
 
+// TestSeriesDialogURLsResolveFromTheBookPage is the regression test for
+// a dialog whose links were built from its own route.
+//
+// The dialog is an htmx fragment served from /ui/books/{id}/series and
+// /ui/books/{id}/series/reset, one and two segments deeper than the
+// /ui/books/{id} page it is swapped into. A browser resolves the URLs
+// inside it against that page, so rendering them at the fragment's own
+// depth put one ../ too many in every one of them: the typeahead and
+// the save both climbed past the UI root and 404'd.
+func TestSeriesDialogURLsResolveFromTheBookPage(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := seriesBook(t, f, "one", "Foundation", 1)
+	page, err := url.Parse(f.ts.URL + "/ui/books/" + bookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	served := map[string]bool{
+		"/ui/entities/series/suggest":           true,
+		"/ui/books/" + bookID + "/series":       true,
+		"/ui/books/" + bookID + "/series/reset": true,
+	}
+
+	// resolves states the browser's rule rather than matching a string:
+	// each URL is resolved against the page the fragment lives on, and
+	// has to land on a route this server answers.
+	resolves := func(what, body string) map[string]bool {
+		t.Helper()
+		seen := map[string]bool{}
+		for _, m := range seriesDialogURL.FindAllStringSubmatch(body, -1) {
+			ref, err := url.Parse(m[1])
+			if err != nil {
+				t.Fatalf("%s: unparseable URL %q", what, m[1])
+			}
+			got := page.ResolveReference(ref).Path
+			if !served[got] {
+				t.Errorf("%s: %q resolves to %s from the book page, "+
+					"which is not a route this server serves", what, m[1], got)
+			}
+			seen[got] = true
+		}
+		if len(seen) == 0 {
+			t.Fatalf("%s: the dialog asks the browser for nothing:\n%s", what, body)
+		}
+		return seen
+	}
+
+	_, form := f.getFragment(t, "/ui/books/"+bookID+"/series", f.cookie)
+	seen := resolves("the dialog", form)
+	if !seen["/ui/entities/series/suggest"] {
+		t.Error("the dialog offers no typeahead")
+	}
+	if !seen["/ui/books/"+bookID+"/series"] {
+		t.Error("the dialog has nowhere to save to")
+	}
+
+	// After a claim the reset form is there too, so the fragment carries
+	// every URL it ever renders.
+	csrf := csrfFrom(t, form)
+	_, after := f.postFragment(t, "/ui/books/"+bookID+"/series", f.cookie,
+		url.Values{"csrf": {csrf}, "name": {"The Robot Novels"}, "position": {"2"}})
+	if !resolves("the saved dialog", after)["/ui/books/"+bookID+"/series/reset"] {
+		t.Error("no reset offered after a claim")
+	}
+
+	// The refusal and the reset re-render the same fragment, and each
+	// used to get its prefix from its own deeper route.
+	_, bad := f.postFragment(t, "/ui/books/"+bookID+"/series", f.cookie,
+		url.Values{"csrf": {csrf}, "name": {"Foundation"}, "position": {"soon"}})
+	resolves("the refused dialog", bad)
+
+	_, reset := f.postFragment(t, "/ui/books/"+bookID+"/series/reset",
+		f.cookie, url.Values{"csrf": {csrf}})
+	resolves("the reset dialog", reset)
+}
+
+// seriesDialogURL pulls every URL the assign dialog asks a browser for:
+// the htmx attributes and the plain form actions behind them.
+var seriesDialogURL = regexp.MustCompile(`(?:hx-get|hx-post|action)="([^"]*)"`)
+
 // TestSeriesAssignRefusesBadPosition keeps the reader's typing on screen
 // rather than replacing the page with an error.
 func TestSeriesAssignRefusesBadPosition(t *testing.T) {
 	f := newBooksFixture(t)
 	bookID := seriesBook(t, f, "one", "Foundation", 1)
-	_, form := f.get(t, "/ui/books/"+bookID+"/series", f.cookie)
+	_, form := f.getFragment(t, "/ui/books/"+bookID+"/series", f.cookie)
 	csrf := csrfFrom(t, form)
 
 	resp, body := f.postFragment(t, "/ui/books/"+bookID+"/series", f.cookie,
@@ -219,7 +323,7 @@ func TestSeriesAssignRefusesBadPosition(t *testing.T) {
 func TestSeriesSharedLayerNeedsAdmin(t *testing.T) {
 	f := newBooksFixture(t)
 	bookID := seriesBook(t, f, "one", "Foundation", 1)
-	_, form := f.get(t, "/ui/books/"+bookID+"/series", f.cookie)
+	_, form := f.getFragment(t, "/ui/books/"+bookID+"/series", f.cookie)
 	csrf := csrfFrom(t, form)
 	// A non-admin is not even offered the choice.
 	if strings.Contains(form, `name="scope" value="shared"`) {
@@ -243,7 +347,7 @@ func TestSeriesSharedLayerNeedsAdmin(t *testing.T) {
 		t.Fatal(err)
 	}
 	admin := f.login(t, "alice")
-	_, form = f.get(t, "/ui/books/"+bookID+"/series", admin)
+	_, form = f.getFragment(t, "/ui/books/"+bookID+"/series", admin)
 	if !strings.Contains(form, `name="scope" value="shared"`) {
 		t.Fatalf("an admin was not offered the shared layer:\n%s", form)
 	}
@@ -306,6 +410,95 @@ func TestSeriesSuggestOffersExistingNames(t *testing.T) {
 	_, html = f.get(t, "/ui/entities/series/suggest", f.cookie)
 	if strings.Contains(html, "Foundation") {
 		t.Error("an empty query listed the whole folder")
+	}
+}
+
+// TestSeriesFragmentsDeclareTheirType pins what the dialog and the
+// typeahead say they are.
+//
+// A page starts with a doctype and is sniffed correctly; a fragment is
+// a bare run of elements, and http.DetectContentType knows <div> but
+// not <option>. The typeahead's option list was therefore served as
+// text/plain, next to this UI's X-Content-Type-Options: nosniff, which
+// makes the declared type the last word.
+func TestSeriesFragmentsDeclareTheirType(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := seriesBook(t, f, "one", "Foundation", 1)
+
+	for _, path := range []string{
+		"/ui/entities/series/suggest?q=found",
+		// An empty answer is a fragment too, and sniffs to text/plain
+		// whatever it would have contained.
+		"/ui/entities/series/suggest?q=nothingmatchesthis",
+		"/ui/books/" + bookID + "/series",
+	} {
+		resp, _ := f.getFragment(t, path, f.cookie)
+		if got := resp.Header.Get("Content-Type"); got != "text/html; charset=utf-8" {
+			t.Errorf("%s: Content-Type %q, want text/html; charset=utf-8", path, got)
+		}
+	}
+}
+
+// TestSeriesAssignWorksWithoutScripting is the other half of the
+// dialog's promise.
+//
+// The placeholder on the book page is a plain link to the fragment
+// route, so a reader with scripting off lands on it directly. Answering
+// that with the bare fragment made an unstyled run of form controls the
+// whole document, and posting it did the same again. A request that did
+// not come from htmx gets a page: the book page with the dialog open,
+// and a redirect back to it once the claim is saved.
+func TestSeriesAssignWorksWithoutScripting(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := seriesBook(t, f, "one", "Foundation", 1)
+
+	// Following the link gives a whole page, not a fragment.
+	resp, page := f.get(t, "/ui/books/"+bookID+"/series", f.cookie)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("following the link: %d", resp.StatusCode)
+	}
+	if !strings.Contains(page, "<!doctype html>") {
+		t.Errorf("the link answered with a bare fragment:\n%s", page)
+	}
+	if !strings.Contains(page, `id="series-assign"`) {
+		t.Error("the page does not have the dialog open")
+	}
+	if strings.Contains(page, "Change this book's series") {
+		t.Error("the page shows the placeholder link as well as the dialog")
+	}
+
+	// Saving redirects back to the book page rather than answering with
+	// a fragment, so a reload does not save the same claim twice.
+	csrf := csrfFrom(t, page)
+	resp = f.postForm(t, "/ui/books/"+bookID+"/series", f.cookie,
+		url.Values{"csrf": {csrf}, "name": {"The Robot Novels"}, "position": {"2"}})
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("saving without scripting: %d, want 303", resp.StatusCode)
+	}
+	loc := resp.Header.Get("Location")
+	here, err := url.Parse(f.ts.URL + "/ui/books/" + bookID + "/series")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("unparseable Location %q", loc)
+	}
+	if got := here.ResolveReference(ref).Path; got != "/ui/books/"+bookID {
+		t.Errorf("Location %q lands on %s, want the book page", loc, got)
+	}
+
+	// And the claim was really made.
+	_, book := f.get(t, "/ui/books/"+bookID, f.cookie)
+	if !strings.Contains(book, "The Robot Novels") {
+		t.Error("the book page does not show the claim saved without scripting")
+	}
+
+	// A refusal keeps the reader on a page, with the complaint on it.
+	resp = f.postForm(t, "/ui/books/"+bookID+"/series", f.cookie,
+		url.Values{"csrf": {csrf}, "name": {"Foundation"}, "position": {"soon"}})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("a position that is not a number: %d, want 400", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
## What changed

Putting a book in a series has never worked from a browser. The dialog built its addresses relative to the address it was fetched from rather than the book page it appears on, so the name suggestions and the Save button both asked the server for pages that do not exist and got a 404 back.

Two smaller problems in the same dialog are fixed alongside it:

- The name suggestion list went out as plain text rather than HTML, next to this UI's `nosniff` header. It worked only because htmx ignores the declared type.
- With scripting turned off, the "Change this book's series" link led to a bare form with none of the surrounding page, and saving did the same again. Every other series action already redirected back to a real page.

## Why

The bug arrived with the feature itself, so anyone who tried to assign a series from the web UI got a dialog that silently failed. Claims written through the API were unaffected.

## Testing

- `go test ./internal/webui/` passes.
- Two new tests fail on the unfixed code and pass with it. One resolves every address in the dialog against the book page the way a browser does, and reproduces the exact 404s from the report. The other pins the content type on the suggestion list.
- A third test covers the dialog with scripting off: the link now gives a whole page, and saving redirects back to the book.
- `go vet` and `golangci-lint run` are clean.

One unrelated test, `TestWatcherReconcilesAFolderAddedAtRuntime` in `internal/content`, fails on my Linux test host. It fails the same way on an unmodified checkout there, so it is environmental and not from this change.
