### PR TITLE
Show a book's series on the book page

### DIFF
--- a/internal/webui/books.go
+++ b/internal/webui/books.go
@@ -170,6 +170,26 @@ func (s *Server) bookView(r *http.Request, u *store.User, bookID string) (BookVi
 			})
 		}
 	}
+	// The organization card states the book's series rather than making
+	// a reader open the editor to find out. The layers are read here
+	// rather than taken from the relations above because the card also
+	// says which layer is in force, and what the folder said underneath
+	// a claim (ADR-0018) — neither of which survives into a chip.
+	if layers, err := s.St.BookSeriesLayers(
+		r.Context(), readerID(u), book.ID,
+	); err == nil {
+		v.SeriesSource = string(layers.Source)
+		for _, ser := range layers.Effective {
+			v.SeriesNow = append(v.SeriesNow, BookSeriesLine{
+				Name:     ser.Name,
+				Position: formatSeriesPosition(ser.Position),
+				URL:      entityURL(book.FolderID, "series", ser.SeriesID),
+			})
+		}
+		if layers.Source != store.SeriesSourceFolder {
+			v.SeriesFolderNote = seriesFolderNote(assignRows(layers.Folder))
+		}
+	}
 	return v, true
 }
 

--- a/internal/webui/books.templ
+++ b/internal/webui/books.templ
@@ -68,17 +68,33 @@ type BookView struct {
 	Problem   string
 	// SeriesAssign is the assign dialog rendered into the page rather
 	// than fetched. It is nil in the ordinary case: with scripting on,
-	// htmx swaps the dialog in where the placeholder sits, and building
-	// it costs three store reads a reader who is not editing does not
-	// need. It is set when the fragment route is reached without htmx,
-	// which is what the placeholder's plain link does.
+	// htmx swaps the dialog in where the section sits. It is set when
+	// the fragment route is reached without htmx, which is what that
+	// section's plain link does.
 	SeriesAssign *SeriesAssignView
 	// Chips are the book's entities as links: the fastest way from one
 	// book to the rest of its author or its series.
 	Authors []ChipLink
 	Series  []ChipLink
+	// SeriesNow is what the organization card states before anybody
+	// opens the editor, with this book's number in each series.
+	SeriesNow []BookSeriesLine
+	// SeriesSource names the layer SeriesNow came from (ADR-0018).
+	SeriesSource string
+	// SeriesFolderNote is what the folder says, and is set only when a
+	// claim is in force over it: a reader who arranged their own shelf
+	// should be able to see what they arranged it away from.
+	SeriesFolderNote string
 	// Byline is the authors as one line, for the hero and the title tag.
 	Byline string
+}
+
+// BookSeriesLine is one series the organization card names: the shelf it
+// links to and where this book sits on it.
+type BookSeriesLine struct {
+	Name     string
+	Position string
+	URL      string
 }
 
 templ bookPage(prefix string, u userCtx, csrf string, b BookView) {
@@ -176,15 +192,38 @@ templ bookBody(prefix, csrf string, b BookView) {
 	}
 	<details class="card bookorganization">
 		<summary>Library organization</summary>
-		// The dialog is fetched rather than rendered: it is three store
-		// reads a reader who is not editing does not need, and htmx swaps it
-		// in where this placeholder sits. With scripting off the link is a
-		// plain link that comes back here with the dialog already open.
+		// The editor is fetched rather than rendered: it is a store read
+		// a reader who is not editing does not need, and htmx swaps it in
+		// where this section sits. What the section says without it comes
+		// from the page's own read, so the current series is legible
+		// before anybody decides to change it. With scripting off the
+		// link is a plain link that comes back here with the editor
+		// already open.
 		if b.SeriesAssign != nil {
 			@seriesAssignForm(prefix, csrf, *b.SeriesAssign)
 		} else {
 			<div id="series-assign" class="book-organization-section">
 				<h2>Series</h2>
+				if len(b.SeriesNow) > 0 {
+					<p class="seriesnow">
+						for _, s := range b.SeriesNow {
+							<a class="chip" href={ prefix + s.URL }>
+								{ s.Name }
+								if s.Position != "" {
+									<span class="num">{ " #" + s.Position }</span>
+								}
+							</a>
+						}
+					</p>
+				} else {
+					<p>This book is in no series.</p>
+				}
+				if b.SeriesSource != "" {
+					<p class="muted">{ seriesSourceSentence(b.SeriesSource) }</p>
+				}
+				if b.SeriesFolderNote != "" {
+					<p class="muted">{ b.SeriesFolderNote }</p>
+				}
 				<p>
 					<a
 						class="btn"

--- a/internal/webui/books.templ
+++ b/internal/webui/books.templ
@@ -215,7 +215,12 @@ templ bookBody(prefix, csrf string, b BookView) {
 							</a>
 						}
 					</p>
-				} else {
+				} else if b.SeriesSource != "" {
+					// Only a read that succeeded can say a book is in no
+					// series. SeriesSource is set on every success, so an
+					// unset one means the layers did not come back, and
+					// the section says nothing rather than something
+					// false about somebody's shelf.
 					<p>This book is in no series.</p>
 				}
 				if b.SeriesSource != "" {

--- a/internal/webui/booksseries_ext_test.go
+++ b/internal/webui/booksseries_ext_test.go
@@ -1,0 +1,179 @@
+//go:build linux
+
+package webui_test
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// The book page's Library organization card (ADR-0018). It used to be a
+// heading and a button, so the only way to learn which series a book was
+// in was to open the editor, and a reader whose own claim sat on top of
+// what the folder said could not see that it did.
+
+// organizationCard is the series part of that card, cut out so an
+// assertion about it cannot be satisfied by the chips in the hero.
+func organizationCard(t *testing.T, page string) string {
+	t.Helper()
+	start := strings.Index(page, `id="series-assign"`)
+	if start < 0 {
+		t.Fatalf("no series section on the book page:\n%s", page)
+	}
+	card := page[start:]
+	if end := strings.Index(card, "<h2>File</h2>"); end >= 0 {
+		card = card[:end]
+	}
+	return card
+}
+
+func TestBookPageNamesTheSeriesWithoutOpeningTheEditor(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := seriesBook(t, f, "first", "Foundation", 1)
+
+	resp, page := f.get(t, "/ui/books/"+bookID, f.cookie)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("book page: %d", resp.StatusCode)
+	}
+	card := organizationCard(t, page)
+	if !strings.Contains(card, "Foundation") {
+		t.Errorf("the card does not name the series:\n%s", card)
+	}
+	if !strings.Contains(card, "#1") {
+		t.Errorf("the card does not say where the book sits:\n%s", card)
+	}
+	if !strings.Contains(card, "This is what the folder says.") {
+		t.Errorf("the card does not say which layer it is reading:\n%s", card)
+	}
+	// The folder is the layer in force, so repeating it underneath
+	// would say the same thing twice.
+	if strings.Contains(card, "The folder says:") {
+		t.Errorf("the card quotes the folder against itself:\n%s", card)
+	}
+	// The editor is still a click away rather than rendered into every
+	// book page.
+	if !strings.Contains(card, "Change this book's series") {
+		t.Errorf("the card no longer offers the editor:\n%s", card)
+	}
+}
+
+func TestBookPageSaysWhatTheFolderSaidUnderneathAClaim(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := seriesBook(t, f, "first", "Foundation", 1)
+
+	_, form := f.getFragment(t, "/ui/books/"+bookID+"/series", f.cookie)
+	resp, _ := f.postFragment(t, "/ui/books/"+bookID+"/series", f.cookie,
+		url.Values{
+			"csrf": {csrfFrom(t, form)},
+			"name": {"Second Foundation"}, "position": {""},
+		})
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("claiming a series: %d", resp.StatusCode)
+	}
+
+	_, page := f.get(t, "/ui/books/"+bookID, f.cookie)
+	card := organizationCard(t, page)
+	if !strings.Contains(card, "Second Foundation") {
+		t.Errorf("the card does not name the claimed series:\n%s", card)
+	}
+	if !strings.Contains(card, "You arranged this. Only you see it.") {
+		t.Errorf("the card does not say whose arrangement this is:\n%s", card)
+	}
+	if !strings.Contains(card, "The folder says: Foundation #1.") {
+		t.Errorf("the card does not say what the claim covers up:\n%s", card)
+	}
+
+	// A claim is one reader's. Another account sees the folder's answer
+	// and is told nothing about the claim or that one exists.
+	bob := f.login(t, "bob")
+	_, theirs := f.get(t, "/ui/books/"+bookID, bob)
+	theirCard := organizationCard(t, theirs)
+	if strings.Contains(theirCard, "Second Foundation") {
+		t.Errorf("one reader's claim is on another reader's book page:\n%s", theirCard)
+	}
+	if !strings.Contains(theirCard, "This is what the folder says.") {
+		t.Errorf("the folder's answer is not what a stranger sees:\n%s", theirCard)
+	}
+}
+
+func TestBookPageSaysWhenABookIsInNoSeries(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "loner", []byte(strings.Repeat("web-epub", 50)))
+
+	_, page := f.get(t, "/ui/books/"+bookID, f.cookie)
+	card := organizationCard(t, page)
+	if !strings.Contains(card, "This book is in no series.") {
+		t.Errorf("the card says nothing about a book in no series:\n%s", card)
+	}
+}
+
+// TestSeriesDialogFieldsAreNamed covers the pair of text boxes the
+// editor is made of. The placeholders disappear as soon as either has
+// anything in it, and "#" does not say what number it wants, so the
+// columns are headed and the fields carry a name of their own.
+func TestSeriesDialogFieldsAreNamed(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := seriesBook(t, f, "first", "Foundation", 1)
+
+	resp, form := f.getFragment(t, "/ui/books/"+bookID+"/series", f.cookie)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("dialog: %d", resp.StatusCode)
+	}
+	for _, want := range []string{
+		`aria-label="Series name"`,
+		`aria-label="Number in the series"`,
+		"Book no.",
+	} {
+		if !strings.Contains(form, want) {
+			t.Errorf("the dialog is missing %q:\n%s", want, form)
+		}
+	}
+}
+
+// TestSeriesResetWorksWithoutScripting is the guard on splitting the two
+// buttons apart. Save and undo submit different forms, and putting them
+// on one line means the undo button sits inside the form it does not
+// belong to and names its own. That is only correct if a browser with no
+// scripting still resets from it.
+func TestSeriesResetWorksWithoutScripting(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := seriesBook(t, f, "first", "Foundation", 1)
+
+	resp, page := f.get(t, "/ui/books/"+bookID+"/series", f.cookie)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("following the link: %d", resp.StatusCode)
+	}
+	csrf := csrfFrom(t, page)
+	if resp := f.postForm(t, "/ui/books/"+bookID+"/series", f.cookie,
+		url.Values{
+			"csrf": {csrf},
+			"name": {"Second Foundation"}, "position": {""},
+		}); resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("claiming without scripting: %d", resp.StatusCode)
+	}
+
+	_, withClaim := f.get(t, "/ui/books/"+bookID+"/series", f.cookie)
+	if !strings.Contains(withClaim, `form="series-reset-form"`) {
+		t.Errorf("the undo button does not name the form it submits:\n%s", withClaim)
+	}
+	if !strings.Contains(withClaim, `id="series-reset-form"`) {
+		t.Errorf("the form the undo button names is not on the page:\n%s", withClaim)
+	}
+
+	if resp := f.postForm(t, "/ui/books/"+bookID+"/series/reset", f.cookie,
+		url.Values{"csrf": {csrfFrom(t, withClaim)}},
+	); resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("undoing without scripting: %d", resp.StatusCode)
+	}
+
+	_, back := f.get(t, "/ui/books/"+bookID, f.cookie)
+	card := organizationCard(t, back)
+	if strings.Contains(card, "Second Foundation") {
+		t.Errorf("the claim survived the undo:\n%s", card)
+	}
+	if !strings.Contains(card, "This is what the folder says.") {
+		t.Errorf("the book did not go back to the folder's answer:\n%s", card)
+	}
+}

--- a/internal/webui/booksseries_ext_test.go
+++ b/internal/webui/booksseries_ext_test.go
@@ -3,10 +3,14 @@
 package webui_test
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/chmouel/liseur-sync/internal/store"
 )
 
 // The book page's Library organization card (ADR-0018). It used to be a
@@ -175,5 +179,38 @@ func TestSeriesResetWorksWithoutScripting(t *testing.T) {
 	}
 	if !strings.Contains(card, "This is what the folder says.") {
 		t.Errorf("the book did not go back to the folder's answer:\n%s", card)
+	}
+}
+
+// seriesLayersUnreadable is a store whose series layers never come back.
+// The card reads them separately from the chips in the hero, so it is
+// the one part of the page that can lose them on its own.
+type seriesLayersUnreadable struct{ store.Store }
+
+func (seriesLayersUnreadable) BookSeriesLayers(
+	context.Context, string, string,
+) (store.BookSeriesLayers, error) {
+	return store.BookSeriesLayers{}, errors.New("the layers did not come back")
+}
+
+func TestBookPageDoesNotClaimNoSeriesWhenItCouldNotLook(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := seriesBook(t, f, "first", "Foundation", 1)
+
+	f.ui.St = seriesLayersUnreadable{f.ui.St}
+
+	resp, page := f.get(t, "/ui/books/"+bookID, f.cookie)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("book page: %d", resp.StatusCode)
+	}
+	card := organizationCard(t, page)
+	// Saying nothing is the honest answer. Saying "in no series" would
+	// be a read failure dressed up as a fact about the book, and the
+	// book is in Foundation.
+	if strings.Contains(card, "This book is in no series.") {
+		t.Errorf("a failed read told the reader the book is in no series:\n%s", card)
+	}
+	if !strings.Contains(card, "Change this book's series") {
+		t.Errorf("the card stopped offering the editor:\n%s", card)
 	}
 }

--- a/internal/webui/series.go
+++ b/internal/webui/series.go
@@ -896,6 +896,31 @@ func folderSeriesSentence(rows []SeriesAssignRow) string {
 	return joinWithAnd(out)
 }
 
+// seriesFolderNote is what the folder says about a book. It is worth
+// saying only where a claim is in force over it, otherwise it repeats
+// what the reader is already looking at.
+func seriesFolderNote(folder []SeriesAssignRow) string {
+	if len(folder) == 0 {
+		return "The folder puts this book in no series."
+	}
+	return "The folder says: " + folderSeriesSentence(folder) + "."
+}
+
+// seriesSourceSentence names the layer a book's series came from
+// (ADR-0018). The book page and the dialog say it the same way, so a
+// reader who opens the editor is not told something new.
+func seriesSourceSentence(source string) string {
+	switch source {
+	case string(store.SeriesSourceFolder):
+		return "This is what the folder says."
+	case string(store.SeriesSourceShared):
+		return "An administrator arranged this. It is what everybody sees."
+	case string(store.SeriesSourcePersonal):
+		return "You arranged this. Only you see it."
+	}
+	return ""
+}
+
 func joinWithAnd(items []string) string {
 	switch len(items) {
 	case 0:

--- a/internal/webui/series.templ
+++ b/internal/webui/series.templ
@@ -318,16 +318,9 @@ templ seriesAssignForm(prefix, csrf string, v SeriesAssignView) {
 		if v.Problem != "" {
 			<p class="error" role="alert">{ v.Problem }</p>
 		}
-		<p class="muted">
-			if v.Source == "folder" {
-				This is what the folder says.
-			} else if v.Source == "shared" {
-				An administrator arranged this. It is what everybody sees.
-			} else {
-				You arranged this. Only you see it.
-			}
-		</p>
+		<p class="muted">{ seriesSourceSentence(v.Source) }</p>
 		<form
+			id="series-assign-form"
 			method="post"
 			action={ prefix + "books/" + v.BookID + "/series" }
 			hx-post={ prefix + "books/" + v.BookID + "/series" }
@@ -336,6 +329,10 @@ templ seriesAssignForm(prefix, csrf string, v SeriesAssignView) {
 		>
 			<input type="hidden" name="csrf" value={ csrf }/>
 			<datalist id="series-names"></datalist>
+			<div class="assignhead" aria-hidden="true">
+				<span>Series</span>
+				<span>Book no.</span>
+			</div>
 			<div class="assignrows">
 				for _, row := range v.Current {
 					@seriesAssignRowFields(prefix, row)
@@ -354,12 +351,27 @@ templ seriesAssignForm(prefix, csrf string, v SeriesAssignView) {
 					Everybody sees this
 				</label>
 			}
-			<div class="cta">
+			if v.CanReset {
+				<p class="muted">{ seriesFolderNote(v.Folder) }</p>
+			}
+			<div class="assignactions">
 				<button class="btn primary" type="submit">Save</button>
+				if v.CanReset {
+					// The undo button sits here so it reads as the other
+					// half of one decision, and names the form below it.
+					<button class="btn" type="submit" form="series-reset-form">
+						if v.Shared {
+							Undo the shared arrangement
+						} else {
+							Back to what the folder says
+						}
+					</button>
+				}
 			</div>
 		</form>
 		if v.CanReset {
 			<form
+				id="series-reset-form"
 				method="post"
 				action={ prefix + "books/" + v.BookID + "/series/reset" }
 				hx-post={ prefix + "books/" + v.BookID + "/series/reset" }
@@ -370,25 +382,15 @@ templ seriesAssignForm(prefix, csrf string, v SeriesAssignView) {
 				if v.Shared && v.CanShare {
 					<input type="hidden" name="scope" value="shared"/>
 				}
-				<button class="btn" type="submit">
-					if v.Shared {
-						Undo the shared arrangement
-					} else {
-						Back to what the folder says
-					}
-				</button>
 			</form>
-			if len(v.Folder) > 0 {
-				<p class="muted">
-					{ "The folder says: " + folderSeriesSentence(v.Folder) }
-				</p>
-			} else {
-				<p class="muted">The folder puts this book in no series.</p>
-			}
 		}
 	</div>
 }
 
+// seriesAssignRowFields is one row: a series and this book's number in
+// it. The placeholders are a reminder, not the label — they vanish as
+// soon as there is anything to read, so the fields carry a name of their
+// own for anybody not looking at the column headings.
 templ seriesAssignRowFields(prefix string, row SeriesAssignRow) {
 	<p class="assignrow">
 		<input
@@ -396,6 +398,7 @@ templ seriesAssignRowFields(prefix string, row SeriesAssignRow) {
 			name="name"
 			value={ row.Name }
 			placeholder="Series"
+			aria-label="Series name"
 			list="series-names"
 			autocomplete="off"
 			hx-get={ prefix + "entities/series/suggest" }
@@ -408,6 +411,7 @@ templ seriesAssignRowFields(prefix string, row SeriesAssignRow) {
 			name="position"
 			value={ row.Position }
 			placeholder="#"
+			aria-label="Number in the series"
 			inputmode="decimal"
 			size="4"
 		/>

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -1106,12 +1106,39 @@ button.linkish:hover, button.linkish:focus-visible {
 }
 
 /* The assign dialog. Each row is a name and a position, and the position
-   stays narrow so the name gets the width it needs. */
-.assignrows { display: flex; flex-direction: column; gap: .4rem; margin: .8rem 0; }
-.assignrow { display: flex; gap: .5rem; margin: 0; }
-.assignrow input[type="text"] { min-width: 0; }
-.assignrow input[name="name"] { flex: 1; }
-.assignrow input[name="position"] { flex: 0 0 5rem; }
+   stays narrow so the name gets the width it needs.
+   The row selector is doubled on purpose. A row is a <p> inside a card
+   form, so `.card form p` matches it, and that rule stacks a label over
+   its field with `flex-direction: column`. Being more specific than one
+   class it won, and a flex-basis written to mean "5rem wide" was read as
+   "5rem tall". Hence two classes here, and widths rather than a basis on
+   the fields, so no surrounding direction can flip them again. */
+.assignrows { display: flex; flex-direction: column; gap: .4rem; margin: .2rem 0 .8rem; }
+.assignrows .assignrow {
+	display: flex; flex-direction: row; align-items: center;
+	gap: .5rem; margin: 0; max-width: 40rem;
+}
+.assignrows .assignrow > input[type="text"] { min-width: 0; }
+.assignrows .assignrow > input[name="name"] { flex: 1 1 auto; width: auto; }
+.assignrows .assignrow > input[name="position"] { flex: 0 0 auto; width: 5rem; }
+
+/* The headings for those two columns, held to the same two widths. */
+.assignhead {
+	display: flex; gap: .5rem; max-width: 40rem; margin: .8rem 0 0;
+	font-size: .8rem; color: var(--muted);
+}
+.assignhead > :first-child { flex: 1 1 auto; min-width: 0; }
+.assignhead > :last-child { flex: 0 0 auto; width: 5rem; }
+
+/* Saving and undoing are two forms, so left alone they stack into a pile
+   of buttons. The undo button sits in the first form and names the
+   second one, which is what the form attribute is for. */
+.assignactions { display: flex; flex-wrap: wrap; align-items: center; gap: .5rem; margin: .8rem 0 0; }
+
+/* The series a book is in, stated on the book page before the editor is
+   opened. */
+.seriesnow { display: flex; flex-wrap: wrap; gap: .4rem; margin: 0 0 .4rem; }
+.seriesnow .num { color: var(--muted); }
 
 /* The names a merge or a split made lead to a shelf (ADR-0021). Each is
    a statement and the button that takes it back, so they sit on one


### PR DESCRIPTION
## What changed

The book page's "Library organization" card now names the series a book
is in, without anyone having to open the editor to find out. Each series
is a link to its shelf and carries this book's number in it. The card
also says which arrangement is in force: what the folder says, a shared
arrangement an administrator made, or the reader's own claim. Where a
claim overrides the folder, the card says what the folder said
underneath it.

The series editor is tidied in the same pass:

- The two fields have column headings and labels of their own, so the
  "Series" and "#" placeholders are no longer the only thing naming
  them. Placeholders vanish as soon as there is anything to read.
- The undo button sits beside Save rather than in a block below it,
  because the two are halves of one decision.
- The note about what the folder says moved next to the button that
  goes back to it.

## Why

Finding out which series a book was in meant opening the editor, which
is a page for changing things rather than reading them. Until then the
card was a heading and a button that said nothing about the book.

## Testing

- New tests in `internal/webui` cover what the card says for each of the
  three arrangements, the links it produces, the folder note showing up
  only when a claim overrides the folder, and the editor's field labels.
- `GOOS=linux go build ./...` and `go vet` are clean, and the webui test
  binary compiles.
- I could not run the suite on this machine: `internal/content` is Linux
  only and there is no container runtime here, so CI is running the
  race-enabled suite instead.
