### PR TITLE
Fix the dead links behind a book's series and author names

### DIFF
--- a/internal/webui/books.go
+++ b/internal/webui/books.go
@@ -15,7 +15,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -162,11 +161,11 @@ func (s *Server) bookView(r *http.Request, u *store.User, bookID string) (BookVi
 	if rel, err := s.St.CatalogBookRelationsForBooks(
 		r.Context(), readerID(u), []string{book.ID},
 	); err == nil {
-		v.Authors, v.Byline = contributorChips(book.FolderID, rel.Contributors[book.ID])
+		v.Authors, v.Byline = contributorChips(rel.Contributors[book.ID])
 		for _, ser := range rel.Series[book.ID] {
 			v.Series = append(v.Series, ChipLink{
 				Name: ser.Name,
-				URL:  entityURL(book.FolderID, "series", ser.SeriesID),
+				URL:  uiEntity("series", ser.SeriesID),
 			})
 		}
 	}
@@ -183,7 +182,7 @@ func (s *Server) bookView(r *http.Request, u *store.User, bookID string) (BookVi
 			v.SeriesNow = append(v.SeriesNow, BookSeriesLine{
 				Name:     ser.Name,
 				Position: formatSeriesPosition(ser.Position),
-				URL:      entityURL(book.FolderID, "series", ser.SeriesID),
+				URL:      uiEntity("series", ser.SeriesID),
 			})
 		}
 		if layers.Source != store.SeriesSourceFolder {
@@ -193,17 +192,11 @@ func (s *Server) bookView(r *http.Request, u *store.User, bookID string) (BookVi
 	return v, true
 }
 
-// entityURL is the page listing everything else that claims an entity.
-func entityURL(folderID, kind, entityID string) string {
-	return "folders/" + url.PathEscape(folderID) + "/" + kind + "/" +
-		url.PathEscape(entityID)
-}
-
 // contributorChips returns the links and the byline. The byline names
 // authors only when the file said who they are, and falls back to every
 // contributor when it did not: a book credited solely to a translator
 // should still say so rather than say nothing.
-func contributorChips(folderID string, rows []store.BookContributor) ([]ChipLink, string) {
+func contributorChips(rows []store.BookContributor) ([]ChipLink, string) {
 	chips := make([]ChipLink, 0, len(rows))
 	var authors []string
 	var everyone []string
@@ -217,7 +210,7 @@ func contributorChips(folderID string, rows []store.BookContributor) ([]ChipLink
 		if _, seen := seenContributors[key]; !seen {
 			chips = append(chips, ChipLink{
 				Name: c.Name,
-				URL:  entityURL(folderID, "contributors", c.ContributorID),
+				URL:  uiEntity("contributors", c.ContributorID),
 			})
 			everyone = append(everyone, c.Name)
 			seenContributors[key] = struct{}{}

--- a/internal/webui/entities.go
+++ b/internal/webui/entities.go
@@ -70,9 +70,11 @@ func (s *Server) handleEntities(
 		Problem:  r.URL.Query().Get("problem"),
 		View:     readPrefs(r).View,
 	}
-	// The view toggle returns here. A relative target is resolved by the
-	// browser against this URL, so the kind segment alone is this page.
-	v.Back = url.PathEscape(v.Kind)
+	// The view toggle returns here. The preference form posts to
+	// /ui/preferences and its redirect is resolved from the UI root, so
+	// this is the path relative to /ui/ — the whole route, not the kind
+	// segment the browser happens to be standing on.
+	v.Back = uiEntityList(v.Kind)
 	for _, row := range rows {
 		// A series nothing claims any more is a name and not a shelf.
 		// This became reachable rather than theoretical with ADR-0018:
@@ -89,7 +91,7 @@ func (s *Server) handleEntities(
 		})
 	}
 	if len(rows) == entityPageSize {
-		v.NextURL = url.PathEscape(v.Kind) + "?after=" +
+		v.NextURL = uiEntityList(v.Kind) + "?after=" +
 			url.QueryEscape(rows[len(rows)-1].NormalizedName)
 	}
 	entitiesPage(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a), v).
@@ -134,7 +136,7 @@ func (s *Server) handleEntityBooks(
 		Heading:  entity.Name,
 		Singular: entityKindLabels[kind].One,
 		View:     readPrefs(r).View,
-		Back:     url.PathEscape(entityID),
+		Back:     uiEntity(r.PathValue("kind"), entityID),
 	}
 	for _, b := range books {
 		v.Books = append(v.Books, BookRow{
@@ -148,7 +150,7 @@ func (s *Server) handleEntityBooks(
 	// The store hands back the cursor for the next page, because the
 	// sort key depends on the kind and only the store knows it.
 	if next != nil {
-		v.NextURL = url.PathEscape(v.Kind) + "/" + url.PathEscape(entityID) +
+		v.NextURL = uiEntity(v.Kind, entityID) +
 			"?cursor=" + url.QueryEscape(encodeBooksCursor(*next))
 	}
 	entityBooksPage(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a), v).

--- a/internal/webui/links_ext_test.go
+++ b/internal/webui/links_ext_test.go
@@ -1,0 +1,256 @@
+//go:build linux
+
+package webui_test
+
+import (
+	"fmt"
+	"html"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// Every link in this UI is assembled by hand from a prefix and a path,
+// and until this test nothing checked that the result was a route. It
+// stopped being theoretical when entities became library-wide
+// (ADR-0019): the pages moved from /ui/folders/{folder}/{kind}/{entity}
+// to /ui/entities/{kind}/{entity}, the templates followed and the
+// builders behind the book page's chips did not, so every author and
+// series chip led to a 404 that nothing failed on.
+//
+// So this walks the pages a reader passes through, resolves every link,
+// form target and "back where you came from" value the way a browser
+// would, and asks whether anything answers it. The question goes to the
+// router rather than to a POST, because a form target must not be
+// submitted to find out that it exists; where the router does say a GET
+// leads somewhere, the page is fetched too, since a route that answers
+// 404 for this reader is as dead an end as no route at all.
+//
+// dashboard is the one pattern that proves nothing: /ui/ matches every
+// unclaimed path under it and the handler 404s all but its own.
+const dashboardPattern = "GET /ui/"
+
+var (
+	uiLinkAttr = regexp.MustCompile(
+		`(?:href|action|hx-get|hx-post)="([^"]*)"`)
+	uiBackValue = regexp.MustCompile(
+		`name="back" value="([^"]*)"`)
+)
+
+// pageLinks is every internal /ui target a page points at, absolute and
+// deduplicated. Relative targets resolve against the page's own URL, as
+// the browser resolves them; a "back" value resolves against the UI root,
+// which is where the forms carrying one post and where their redirects
+// are resolved from.
+func pageLinks(t *testing.T, pagePath, body string) []string {
+	t.Helper()
+	base, err := url.Parse(pagePath)
+	if err != nil {
+		t.Fatalf("page path %q: %v", pagePath, err)
+	}
+	root, _ := url.Parse("/ui/")
+
+	seen := map[string]bool{}
+	add := func(against *url.URL, raw string) {
+		raw = strings.TrimSpace(html.UnescapeString(raw))
+		if raw == "" || strings.HasPrefix(raw, "#") {
+			return
+		}
+		ref, err := url.Parse(raw)
+		if err != nil || ref.IsAbs() || ref.Host != "" {
+			return
+		}
+		target := against.ResolveReference(ref)
+		if !strings.HasPrefix(target.Path, "/ui/") ||
+			strings.HasPrefix(target.Path, "/ui/static/") {
+			return
+		}
+		target.Fragment = ""
+		seen[target.String()] = true
+	}
+	for _, m := range uiLinkAttr.FindAllStringSubmatch(body, -1) {
+		add(base, m[1])
+	}
+	for _, m := range uiBackValue.FindAllStringSubmatch(body, -1) {
+		add(root, m[1])
+	}
+
+	out := make([]string, 0, len(seen))
+	for link := range seen {
+		out = append(out, link)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestEveryLinkAPageOffersLeadsSomewhere(t *testing.T) {
+	f := newBooksFixture(t)
+	now := time.Now().UTC()
+	bookID := observeSeriesBook(t, f, "dune.epub", "Dune", "Chronicles", 1, now)
+	seriesID := seriesIDFor(t, f, "Chronicles")
+	contributorID := entityIDFor(t, f, store.EntityContributor, "Series Author")
+
+	// The same routing table the server runs, asked rather than driven.
+	routes := http.NewServeMux()
+	f.ui.Mount(routes, func(h http.Handler) http.Handler { return h })
+
+	pages := []string{
+		"/ui/",
+		"/ui/library",
+		"/ui/library?filter=reading",
+		"/ui/books/" + bookID,
+		"/ui/entities/series",
+		"/ui/entities/contributors",
+		"/ui/entities/tags",
+		"/ui/entities/series/" + seriesID,
+		"/ui/entities/contributors/" + contributorID,
+		"/ui/folders/" + f.folder + "/search?q=dune",
+		"/ui/settings",
+	}
+	for _, page := range pages {
+		resp, body := f.get(t, page, f.cookie)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s: got %d, want 200", page, resp.StatusCode)
+		}
+		for _, link := range pageLinks(t, page, body) {
+			get, post := patternsFor(t, routes, link)
+			switch {
+			case get != "" && get != dashboardPattern || link == "/ui/":
+				if resp, _ := f.get(t, link, f.cookie); resp.StatusCode == http.StatusNotFound {
+					t.Errorf("%s offers %s, which answers 404", page, link)
+				}
+			case post != "":
+				// A form target: routed, and not ours to submit.
+			default:
+				t.Errorf("%s offers %s, which no route answers", page, link)
+			}
+		}
+	}
+}
+
+// patternsFor asks the router which patterns claim a target, for a GET
+// and for a POST. An empty string means nothing does.
+func patternsFor(
+	t *testing.T, routes *http.ServeMux, target string,
+) (getPattern, postPattern string) {
+	t.Helper()
+	u, err := url.Parse(target)
+	if err != nil {
+		t.Fatalf("link %q: %v", target, err)
+	}
+	ask := func(method string) string {
+		_, pattern := routes.Handler(&http.Request{
+			Method: method, URL: u, Host: "liseur.test",
+		})
+		return pattern
+	}
+	return ask(http.MethodGet), ask(http.MethodPost)
+}
+
+// entityIDFor is seriesIDFor for the other kinds, since the store mints
+// every entity id.
+func entityIDFor(
+	t *testing.T, f *booksFixture, kind store.EntityKind, name string,
+) string {
+	t.Helper()
+	rows, err := f.st.ListCatalogEntities(t.Context(), "u1", kind, "", 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.Name == name {
+			return row.ID
+		}
+	}
+	t.Fatalf("no %s named %q", kind, name)
+	return ""
+}
+
+// TestPaginationLinksLeadToTheNextPage covers what the walk above cannot
+// reach with a handful of books: the "Next page" links, which only
+// appear once a page is full. They were the other half of the same bug
+// — a next-page link built for a route that had moved, or rendered
+// without the prefix its page needed — so they are exercised with
+// enough books to make them appear.
+func TestPaginationLinksLeadToTheNextPage(t *testing.T) {
+	f := newBooksFixture(t)
+	now := time.Now().UTC()
+	// One more than the shelf holds (seriesShelfSize), so it pages.
+	const volumes = 201
+	observed := make([]store.ObservedBook, 0, volumes)
+	for i := range volumes {
+		position := float64(i + 1)
+		name := fmt.Sprintf("vol-%03d", i)
+		observed = append(observed, store.ObservedBook{
+			RelativePath: name + ".epub", SizeBytes: 4096, MTime: now,
+			ContentSHA256: name, OriginalFilename: name + ".epub",
+			MediaType: "application/epub+zip",
+			Title:     "Volume " + name,
+			Series: []store.ObservedSeries{
+				{Name: "Long Run", Position: &position},
+			},
+			// One author on every volume, so that shelf pages, plus one
+			// of their own, so the contributors listing pages too.
+			Contributors: []store.ObservedContributor{
+				{Name: "Prolific Author", Role: store.ContributorRoleAuthor, Position: 1},
+				{Name: "Editor " + name, Role: "edt", Position: 2},
+			},
+		})
+	}
+	if _, err := f.st.ReconcileFolder(
+		t.Context(), f.folder, observed, false, now,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	routes := http.NewServeMux()
+	f.ui.Mount(routes, func(h http.Handler) http.Handler { return h })
+
+	for _, page := range []string{
+		"/ui/entities/series/" + seriesIDFor(t, f, "Long Run"),
+		"/ui/entities/contributors",
+		"/ui/entities/contributors/" +
+			entityIDFor(t, f, store.EntityContributor, "Prolific Author"),
+	} {
+		resp, body := f.get(t, page, f.cookie)
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("%s: got %d, want 200", page, resp.StatusCode)
+		}
+		next := nextPageLink(t, page, body)
+		if get, _ := patternsFor(t, routes, next); get == "" || get == dashboardPattern {
+			t.Errorf("%s pages to %s, which no route answers", page, next)
+			continue
+		}
+		if resp, _ := f.get(t, next, f.cookie); resp.StatusCode != http.StatusOK {
+			t.Errorf("%s pages to %s: got %d, want 200",
+				page, next, resp.StatusCode)
+		}
+	}
+}
+
+var nextPageHref = regexp.MustCompile(`href="([^"]*)">Next page<`)
+
+// nextPageLink is the page's own "Next page" target, resolved the way
+// the browser on that page would resolve it.
+func nextPageLink(t *testing.T, pagePath, body string) string {
+	t.Helper()
+	m := nextPageHref.FindStringSubmatch(body)
+	if m == nil {
+		t.Fatalf("%s: no next-page link, so nothing paged", pagePath)
+	}
+	base, err := url.Parse(pagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := url.Parse(html.UnescapeString(m[1]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base.ResolveReference(ref).String()
+}

--- a/internal/webui/readerbrowser_ext_test.go
+++ b/internal/webui/readerbrowser_ext_test.go
@@ -485,7 +485,7 @@ func TestUIScreenshots(t *testing.T) {
 		"SHOT_COOKIE="+cookie.Name+"="+cookie.Value,
 		"SHOT_DIR="+outDir,
 		"SHOT_PATHS=/ui/,/ui/library,/ui/library?filter=reading,/ui/books/"+books[0]+","+
-			"/ui/folders/"+f.folder+"/contributors,/ui/settings?section=devices,/ui/settings",
+			"/ui/entities/contributors,/ui/settings?section=devices,/ui/settings",
 		"SHOT_PREFS="+os.Getenv("LISEUR_UI_PREFS"),
 		"SHOT_TAG="+os.Getenv("LISEUR_UI_TAG"),
 	)

--- a/internal/webui/series.go
+++ b/internal/webui/series.go
@@ -224,7 +224,7 @@ func (s *Server) handleSeriesShelf(
 	v.NextUp = nextUpVolume(v.Volumes)
 	v.Gaps = seriesGaps(v.Volumes)
 	if next != nil {
-		v.NextURL = "series/" + url.PathEscape(entity.ID) +
+		v.NextURL = uiEntity("series", entity.ID) +
 			"?cursor=" + url.QueryEscape(encodeBooksCursor(*next))
 	}
 	seriesShelfPage(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a), v).

--- a/internal/webui/series.templ
+++ b/internal/webui/series.templ
@@ -95,7 +95,7 @@ templ seriesShelfBody(prefix, csrf string, v SeriesShelfView) {
 		}
 		if v.NextURL != "" {
 			<div class="more">
-				<a href={ v.NextURL }>Next page</a>
+				<a href={ prefix + v.NextURL }>Next page</a>
 			</div>
 		}
 	</section>

--- a/internal/webui/urls.go
+++ b/internal/webui/urls.go
@@ -1,0 +1,32 @@
+package webui
+
+import "net/url"
+
+// The UI has one rule about links, and this file is where it lives.
+//
+// Every URL a handler puts in a view is a path relative to the UI root
+// (/ui/), with no leading slash: "library", "books/{id}",
+// "entities/series/{id}". A template renders it as `prefix + path`,
+// where prefix is relPrefix of the page's own request path. That pairing
+// is what lets the whole UI work under a stripped subpath, and it only
+// holds if both halves agree — a value that is already relative to the
+// page, or that still carries a route shape from an older layout, points
+// somewhere that does not exist.
+//
+// It went wrong exactly that way once: entities became library-wide
+// (ADR-0019) and moved from /ui/folders/{folder}/{kind}/{entity} to
+// /ui/entities/{kind}/{entity}, the templates were updated and these
+// builders were not, so every author and series chip on a book page led
+// to a 404. Routes move; a builder in one place moves with them.
+
+// uiEntityList is the page listing every entity of one kind.
+func uiEntityList(kind string) string {
+	return "entities/" + url.PathEscape(kind)
+}
+
+// uiEntity is the page for one entity: a contributor's or a tag's
+// listing, or a series' shelf, which is a route of its own (ADR-0018)
+// under the same path.
+func uiEntity(kind, entityID string) string {
+	return uiEntityList(kind) + "/" + url.PathEscape(entityID)
+}


### PR DESCRIPTION
Clicking the series or author name on a book page led to a "page not found". Those names pointed at the addresses the series and contributor pages had before they became library-wide and moved out of the folder.

The same stale addresses broke three more things nobody had reported yet: the "Next page" link at the bottom of a long series shelf, the "Next page" link on the contributor and tag listings, and the grid/list toggle on an entity page, which sent the reader to a URL with nothing behind it.

Nothing checked that a link a page renders is a link the server answers, which is why the routes could move and the pages could keep pointing at where they used to be. There is a test for that now: it walks the dashboard, the library, a book page, a series shelf, the entity listings and settings, resolves every link, form target and return address the way a browser would, and fails when one leads nowhere. It fails on all four bugs when the fixes are backed out.

Checked with `go build ./...`, `go vet`, `go test -race ./internal/webui/...` and `golangci-lint run ./internal/webui/...`.