### PR TITLE
Add auto-hiding reader controls with edge taps

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ a Calibre library, `metadata.db` is the catalog.
 
 `liseur-sync` includes a browser-based EPUB reader.
 
+The bar and the page-turn arrows step aside while you read and come
+back when you reach for them: move the pointer to the top or the sides,
+tap the middle of the page, or press `z`. Tapping or clicking the left
+and right edges of the page turns it, which is how a phone reads
+without any chrome at all. "Auto-hide bars" under Aa turns this off.
+
 The browser unpacks and renders EPUBs without exposing publisher content
 through application routes. Scripts inside EPUBs do not run.
 

--- a/docs/adr/0012-reader-engine-foliate.md
+++ b/docs/adr/0012-reader-engine-foliate.md
@@ -105,10 +105,18 @@ mechanism.
   `foliate-js.LICENSE`. Updating is a deliberate re-copy, which for a
   security-sensitive component is a feature.
 - The user stylesheet the engine injects after the publication's own is
-  what reader appearance settings (theme, font, size, spacing, layout)
-  are built on. They are a browser preference in `localStorage`, applied
-  client-side, and never sent to the server; the default for every one
-  of them is the publisher's design, untouched.
+  what reader appearance settings (theme, font, size, spacing, layout,
+  and whether the bar and page-turn arrows hide themselves while you
+  read) are built on. They are a browser preference in `localStorage`,
+  applied client-side, and never sent to the server; the default for
+  every one of them is the publisher's design, untouched.
+- The chrome that hides has to leave a way to turn a page behind it, so
+  the sides of the window turn pages wherever they are clicked —
+  margin or text — and the middle brings the chrome back. Clicks on the
+  text are handled per chapter document, next to the reading keys,
+  because a chapter is a document of its own and nothing that happens
+  over it reaches the page. A drag, a selection or a control is not a
+  tap and is left alone.
 - The browser-test fixture now carries the `position:absolute` title
   page that defeated epub.js, so the failure that forced this ADR is
   pinned as a regression test.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.5
 require (
 	github.com/BurntSushi/toml v1.6.0
 	github.com/a-h/templ v0.3.1020
+	github.com/fsnotify/fsnotify v1.10.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.10.0
 	golang.org/x/crypto v0.54.0
@@ -22,7 +23,6 @@ require (
 	github.com/cli/browser v1.3.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/color v1.16.0 // indirect
-	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/internal/webui/reader.templ
+++ b/internal/webui/reader.templ
@@ -144,6 +144,9 @@ templ readerPage(v ReaderView, csrf string) {
 								<option value="wide">Wide</option>
 							</select>
 						</label>
+						<div class="row2">
+							<label class="chip"><input type="checkbox" name="autohide"/> Auto-hide bars</label>
+						</div>
 						<button type="button" id="reader-settings-reset">Reset to defaults</button>
 					</form>
 				</details>
@@ -208,10 +211,16 @@ templ readerPage(v ReaderView, csrf string) {
 						<tr><td><kbd>Home</kbd> / <kbd>End</kbd></td><td>Beginning / end of book</td></tr>
 						<tr><td><kbd>t</kbd></td><td>Table of contents</td></tr>
 						<tr><td><kbd>f</kbd></td><td>Full screen</td></tr>
+						<tr><td><kbd>z</kbd></td><td>Show or hide the bars</td></tr>
 						<tr><td><kbd>?</kbd></td><td>This help</td></tr>
 						<tr><td><kbd>Esc</kbd></td><td>Close help, contents or settings</td></tr>
 					</tbody>
 				</table>
+				<p class="reader-help-note">
+					Click or tap the left and right edges of the page to turn it, and
+					the middle to show or hide the bars. They step aside on their own
+					while you read; &ldquo;Auto-hide bars&rdquo; under Aa turns that off.
+				</p>
 				<form method="dialog"><button>Close</button></form>
 			</dialog>
 			<script type="module" src={ v.StaticBase + "reader-app.js" } nonce={ v.ScriptNonce }></script>

--- a/internal/webui/readerpage_ext_test.go
+++ b/internal/webui/readerpage_ext_test.go
@@ -143,3 +143,26 @@ func TestReaderPageLinksTheCoverAsItsIcon(t *testing.T) {
 		t.Errorf("the reader page does not link the cover icon:\n%s", page)
 	}
 }
+
+// TestReaderPageOffersTheChromeControls: the bar and the page-turn
+// arrows step aside while somebody reads, so the two ways of getting
+// them back — the "z" key and the setting that turns the behaviour off
+// — have to be on the page that says what the reader can do. So does
+// the sentence about the tap zones: once the arrows have faded, tapping
+// the sides of the page is how a phone turns it, and nothing else on
+// screen says so.
+func TestReaderPageOffersTheChromeControls(t *testing.T) {
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "novel", []byte(strings.Repeat("web-epub", 50)))
+
+	_, page := f.get(t, "/ui/books/"+bookID+"/read", f.cookie)
+	for _, want := range []string{
+		`name="autohide"`,
+		`<kbd>z</kbd>`,
+		`reader-help-note`,
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("the reader page is missing %q", want)
+		}
+	}
+}

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -900,7 +900,6 @@ function tapAt(x, y) {
     return true;
   }
   if (chromeVisible()) {
-    if (!chromeAuto()) return false;
     clearTimeout(chromeTimer);
     setChrome(false);
   } else {

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -41,6 +41,7 @@ if (cfg.detached) {
   history.replaceState(null, "", location.pathname + location.search);
 }
 const stage = document.getElementById("reader-view");
+const stageArea = stage.closest(".reader-stage") || stage;
 const status = document.getElementById("reader-status");
 const progressBar = document.getElementById("reader-progress-bar");
 const progressText = document.getElementById("reader-progress-text");
@@ -1354,7 +1355,9 @@ function bookHasSelection() {
 
 let stageTouchAt = 0;
 let stageGesture = newGesture();
-stage.addEventListener(
+const stageSurface = (target) =>
+  target === stageArea || target === stage || target === view;
+stageArea.addEventListener(
   "pointerdown",
   (e) => {
     if (stageGesture.id !== null && stageGesture.id !== e.pointerId) {
@@ -1375,9 +1378,9 @@ const spoilStage = (e) => {
   if (stageGesture.id === null || stageGesture.id === e.pointerId)
     stageGesture.spoiled = true;
 };
-stage.addEventListener("pointercancel", spoilStage, { passive: true });
-stage.addEventListener("lostpointercapture", spoilStage, { passive: true });
-stage.addEventListener("pointerup", (e) => {
+stageArea.addEventListener("pointercancel", spoilStage, { passive: true });
+stageArea.addEventListener("lostpointercapture", spoilStage, { passive: true });
+stageArea.addEventListener("pointerup", (e) => {
   if (stageGesture.id !== null && stageGesture.id !== e.pointerId) {
     stageGesture.spoiled = true;
     return;
@@ -1398,13 +1401,13 @@ stage.addEventListener("pointerup", (e) => {
   }
   if (!clean) return;
   if (stageGesture.hadSelection || bookHasSelection()) return;
-  if (e.target !== stage && e.target !== view) return;
+  if (!stageSurface(e.target)) return;
   tapAt(e.clientX, e.clientY);
 });
-stage.addEventListener("click", (e) => {
+stageArea.addEventListener("click", (e) => {
   if (!view) return;
   if (tocPanel && !tocPanel.hidden) return; // the click puts the drawer away
-  if (e.target !== stage && e.target !== view) return;
+  if (!stageSurface(e.target)) return;
   if (Date.now() - stageTouchAt < TOUCH_CLICK_MS) return; // already handled
   if (stageGesture.hadSelection || bookHasSelection()) return;
   tapAt(e.clientX, e.clientY);

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -565,6 +565,7 @@ const SETTINGS_DEFAULTS = Object.freeze({
   flow: "paginated",
   columns: "auto",
   margin: "normal",
+  autohide: true,
 });
 const THEMES = {
   light: { bg: "#ffffff", fg: "#1b1b1f", link: "#1a63c4", scheme: "light" },
@@ -691,6 +692,7 @@ function chapterCSS(s) {
 
 function applySettings() {
   document.body.dataset.readerTheme = settings.theme;
+  applyChrome();
   if (!view || !view.renderer) return;
   const renderer = view.renderer;
   renderer.setAttribute(
@@ -742,6 +744,7 @@ function readSettingsForm() {
     flow: String(data.get("flow") || SETTINGS_DEFAULTS.flow),
     columns: String(data.get("columns") || SETTINGS_DEFAULTS.columns),
     margin: String(data.get("margin") || SETTINGS_DEFAULTS.margin),
+    autohide: data.has("autohide"),
   };
   if (sizeOut) sizeOut.textContent = settings.size + "%";
 }
@@ -791,6 +794,357 @@ if (fullscreenBtn) {
       p.setAttribute("d", MAXIMIZE_PATH);
       fullscreenBtn.title = "Full screen (f)";
     }
+  });
+}
+
+// ---------------------------------------------- chrome and tap zones
+
+// The bar and the two arrows float over the book and step aside while
+// nobody is reaching for them. What replaces them is the tap model
+// here: the sides of the window turn pages wherever they are clicked —
+// blank margin or the text itself — and the middle asks for the chrome
+// back. A phone has no hover and no arrows to aim at once they have
+// faded, so without this there would be no way left to turn a page.
+//
+// The zones are a share of the window rather than a fixed ribbon: a
+// third of a phone is a thumb, a third of a desktop window is most of
+// the column.
+const CHROME_IDLE_MS = 2200;
+const CHROME_TOUCH_MS = 4000;
+const TAP_SLOP_PX = 10;
+
+let chromePinned = false;
+let chromeTimer = null;
+
+function chromeAuto() {
+  return !!settings.autohide && !chromePinned;
+}
+
+function chromeVisible() {
+  return document.body.dataset.readerChrome !== "hidden";
+}
+
+function setChrome(visible) {
+  document.body.dataset.readerChrome = visible ? "visible" : "hidden";
+}
+
+// chromeBusy is every reason the bar cannot be taken away right now:
+// something it owns is open, an error is on screen — a failure must
+// never hide behind an invisible bar — or the keyboard is in it.
+function chromeBusy() {
+  if (tocPanel && !tocPanel.hidden) return true;
+  if (settingsPanel && settingsPanel.open) return true;
+  if (status && !status.hidden) return true;
+  const help = document.getElementById("reader-help");
+  if (help && help.open) return true;
+  const active = document.activeElement;
+  return !!(
+    active &&
+    active.closest &&
+    active.closest(".reader-bar, .reader-turn")
+  );
+}
+
+function armChrome(delay) {
+  clearTimeout(chromeTimer);
+  if (!chromeAuto()) return;
+  chromeTimer = setTimeout(() => {
+    if (chromeBusy()) {
+      armChrome(delay);
+      return;
+    }
+    setChrome(false);
+  }, delay);
+}
+
+function revealChrome(delay) {
+  setChrome(true);
+  armChrome(delay || CHROME_IDLE_MS);
+}
+
+function applyChrome() {
+  if (!chromeAuto()) {
+    clearTimeout(chromeTimer);
+    setChrome(true);
+    return;
+  }
+  revealChrome();
+}
+
+function sideWidth() {
+  const w = window.innerWidth || 1;
+  return Math.max(64, Math.min(w * (w < 700 ? 0.3 : 0.22), 260));
+}
+
+function tapZone(x) {
+  const w = window.innerWidth || 1;
+  const side = sideWidth();
+  if (x <= side) return "prev";
+  if (x >= w - side) return "next";
+  return "chrome";
+}
+
+function inTopZone(y) {
+  return y <= Math.max(56, (window.innerHeight || 0) * 0.1);
+}
+
+// tapAt is the whole click model, in viewport coordinates: the stage,
+// the engine's margins and every chapter document funnel here so that
+// one rule covers the page whatever the click happened to land on.
+function tapAt(x, y) {
+  const zone = tapZone(x);
+  if (zone !== "chrome") {
+    turn(zone === "prev" ? -1 : 1);
+    if (chromeVisible()) armChrome(CHROME_IDLE_MS);
+    return true;
+  }
+  if (chromeVisible()) {
+    if (!chromeAuto()) return false;
+    clearTimeout(chromeTimer);
+    setChrome(false);
+  } else {
+    chromePinned = false;
+    revealChrome(CHROME_TOUCH_MS);
+  }
+  return true;
+}
+
+function toggleChrome() {
+  if (chromeVisible()) {
+    chromePinned = false;
+    clearTimeout(chromeTimer);
+    setChrome(false);
+  } else {
+    chromePinned = true;
+    clearTimeout(chromeTimer);
+    setChrome(true);
+  }
+}
+
+function pointerMoved(x, y, pointerType) {
+  if (pointerType === "touch") return; // a finger reveals by tapping
+  if (!chromeAuto()) return;
+  if (inTopZone(y) || tapZone(x) !== "chrome") revealChrome();
+  else if (chromeVisible()) armChrome(CHROME_IDLE_MS);
+}
+
+document.addEventListener(
+  "pointermove",
+  (e) => pointerMoved(e.clientX, e.clientY, e.pointerType),
+  { passive: true },
+);
+document.addEventListener("focusin", () => {
+  if (chromeAuto() && chromeBusy()) revealChrome();
+});
+
+// A chapter is a document of its own, so nothing that happens over the
+// text reaches this page: pointer and click handling has to be wired
+// per chapter, the way the reading keys already are. Its coordinates
+// are the frame's, and the frame knows where it sits.
+// A coordinate inside a chapter is the chapter's, and the reader thinks
+// in the window's. The frame says where it sits — and, for a
+// fixed-layout publication, how much the engine scaled it: those frames
+// carry a CSS transform, so the rectangle is in rendered pixels while
+// the coordinate inside it is in the document's own. A reflowable book
+// scales by 1 and passes through unchanged.
+function frameOffset(doc) {
+  try {
+    const el = doc.defaultView && doc.defaultView.frameElement;
+    if (el) {
+      const box = el.getBoundingClientRect();
+      const scale = el.offsetWidth ? box.width / el.offsetWidth : 1;
+      return { left: box.left, top: box.top, scale: scale || 1 };
+    }
+  } catch (err) {
+    /* the frame was replaced between events */
+  }
+  const box = stage.getBoundingClientRect();
+  return { left: box.left, top: box.top, scale: 1 };
+}
+
+function toViewport(doc, x, y) {
+  const box = frameOffset(doc);
+  return [box.left + x * box.scale, box.top + y * box.scale];
+}
+
+// Everything in a publication that is already something when it is
+// clicked: a control, a link, a media player, an image map, a frame.
+// Clicking one of those is doing that thing, not turning a page.
+const TAP_EXEMPT =
+  "a,button,input,textarea,select,summary,label,audio,video,area[href]," +
+  "iframe,embed,object,[contenteditable],[role='button'],[role='link']";
+// Long enough to cover the usual platform double-click intervals
+// (Windows and macOS both default to about half a second).
+const DOUBLE_CLICK_MS = 500;
+// How long after a tap the browser's synthesized click may still turn
+// up. It is the same tap, and it has already been answered.
+const TOUCH_CLICK_MS = 700;
+
+// overText answers the only question that makes a mouse click
+// ambiguous: is there a word under the pointer? A click on a line of
+// text might be the first half of a double-click that selects it, so it
+// has to wait; a click on a margin, a gutter or the space below the
+// last line cannot be selecting anything and turns the page at once.
+// caretRangeFromPoint alone is not enough — it answers with the
+// *nearest* caret position even when the point is nowhere near it — so
+// the character it names is measured and the point has to be inside it.
+function overText(doc, x, y) {
+  const find = doc.caretRangeFromPoint || doc.caretPositionFromPoint;
+  if (!find) return true; // no way to tell: assume the careful answer
+  try {
+    const hit = find.call(doc, x, y);
+    if (!hit) return false;
+    const node = hit.startContainer || hit.offsetNode;
+    const offset = hit.startOffset ?? hit.offset ?? 0;
+    if (!node || node.nodeType !== 3 || !node.length) return false;
+    const at = Math.min(offset, node.length - 1);
+    const range = doc.createRange();
+    range.setStart(node, at);
+    range.setEnd(node, at + 1);
+    const box = range.getBoundingClientRect();
+    return (
+      x >= box.left - 2 &&
+      x <= box.right + 2 &&
+      y >= box.top - 2 &&
+      y <= box.bottom + 2
+    );
+  } catch (err) {
+    return true;
+  }
+}
+
+// A gesture is one pointer, from its own down to its own up. A second
+// finger, a cancelled pointer or a stolen capture ends it: what happens
+// next is a pinch, a scroll or the browser's business, never a tap.
+function newGesture() {
+  return { id: null, x: 0, y: 0, spoiled: true, hadSelection: false };
+}
+
+function wireChapterPointer(doc) {
+  let gesture = newGesture();
+  let mouse = false;
+  let touchAt = 0;
+  let deferred = null;
+  const cancelDeferred = () => {
+    clearTimeout(deferred);
+    deferred = null;
+  };
+  const selected = () => {
+    const sel = doc.getSelection && doc.getSelection();
+    return !!(sel && sel.rangeCount && !sel.isCollapsed);
+  };
+  // Everything a tap has to not be, in one place: a drag, a gesture
+  // that was never ours to finish, a second click, a control — or a
+  // click that is putting a selection away rather than making one,
+  // which is why the selection is remembered from pointerdown: the
+  // browser collapses it before the click arrives, and by then the
+  // evidence is gone.
+  const isTap = (e) => {
+    if (gesture.spoiled) return false;
+    if (typeof e.button === "number" && e.button !== 0) return false;
+    if (e.detail > 1) return false;
+    if (gesture.hadSelection || selected()) return false;
+    return !(e.target && e.target.closest && e.target.closest(TAP_EXEMPT));
+  };
+  doc.addEventListener(
+    "pointermove",
+    (e) => {
+      pointerMoved(...toViewport(doc, e.clientX, e.clientY), e.pointerType);
+    },
+    { passive: true },
+  );
+  doc.addEventListener(
+    "pointerdown",
+    (e) => {
+      if (gesture.id !== null && gesture.id !== e.pointerId) {
+        gesture.spoiled = true; // a second finger: not a tap any more
+        return;
+      }
+      mouse = e.pointerType !== "touch" && e.pointerType !== "pen";
+      gesture = {
+        id: e.pointerId,
+        x: e.clientX,
+        y: e.clientY,
+        spoiled: false,
+        hadSelection: selected(),
+      };
+    },
+    { passive: true },
+  );
+  const spoil = (e) => {
+    if (gesture.id === null || gesture.id === e.pointerId) gesture.spoiled = true;
+  };
+  doc.addEventListener("pointercancel", spoil, { passive: true });
+  doc.addEventListener("lostpointercapture", spoil, { passive: true });
+  // A finger is answered here rather than on the click that should
+  // follow it: the engine snaps the page on every touchend, and a
+  // scroll between touchend and the synthesized click cancels that
+  // click outright. Waiting for it would mean tapping a phone and
+  // watching nothing happen.
+  doc.addEventListener(
+    "pointerup",
+    (e) => {
+      if (gesture.id !== null && gesture.id !== e.pointerId) {
+        gesture.spoiled = true;
+        return;
+      }
+      if (
+        Math.abs(e.clientX - gesture.x) > TAP_SLOP_PX ||
+        Math.abs(e.clientY - gesture.y) > TAP_SLOP_PX
+      )
+        gesture.spoiled = true;
+      gesture.id = null;
+      if (e.pointerType !== "touch" && e.pointerType !== "pen") return;
+      touchAt = Date.now();
+      if (tocPanel && !tocPanel.hidden) {
+        toggleTOC(false); // the drawer cannot hear a tap inside the book
+        gesture.spoiled = true;
+        return;
+      }
+      if (!isTap(e)) return;
+      tapAt(...toViewport(doc, e.clientX, e.clientY));
+    },
+    { passive: true },
+  );
+  // Double-clicking a word selects it, and the reader who did that
+  // wants the word, not the next page — but the first click of the
+  // pair arrives while the selection is still empty and looks exactly
+  // like a tap. A mouse click *on a word* therefore waits out the
+  // double-click interval and is cancelled if a second click, a
+  // selection or a dblclick follows. A mouse click anywhere else, and
+  // any touch or pen tap, turns the page immediately: there is nothing
+  // there to select, so there is nothing to wait for. (Beyond a
+  // half-second double-click interval the first click does turn a
+  // page; the reader turns back, and nothing is lost.)
+  doc.addEventListener("dblclick", cancelDeferred);
+  doc.addEventListener("selectstart", cancelDeferred);
+  // A tap on the text turns the page; a drag, a selection, a link or
+  // any other control is not a tap and is left entirely alone.
+  doc.addEventListener("click", (e) => {
+    if (e.detail > 1) {
+      cancelDeferred();
+      return;
+    }
+    // The tap this click belongs to was already answered on pointerup.
+    if (Date.now() - touchAt < TOUCH_CLICK_MS) return;
+    if (tocPanel && !tocPanel.hidden) {
+      toggleTOC(false);
+      gesture.spoiled = true;
+      return;
+    }
+    if (!isTap(e)) return;
+    const [x, y] = toViewport(doc, e.clientX, e.clientY);
+    if (!mouse || !overText(doc, e.clientX, e.clientY)) {
+      tapAt(x, y);
+      return;
+    }
+    cancelDeferred();
+    deferred = setTimeout(() => {
+      deferred = null;
+      const live = doc.getSelection && doc.getSelection();
+      if (live && live.rangeCount && !live.isCollapsed) return;
+      tapAt(x, y);
+    }, DOUBLE_CLICK_MS);
   });
 }
 
@@ -876,6 +1230,9 @@ function toggleTOC(open) {
   const want = typeof open === "boolean" ? open : tocPanel.hidden;
   tocPanel.hidden = !want;
   if (want) {
+    // The drawer belongs to the button in the bar, so the bar comes
+    // back with it however the drawer was opened.
+    revealChrome();
     const current =
       tocList.querySelector("a.current") || tocList.querySelector("a");
     if (current) current.focus();
@@ -965,15 +1322,92 @@ document
 // Any blank margin is a page turn: a click that lands on the stage or
 // on the engine's own chrome (margins, gaps, header, footer — all of
 // which retarget to the foliate-view host from its closed shadow root)
-// turns toward whichever half of the stage it fell in. Clicks inside
-// the chapter itself belong to the chapter — text selection and links
-// stay untouched, because those land in the frame, not here.
+// goes through the same tap zones as the text, so the sides turn the
+// page and the middle brings the bar back. Clicks inside the chapter
+// itself are handled in that chapter's own document, where a link or a
+// live selection can still be told apart from a tap.
+// A tap on the margin, rather than on the text: the same rule, and the
+// same reason for handling touch on pointerup. The engine snaps the
+// page on every touchend, and a scroll between touchend and the click
+// the browser would have synthesized cancels that click — a finger
+// would tap and nothing would happen. When the click does arrive it is
+// the same tap arriving twice, so a short window swallows it.
+// A click on the margin while a passage is selected is putting the
+// selection away, the same as a click on the text: the selection lives
+// in the chapter, so the margin has to go and ask.
+function bookHasSelection() {
+  try {
+    const contents =
+      view && view.renderer && view.renderer.getContents
+        ? view.renderer.getContents()
+        : [];
+    for (const content of contents) {
+      const doc = content && content.doc;
+      const sel = doc && doc.getSelection && doc.getSelection();
+      if (sel && sel.rangeCount && !sel.isCollapsed) return true;
+    }
+  } catch (err) {
+    /* the chapter went away mid-gesture */
+  }
+  return false;
+}
+
+let stageTouchAt = 0;
+let stageGesture = newGesture();
+stage.addEventListener(
+  "pointerdown",
+  (e) => {
+    if (stageGesture.id !== null && stageGesture.id !== e.pointerId) {
+      stageGesture.spoiled = true;
+      return;
+    }
+    stageGesture = {
+      id: e.pointerId,
+      x: e.clientX,
+      y: e.clientY,
+      spoiled: false,
+      hadSelection: bookHasSelection(),
+    };
+  },
+  { passive: true },
+);
+const spoilStage = (e) => {
+  if (stageGesture.id === null || stageGesture.id === e.pointerId)
+    stageGesture.spoiled = true;
+};
+stage.addEventListener("pointercancel", spoilStage, { passive: true });
+stage.addEventListener("lostpointercapture", spoilStage, { passive: true });
+stage.addEventListener("pointerup", (e) => {
+  if (stageGesture.id !== null && stageGesture.id !== e.pointerId) {
+    stageGesture.spoiled = true;
+    return;
+  }
+  if (
+    Math.abs(e.clientX - stageGesture.x) > TAP_SLOP_PX ||
+    Math.abs(e.clientY - stageGesture.y) > TAP_SLOP_PX
+  )
+    stageGesture.spoiled = true; // a swipe: the engine's business
+  const clean = !stageGesture.spoiled;
+  stageGesture.id = null;
+  if (!view) return;
+  if (e.pointerType !== "touch" && e.pointerType !== "pen") return;
+  stageTouchAt = Date.now();
+  if (tocPanel && !tocPanel.hidden) {
+    toggleTOC(false);
+    return;
+  }
+  if (!clean) return;
+  if (stageGesture.hadSelection || bookHasSelection()) return;
+  if (e.target !== stage && e.target !== view) return;
+  tapAt(e.clientX, e.clientY);
+});
 stage.addEventListener("click", (e) => {
   if (!view) return;
   if (tocPanel && !tocPanel.hidden) return; // the click puts the drawer away
   if (e.target !== stage && e.target !== view) return;
-  const box = stage.getBoundingClientRect();
-  turn(e.clientX < box.left + box.width / 2 ? -1 : 1);
+  if (Date.now() - stageTouchAt < TOUCH_CLICK_MS) return; // already handled
+  if (stageGesture.hadSelection || bookHasSelection()) return;
+  tapAt(e.clientX, e.clientY);
 });
 // The standard reading keys. Space is the one every reader agrees on
 // (Shift reverses it, as everywhere else); h/l and j/k are for hands
@@ -1052,6 +1486,10 @@ function handleKeys(e) {
       e.preventDefault();
       toggleFullscreen();
       break;
+    case "z":
+      e.preventDefault();
+      toggleChrome();
+      break;
     case "Home":
       if (view) view.goToFraction(0);
       break;
@@ -1096,8 +1534,11 @@ window.addEventListener("beforeunload", () => {
     // Each chapter document gets the reading keys: after a click in
     // the text, the frame owns the keyboard, and a listener on the
     // page alone would go deaf exactly when the reader looks focused.
+    // The pointer is wired there for the same reason — a tap on the
+    // text is how a phone turns a page once the arrows have faded.
     view.addEventListener("load", (e) => {
       e.detail.doc.addEventListener("keydown", handleKeys);
+      wireChapterPointer(e.detail.doc);
     });
     // Highlight drawing (ADR-0028): the engine asks how to draw each
     // annotation it anchors, and asks again for every chapter it

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -822,18 +822,46 @@ button.linkish:hover, button.linkish:focus-visible {
 .dev-desktop { color: var(--ink); background: var(--surface-1); opacity: .75; }
 
 /* The reader (ADR-0007): a book wants the window, so this page drops
-   the usual chrome and gives the sandboxed frame everything left. */
-.reader-body{margin:0;height:100vh;display:flex;flex-direction:column;overflow:hidden}
-.reader-bar{display:flex;align-items:center;gap:1rem;padding:.5rem .9rem;
-  border-bottom:1px solid var(--line);background:var(--surface)}
+   the usual chrome and gives the sandboxed frame everything left.
+
+   The bar, the progress line and the status float over the stage
+   rather than sitting in the column above it. That is what lets the
+   chrome be taken away and brought back without resizing the stage:
+   a stage that changes height makes the engine repaginate, which
+   would move the page out from under whoever is reading it. */
+.reader-body{margin:0;height:100vh;box-sizing:border-box;padding-top:3px;
+  display:flex;flex-direction:column;overflow:hidden}
+.reader-bar{position:fixed;top:3px;left:0;right:0;z-index:50;
+  display:flex;align-items:center;gap:1rem;padding:.5rem .9rem;
+  border-bottom:1px solid var(--line);background:var(--surface);
+  box-shadow:0 4px 18px rgba(0,0,0,.28);
+  transition:opacity .18s ease,transform .18s ease}
 .reader-back{text-decoration:none;white-space:nowrap}
 .reader-title{flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
 .reader-title span{opacity:.7;margin-left:.5rem}
 .reader-meta{display:flex;gap:.9rem;opacity:.75;font-size:.85rem;white-space:nowrap}
-.reader-progress{height:3px;background:var(--surface-3)}
+.reader-progress{position:fixed;top:0;left:0;right:0;z-index:70;
+  height:3px;background:var(--surface-3)}
 #reader-progress-bar{height:100%;width:0;background:var(--primary);transition:width .2s}
-.reader-status{margin:0;padding:.5rem .9rem;font-size:.9rem;opacity:.8}
+/* The status is only on screen while the book is loading or when it
+   failed to; centred, it can say so whether or not the bar is up. */
+.reader-status{position:fixed;z-index:45;top:50%;left:50%;transform:translate(-50%,-50%);
+  margin:0;padding:.5rem .9rem;font-size:.9rem;opacity:.8;
+  background:var(--surface);border:1px solid var(--line);border-radius:8px;
+  box-shadow:0 8px 24px rgba(0,0,0,.35)}
 .reader-status.problem{color:var(--danger);opacity:1}
+/* Chrome that has stepped aside is invisible and untouchable, never
+   absent: a click at the edge falls through to the page-turn zones,
+   and the buttons stay where a script (or a test) can reach them. */
+.reader-body[data-reader-chrome="hidden"] .reader-bar{
+  opacity:0;transform:translateY(-100%);pointer-events:none}
+.reader-body[data-reader-chrome="hidden"] .reader-turn{opacity:0;pointer-events:none}
+/* Tab is a way of reaching for the bar like any other. */
+.reader-body[data-reader-chrome="hidden"]:has(.reader-bar:focus-within) .reader-bar{
+  opacity:1;transform:none;pointer-events:auto}
+@media (prefers-reduced-motion:reduce){
+  .reader-bar,.reader-turn{transition:none}
+}
 .reader-help{background:var(--surface);color:inherit;border:1px solid var(--line);
   border-radius:10px;box-shadow:0 12px 32px rgba(0,0,0,.45);padding:1.1rem 1.3rem;
   min-width:20rem;font-size:.9rem}
@@ -845,6 +873,7 @@ button.linkish:hover, button.linkish:focus-visible {
 .reader-help kbd{background:var(--surface-3);border:1px solid var(--line);
   border-radius:4px;padding:.05rem .35rem;font-size:.8rem;font-family:inherit}
 .reader-help form{margin:.8rem 0 0;text-align:right}
+.reader-help-note{margin:.9rem 0 0;font-size:.85rem;opacity:.75;max-width:26rem}
 .reader-toc-button{border:1px solid var(--line);border-radius:6px;background:transparent;
   color:inherit;cursor:pointer;padding:.1rem .55rem;font-size:1rem;line-height:1.4}
 .reader-toc-button:hover{background:var(--surface-3)}
@@ -884,7 +913,7 @@ button.linkish:hover, button.linkish:focus-visible {
 .reader-stage{flex:1;display:flex;min-height:0}
 #reader-view{flex:1;min-width:0;height:100%;background:#fff;overflow:hidden}
 .reader-turn{border:0;background:transparent;cursor:pointer;font-size:2rem;
-  padding:0 .6rem;opacity:.35;color:inherit}
+  padding:0 .6rem;opacity:.35;color:inherit;transition:opacity .18s ease}
 .reader-turn:hover{opacity:.9}
 
 /* Reader appearance settings (ADR-0012): a details popover, no script

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -445,6 +445,593 @@ check("the slider lifts the publication's own width caps",
   sized.wrapMaxWidth === 'none' && sized.wrapWidth !== '480px',
   `max-width ${sized.wrapMaxWidth}, width ${sized.wrapWidth}`);
 
+// The chrome (top bar and the two arrows) steps aside while nobody is
+// reaching for it, and what replaces it is the tap model: the sides of
+// the window turn the page wherever they are clicked — including on the
+// text, which is the only thing a phone has left once the arrows have
+// faded — and the middle brings the bar back.
+const chromeState = () => evalIn(`JSON.stringify({
+  state: document.body.dataset.readerChrome || 'visible',
+  bar: getComputedStyle(document.querySelector('.reader-bar')).opacity,
+  arrow: getComputedStyle(document.getElementById('reader-next')).opacity,
+})`);
+const idle = () => new Promise((r) => setTimeout(r, 3000));
+// Tap the chapter document itself, the way a pointer really does it:
+// pointerdown, pointerup, then the click, in the frame's own
+// coordinates, so the page turned on is the one the reader is looking
+// at. A mouse tap waits out the double-click interval before it counts,
+// which is why every check below settles for longer than that.
+const tapChapter = (where, kind = 'mouse', drift = 0) => evalIn(`(() => {
+  const view = document.querySelector('foliate-view');
+  const doc = view.renderer.getContents()[0].doc;
+  const win = doc.defaultView;
+  const box = win.frameElement.getBoundingClientRect();
+  const xs = { left: 6, middle: window.innerWidth / 2, right: window.innerWidth - 6 };
+  const x = xs['${where}'] - box.left, y = window.innerHeight / 2 - box.top;
+  const at = (type, extra) => doc.body.dispatchEvent(new win.PointerEvent(type, {
+    bubbles: true, button: 0, pointerType: '${kind}', clientX: x, clientY: y, ...extra,
+  }));
+  at('pointerdown');
+  at('pointerup', { clientX: x + ${drift} });
+  doc.body.dispatchEvent(new win.MouseEvent('click', {
+    bubbles: true, button: 0, detail: 1, clientX: x + ${drift}, clientY: y,
+  }));
+  return true;
+})()`);
+const settle = () => new Promise((r) => setTimeout(r, 1200));
+
+await idle();
+const parked = JSON.parse(await chromeState());
+check('the chrome steps aside while reading',
+  parked.state === 'hidden' && parked.bar === '0' && parked.arrow === '0',
+  JSON.stringify(parked));
+
+await evalIn(`(() => {
+  document.dispatchEvent(new PointerEvent('pointermove', {
+    bubbles: true, clientX: window.innerWidth / 2, clientY: 4,
+  }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400)); // the bar fades in
+const reached = JSON.parse(await chromeState());
+check('reaching for the top of the window brings the chrome back',
+  reached.state === 'visible' && reached.bar === '1', JSON.stringify(reached));
+
+await idle();
+const beforeTap = JSON.parse(await evalIn(probe));
+await tapChapter('right');
+await settle();
+const tappedForward = JSON.parse(await evalIn(probe));
+check('a tap on the right of the text turns the page',
+  tappedForward.fraction > beforeTap.fraction,
+  `${beforeTap.fraction} -> ${tappedForward.fraction}`);
+await tapChapter('left');
+await settle();
+const tappedBack = JSON.parse(await evalIn(probe));
+check('a tap on the left of the text turns it back',
+  tappedBack.fraction < tappedForward.fraction,
+  `${tappedForward.fraction} -> ${tappedBack.fraction}`);
+
+// A finger has no double-click to wait for, so it turns at once.
+await tapChapter('right', 'touch');
+await new Promise((r) => setTimeout(r, 900));
+const touched = JSON.parse(await evalIn(probe));
+check('a touch tap turns the page without waiting',
+  touched.fraction > tappedBack.fraction,
+  `${tappedBack.fraction} -> ${touched.fraction}`);
+await tapChapter('left', 'touch');
+await settle();
+const touchedBack = JSON.parse(await evalIn(probe));
+
+await idle();
+await tapChapter('middle');
+await settle();
+const middled = JSON.parse(await chromeState());
+const stillThere = JSON.parse(await evalIn(probe));
+check('a tap in the middle of the text asks for the chrome',
+  middled.state === 'visible', JSON.stringify(middled));
+check('the middle of the text never turns the page',
+  stillThere.fraction === touchedBack.fraction,
+  `${touchedBack.fraction} -> ${stillThere.fraction}`);
+
+// A tap is only a tap when it is nothing else: a drag, a double-click
+// on a word, a control, or a live selection all mean the reader is
+// doing something with the text, and the page must stay where it is.
+await tapChapter('right', 'mouse', 40);
+await settle();
+const afterDrag = JSON.parse(await evalIn(probe));
+check('a drag across the text is not a page turn',
+  afterDrag.fraction === stillThere.fraction,
+  `${stillThere.fraction} -> ${afterDrag.fraction}`);
+
+await evalIn(`(() => {
+  const view = document.querySelector('foliate-view');
+  const doc = view.renderer.getContents()[0].doc;
+  const win = doc.defaultView;
+  const box = win.frameElement.getBoundingClientRect();
+  const x = window.innerWidth - 6 - box.left, y = window.innerHeight / 2 - box.top;
+  const opts = { bubbles: true, button: 0, clientX: x, clientY: y };
+  doc.body.dispatchEvent(new win.PointerEvent('pointerdown', { ...opts, pointerType: 'mouse' }));
+  doc.body.dispatchEvent(new win.PointerEvent('pointerup', { ...opts, pointerType: 'mouse' }));
+  doc.body.dispatchEvent(new win.MouseEvent('click', { ...opts, detail: 1 }));
+  doc.body.dispatchEvent(new win.MouseEvent('dblclick', { ...opts, detail: 2 }));
+  return true;
+})()`);
+await settle();
+const afterDouble = JSON.parse(await evalIn(probe));
+check('a double-click on a word is not a page turn',
+  afterDouble.fraction === afterDrag.fraction,
+  `${afterDrag.fraction} -> ${afterDouble.fraction}`);
+
+await evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  const button = doc.createElement('button');
+  button.id = 'tap-guard';
+  button.textContent = 'not a page turn';
+  doc.body.append(button);
+  const box = doc.defaultView.frameElement.getBoundingClientRect();
+  button.dispatchEvent(new MouseEvent('click', {
+    bubbles: true, button: 0, detail: 1,
+    clientX: window.innerWidth - 6 - box.left,
+    clientY: window.innerHeight / 2 - box.top,
+  }));
+  return true;
+})()`);
+await settle();
+const afterControl = JSON.parse(await evalIn(probe));
+check('a click on a control in the text is not a page turn',
+  afterControl.fraction === afterDouble.fraction,
+  `${afterDouble.fraction} -> ${afterControl.fraction}`);
+
+await evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  doc.getSelection().selectAllChildren(doc.body);
+  const box = doc.defaultView.frameElement.getBoundingClientRect();
+  doc.body.dispatchEvent(new MouseEvent('click', {
+    bubbles: true, button: 0, detail: 1,
+    clientX: window.innerWidth - 6 - box.left,
+    clientY: window.innerHeight / 2 - box.top,
+  }));
+  return true;
+})()`);
+await settle();
+const afterSelection = JSON.parse(await evalIn(probe));
+check('a click while text is selected is not a page turn',
+  afterSelection.fraction === afterControl.fraction,
+  `${afterControl.fraction} -> ${afterSelection.fraction}`);
+await evalIn(`(() => {
+  document.querySelector('foliate-view').renderer.getContents()[0]
+    .doc.getSelection().removeAllRanges();
+  return true;
+})()`);
+
+// Everything above dispatched its own events. Untrusted events skip the
+// browser's real input pipeline — no native selection, no synthesized
+// dblclick, no touch-to-pointer translation, and none of the engine's
+// own swipe handling. The checks below therefore go through CDP's
+// Input domain, which is the same path a hand takes.
+const mouse = (type, x, y, clickCount = 1) => S('Input.dispatchMouseEvent', {
+  type, x, y, button: 'left', buttons: type === 'mouseReleased' ? 0 : 1, clickCount,
+});
+const realClick = async (x, y, clickCount = 1) => {
+  await mouse('mousePressed', x, y, clickCount);
+  await mouse('mouseReleased', x, y, clickCount);
+};
+const selectionText = () => evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  return String(doc.getSelection());
+})()`);
+const clearSelection = () => evalIn(`(() => {
+  document.querySelector('foliate-view').renderer.getContents()[0]
+    .doc.getSelection().removeAllRanges();
+  return true;
+})()`);
+// Two points in the page-turning ribbon on the right: one on a word,
+// which a double-click could be selecting, and one in the blank between
+// lines, which it cannot. The reader treats them differently on
+// purpose, so the harness has to find both for real.
+const ribbonPoints = async () => JSON.parse(await evalIn(`(() => {
+  const view = document.querySelector('foliate-view');
+  const doc = view.renderer.getContents()[0].doc;
+  const win = doc.defaultView;
+  const box = win.frameElement.getBoundingClientRect();
+  const w = window.innerWidth, h = window.innerHeight;
+  const side = Math.max(64, Math.min(w * (w < 700 ? 0.3 : 0.22), 260));
+  // The page-turn arrows are real buttons sitting in this same ribbon,
+  // and a real pointer reveals them as it moves. A point behind one of
+  // them would test the button, not the tap zones.
+  const arrows = [...document.querySelectorAll('.reader-turn')]
+    .map((b) => b.getBoundingClientRect());
+  const behindAnArrow = (top, bottom, left, right) => arrows.some((a) =>
+    bottom > a.top - 8 && top < a.bottom + 8 && right > a.left - 8 && left < a.right + 8);
+  const lines = [];
+  const walk = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+  for (let n = walk.nextNode(); n; n = walk.nextNode()) {
+    if (!n.data.trim()) continue;
+    const r = doc.createRange();
+    r.selectNodeContents(n);
+    for (const rect of r.getClientRects()) {
+      if (rect.width < 4 || rect.height < 4) continue;
+      const left = rect.left + box.left, right = rect.right + box.left;
+      const top = rect.top + box.top, bottom = rect.bottom + box.top;
+      // Needs room for a click that is both inside the ribbon and
+      // inside a word rather than past the last glyph.
+      if (right < w - side + 40 || left > w) continue;
+      if (top < 0 || bottom > h) continue;          // not on this page
+      if (behindAnArrow(top, bottom, left, right)) continue;
+      lines.push({ left, right, top, bottom });
+    }
+  }
+  lines.sort((a, b) => a.top - b.top);
+  const word = lines[Math.floor(lines.length / 2)];
+  // Somewhere in the ribbon with no word under it and no button over
+  // it: between two lines, in a paragraph margin, or past the last one.
+  const all = [];
+  const everything = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+  for (let n = everything.nextNode(); n; n = everything.nextNode()) {
+    if (!n.data.trim()) continue;
+    const r = doc.createRange();
+    r.selectNodeContents(n);
+    for (const rect of r.getClientRects()) {
+      if (rect.width < 4 || rect.height < 4) continue;
+      all.push({
+        top: rect.top + box.top, bottom: rect.bottom + box.top,
+        left: rect.left + box.left, right: rect.right + box.left,
+      });
+    }
+  }
+  // The arrows are full-height strips at both edges, so a point in the
+  // ribbon has to sit inboard of them.
+  const arrowEdge = arrows.length
+    ? Math.min(...arrows.filter((a) => a.left > w / 2).map((a) => a.left)) - 10
+    : w - 6;
+  const bx = Math.max(w - side + 8, Math.min(arrowEdge, w - 8));
+  let blank = null;
+  for (let y = 40; y < h - 40 && !blank; y += 8) {
+    if (behindAnArrow(y, y, bx, bx)) continue;
+    if (all.some((r) => y > r.top - 3 && y < r.bottom + 3 && bx > r.left - 3 && bx < r.right + 3))
+      continue;
+    blank = { x: bx, y };
+  }
+  return JSON.stringify({
+    frame: { left: box.left, right: box.right, width: box.width },
+    window: w,
+    lines: lines.length,
+    word: word ? {
+      x: Math.max(Math.min(word.right - 14, w - 8), w - side + 4),
+      y: (word.top + word.bottom) / 2,
+    } : null,
+    blank,
+  });
+})()`));
+
+await idle();
+const spots = await ribbonPoints();
+check('the harness found real text in the page-turning ribbon',
+  spots.lines > 0 && !!spots.word, JSON.stringify(spots));
+
+if (spots.word) {
+  // A real double-click selects a word. The first of its two clicks is
+  // indistinguishable from a tap when it arrives, so this is the case
+  // the deferral exists for — and 350ms apart it is slower than a
+  // synthetic pair, which is the point of testing it for real.
+  const before = JSON.parse(await evalIn(probe));
+  await realClick(spots.word.x, spots.word.y, 1);
+  await new Promise((r) => setTimeout(r, 350));
+  await realClick(spots.word.x, spots.word.y, 2);
+  const picked = await selectionText();
+  await settle();
+  const afterReal = JSON.parse(await evalIn(probe));
+  // What is asserted is the reader's part: the deferred first click was
+  // cancelled, so the pair selected rather than navigated. Whether the
+  // browser also left a word highlighted is the browser's business, and
+  // a headless build does not always bother.
+  check('a real double-click does not turn the page',
+    afterReal.fraction === before.fraction,
+    `${before.fraction} -> ${afterReal.fraction}, selected ${JSON.stringify(picked.slice(0, 20))}`);
+  await clearSelection();
+
+  // A real drag is a selection, never a page turn.
+  await mouse('mousePressed', spots.word.x, spots.word.y, 1);
+  await mouse('mouseMoved', spots.word.x - 120, spots.word.y, 1);
+  await mouse('mouseReleased', spots.word.x - 120, spots.word.y, 1);
+  const dragged = await selectionText();
+  await settle();
+  const afterRealDrag = JSON.parse(await evalIn(probe));
+  check('a real drag across the text does not turn the page',
+    afterRealDrag.fraction === before.fraction,
+    `${before.fraction} -> ${afterRealDrag.fraction}, selected ${JSON.stringify(dragged.slice(0, 20))}`);
+  await clearSelection();
+
+  // A single real click on a word still turns, once the double-click
+  // window has passed.
+  await realClick(spots.word.x, spots.word.y, 1);
+  await settle();
+  const afterRealClick = JSON.parse(await evalIn(probe));
+  check('a real click on a word still turns the page',
+    afterRealClick.fraction > before.fraction,
+    `${before.fraction} -> ${afterRealClick.fraction}`);
+  await realClick(6, spots.word.y, 1);
+  await settle();
+}
+
+if (spots.blank) {
+  // Nothing to select here, so nothing to wait for: the page turns
+  // well inside the double-click window.
+  const before = JSON.parse(await evalIn(probe));
+  await realClick(spots.blank.x, spots.blank.y, 1);
+  await new Promise((r) => setTimeout(r, 250));
+  const quick = JSON.parse(await evalIn(probe));
+  check('a real click between the lines turns the page at once',
+    quick.fraction > before.fraction, `${before.fraction} -> ${quick.fraction}`);
+  await settle();
+  await realClick(6, spots.blank.y, 1);
+  await settle();
+} else {
+  console.log('note: no blank gap found in the ribbon on this page');
+}
+
+// A finger is the engine's business as much as ours: foliate-js pans
+// and snaps on a swipe. If both it and the reader acted on the same
+// gesture the book would jump two pages, so the measure here is one
+// page's worth of progress, taken from a page turn immediately before.
+const innerWidthGuess = Number(await evalIn('window.innerWidth'));
+const innerHeightGuess = Number(await evalIn('window.innerHeight'));
+const beforeStep = JSON.parse(await evalIn(probe));await evalIn(`document.getElementById('reader-next').click()`);
+await settle();
+const afterStep = JSON.parse(await evalIn(probe));
+const pageStep = afterStep.fraction - beforeStep.fraction;
+await evalIn(`document.getElementById('reader-prev').click()`);
+await settle();
+
+const touchable = await S('Input.dispatchTouchEvent', {
+  type: 'touchStart', touchPoints: [{ x: Math.round(innerWidthGuess * 0.7), y: 200 }],
+}).then(() => true, () => false);
+if (touchable) {
+  await S('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  const beforeSwipe = JSON.parse(await evalIn(probe));
+  const y = Math.round(spots.word ? spots.word.y : innerHeightGuess / 2);
+  const from = Math.round(innerWidthGuess * 0.75);
+  await S('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x: from, y }] });
+  for (const step of [0.2, 0.4, 0.6, 0.8, 1]) {
+    await S('Input.dispatchTouchEvent', {
+      type: 'touchMove', touchPoints: [{ x: Math.round(from - 300 * step), y }],
+    });
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  await S('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  await settle();
+  const afterSwipe = JSON.parse(await evalIn(probe));
+  const moved = afterSwipe.fraction - beforeSwipe.fraction;
+  check('a swipe never turns more than one page',
+    pageStep > 0 && moved <= pageStep * 1.6 + 1e-9,
+    `${beforeSwipe.fraction} -> ${afterSwipe.fraction} (one page is ${pageStep.toFixed(4)})`);
+
+  // A tap has no gesture to disambiguate from, so it must not wait.
+  const beforeTouchTap = JSON.parse(await evalIn(probe));
+  await S('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x: Math.round(spots.word ? spots.word.x : innerWidthGuess - 6), y }],
+  });
+  await S('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+  await new Promise((r) => setTimeout(r, 250));
+  const afterTouchTap = JSON.parse(await evalIn(probe));
+  check('a real touch tap turns the page without waiting',
+    afterTouchTap.fraction > beforeTouchTap.fraction,
+    `${beforeTouchTap.fraction} -> ${afterTouchTap.fraction}`);
+  await settle();
+} else {
+  console.log('note: this browser build refused synthetic touch events');
+}
+
+// A second finger is a pinch or a scroll, never a page turn, and a
+// pointer the browser takes back mid-gesture is not one either.
+await idle();
+const beforeFingers = JSON.parse(await evalIn(probe));
+await evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  const win = doc.defaultView;
+  const box = win.frameElement.getBoundingClientRect();
+  const x = window.innerWidth - 6 - box.left, y = window.innerHeight / 2 - box.top;
+  const at = (type, id, extra) => doc.body.dispatchEvent(new win.PointerEvent(type, {
+    bubbles: true, button: 0, pointerType: 'touch', pointerId: id,
+    clientX: x, clientY: y, ...extra,
+  }));
+  at('pointerdown', 1);
+  at('pointerdown', 2, { clientX: x - 60 });
+  at('pointerup', 1);
+  at('pointerup', 2, { clientX: x - 60 });
+  return true;
+})()`);
+await settle();
+const afterFingers = JSON.parse(await evalIn(probe));
+check('a second finger cancels the tap',
+  afterFingers.fraction === beforeFingers.fraction,
+  `${beforeFingers.fraction} -> ${afterFingers.fraction}`);
+
+await evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  const win = doc.defaultView;
+  const box = win.frameElement.getBoundingClientRect();
+  const x = window.innerWidth - 6 - box.left, y = window.innerHeight / 2 - box.top;
+  const at = (type) => doc.body.dispatchEvent(new win.PointerEvent(type, {
+    bubbles: true, button: 0, pointerType: 'touch', pointerId: 7, clientX: x, clientY: y,
+  }));
+  at('pointerdown');
+  at('pointercancel');
+  at('pointerup');
+  return true;
+})()`);
+await settle();
+const afterCancel = JSON.parse(await evalIn(probe));
+check('a cancelled pointer turns nothing',
+  afterCancel.fraction === beforeFingers.fraction,
+  `${beforeFingers.fraction} -> ${afterCancel.fraction}`);
+
+// A click that puts a selection away is not a tap — and by the time it
+// arrives the browser has already collapsed the selection, so the only
+// place the evidence still exists is the pointerdown before it.
+// A few words on the page this reader is looking at, not the whole
+// body: a selection running past the end of the page makes the engine
+// itself follow it forward, which would prove nothing about taps.
+const live = Number(await evalIn(`(() => {
+  const view = document.querySelector('foliate-view');
+  const doc = view.renderer.getContents()[0].doc;
+  const box = doc.defaultView.frameElement.getBoundingClientRect();
+  const walk = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
+  for (let n = walk.nextNode(); n; n = walk.nextNode()) {
+    if (n.data.trim().length < 12) continue;
+    const range = doc.createRange();
+    range.setStart(n, 0);
+    range.setEnd(n, 10);
+    const rect = range.getBoundingClientRect();
+    if (rect.top + box.top < 0 || rect.bottom + box.top > window.innerHeight) continue;
+    const left = rect.left + box.left;
+    if (left < 0 || left > window.innerWidth) continue;
+    const sel = doc.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    return String(sel).length;
+  }
+  return 0;
+})()`));
+await realClick(spots.word.x, spots.word.y, 1);
+await settle();
+const afterClearing = JSON.parse(await evalIn(probe));
+check('a real click that clears a selection turns nothing',
+  live > 0 && afterClearing.fraction === beforeFingers.fraction,
+  `${live} characters selected, ${beforeFingers.fraction} -> ${afterClearing.fraction}`);
+await clearSelection();
+
+// A fixed-layout publication is scaled by the engine with a CSS
+// transform, so a coordinate inside the chapter is not a coordinate in
+// the window. Scaling the frame by hand proves the conversion without
+// needing a second book: the same viewport point must still be the
+// page-turning ribbon.
+// Turning a page scrolls the frame under the window, so the local
+// coordinates are taken fresh for every tap rather than once.
+const scaledLocal = async (share) => JSON.parse(await evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  const frame = doc.defaultView.frameElement;
+  frame.style.transformOrigin = 'top left';
+  frame.style.transform = 'scale(0.8)';
+  const box = frame.getBoundingClientRect();
+  const vx = ${'SHARE'} === 1 ? window.innerWidth - 6 : window.innerWidth * ${'SHARE'};
+  const vy = window.innerHeight / 2;
+  return JSON.stringify({
+    scale: box.width / frame.offsetWidth,
+    x: (vx - box.left) / 0.8,
+    y: (vy - box.top) / 0.8,
+  });
+})()`.replaceAll('SHARE', String(share))));
+const scaledTap = (x, y) => evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  const win = doc.defaultView;
+  const at = (type) => doc.body.dispatchEvent(new win.PointerEvent(type, {
+    bubbles: true, button: 0, pointerType: 'touch', pointerId: 3,
+    clientX: ${x}, clientY: ${y},
+  }));
+  at('pointerdown');
+  at('pointerup');
+  return true;
+})()`);
+const beforeScaled = JSON.parse(await evalIn(probe));
+const rightSpot = await scaledLocal(1);
+check("the frame reports the engine's scale",
+  Math.abs(rightSpot.scale - 0.8) < 0.01, String(rightSpot.scale));
+await scaledTap(rightSpot.x, rightSpot.y);
+await settle();
+const afterScaledRight = JSON.parse(await evalIn(probe));
+check('a tap in a scaled chapter lands where the reader aimed it',
+  afterScaledRight.fraction > beforeScaled.fraction,
+  `${beforeScaled.fraction} -> ${afterScaledRight.fraction}`);
+const middleSpot = await scaledLocal(0.5);
+await scaledTap(middleSpot.x, middleSpot.y);
+await settle();
+const afterScaledMiddle = JSON.parse(await evalIn(probe));
+check('the middle of a scaled chapter is still the middle',
+  afterScaledMiddle.fraction === afterScaledRight.fraction,
+  `${afterScaledRight.fraction} -> ${afterScaledMiddle.fraction}`);
+await evalIn(`(() => {
+  const frame = document.querySelector('foliate-view').renderer
+    .getContents()[0].doc.defaultView.frameElement;
+  frame.style.transform = '';
+  return true;
+})()`);
+
+// The contents drawer cannot hear a tap that happened inside the book,
+// so the book has to tell it.
+await evalIn(`(() => {
+  document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 't', bubbles: true }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
+const beforeDrawerTap = JSON.parse(await evalIn(probe));
+await tapChapter('right', 'touch');
+await settle();
+const afterDrawerTap = JSON.parse(await evalIn(probe));
+const drawerShut = await evalIn(`document.getElementById('reader-toc').hidden`);
+check('a tap in the book puts the contents drawer away', drawerShut === true,
+  String(drawerShut));
+check('the tap that closed the drawer did not also turn the page',
+  afterDrawerTap.fraction === beforeDrawerTap.fraction,
+  `${beforeDrawerTap.fraction} -> ${afterDrawerTap.fraction}`);
+
+// "z" is the keyboard's way of putting the chrome away and getting it
+// back, and the contents drawer brings its own button back with it.
+await evalIn(`(() => {
+  document.dispatchEvent(new PointerEvent('pointermove', {
+    bubbles: true, clientX: window.innerWidth / 2, clientY: 4,
+  }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
+await evalIn(`(() => {
+  document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', bubbles: true }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
+const zHidden = JSON.parse(await chromeState());
+await evalIn(`(() => {
+  document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', bubbles: true }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
+const zShown = JSON.parse(await chromeState());
+check('"z" puts the chrome away', zHidden.state === 'hidden', JSON.stringify(zHidden));
+check('"z" brings it back and pins it', zShown.state === 'visible' && zShown.bar === '1',
+  JSON.stringify(zShown));
+await evalIn(`(() => {
+  document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', bubbles: true }));
+  document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 't', bubbles: true }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
+const withDrawer = JSON.parse(await chromeState());
+check('the contents drawer brings the bar back with it',
+  withDrawer.state === 'visible' && withDrawer.bar === '1', JSON.stringify(withDrawer));
+await evalIn(`(() => {
+  document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+  return true;
+})()`);
+
+// Switching the setting off is what a reader who wants the bar there
+// does, and it has to stick.
+await evalIn(`(() => {
+  const box = document.querySelector('#reader-settings-form input[name="autohide"]');
+  box.checked = false;
+  box.dispatchEvent(new Event('input', { bubbles: true }));
+  return true;
+})()`);
+await idle();
+const pinned = JSON.parse(await chromeState());
+const savedChrome = await evalIn(`localStorage.getItem('liseur.reader.settings')`);
+check('the chrome stays put once auto-hiding is switched off',
+  pinned.state === 'visible' && pinned.bar === '1', JSON.stringify(pinned));
+check('the auto-hide choice persists in the browser',
+  typeof savedChrome === 'string' && savedChrome.includes('"autohide":false'),
+  String(savedChrome));
+
 // The browser refusing to run the publication's script is verified by
 // confirming the script did not run and no unexpected errors occurred.
 const unexpected = consoleErrors.filter((e) =>

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -1067,6 +1067,18 @@ check('the chrome stays put once auto-hiding is switched off',
 check('the auto-hide choice persists in the browser',
   typeof savedChrome === 'string' && savedChrome.includes('"autohide":false'),
   String(savedChrome));
+await tapChapter('middle', 'touch');
+await new Promise((r) => setTimeout(r, 500));
+const manuallyHidden = JSON.parse(await chromeState());
+check('a middle tap can still hide fixed chrome',
+  manuallyHidden.state === 'hidden' && manuallyHidden.bar === '0',
+  JSON.stringify(manuallyHidden));
+await tapChapter('middle', 'touch');
+await new Promise((r) => setTimeout(r, 500));
+const manuallyShown = JSON.parse(await chromeState());
+check('a second middle tap restores fixed chrome',
+  manuallyShown.state === 'visible' && manuallyShown.bar === '1',
+  JSON.stringify(manuallyShown));
 
 // The browser refusing to run the publication's script is verified by
 // confirming the script did not run and no unexpected errors occurred.

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -644,7 +644,16 @@ const ribbonPoints = async () => JSON.parse(await evalIn(`(() => {
     .map((b) => b.getBoundingClientRect());
   const behindAnArrow = (top, bottom, left, right) => arrows.some((a) =>
     bottom > a.top - 8 && top < a.bottom + 8 && right > a.left - 8 && left < a.right + 8);
-  const lines = [];
+  const leftLines = [];
+  const rightLines = [];
+  const leftWords = [];
+  const rightWords = [];
+  const addRect = (target, rect) => {
+    const left = rect.left + box.left, right = rect.right + box.left;
+    const top = rect.top + box.top, bottom = rect.bottom + box.top;
+    if (top < 0 || bottom > h || behindAnArrow(top, bottom, left, right)) return;
+    target.push({ left, right, top, bottom });
+  };
   const walk = doc.createTreeWalker(doc.body, NodeFilter.SHOW_TEXT);
   for (let n = walk.nextNode(); n; n = walk.nextNode()) {
     if (!n.data.trim()) continue;
@@ -653,17 +662,39 @@ const ribbonPoints = async () => JSON.parse(await evalIn(`(() => {
     for (const rect of r.getClientRects()) {
       if (rect.width < 4 || rect.height < 4) continue;
       const left = rect.left + box.left, right = rect.right + box.left;
-      const top = rect.top + box.top, bottom = rect.bottom + box.top;
-      // Needs room for a click that is both inside the ribbon and
-      // inside a word rather than past the last glyph.
-      if (right < w - side + 40 || left > w) continue;
-      if (top < 0 || bottom > h) continue;          // not on this page
-      if (behindAnArrow(top, bottom, left, right)) continue;
-      lines.push({ left, right, top, bottom });
+      if (right > 0 && left < side) addRect(leftLines, rect);
+      if (right > w - side && left < w) addRect(rightLines, rect);
+    }
+    const words = /\S+/g;
+    let match;
+    while ((match = words.exec(n.data))) {
+      const wordRange = doc.createRange();
+      wordRange.setStart(n, match.index);
+      wordRange.setEnd(n, match.index + match[0].length);
+      for (const rect of wordRange.getClientRects()) {
+        if (rect.width < 4 || rect.height < 4) continue;
+        const left = rect.left + box.left, right = rect.right + box.left;
+        if (right > 0 && left < side) addRect(leftWords, rect);
+        if (right > w - side && left < w) addRect(rightWords, rect);
+      }
     }
   }
-  lines.sort((a, b) => a.top - b.top);
-  const word = lines[Math.floor(lines.length / 2)];
+  const lines = [...rightLines, ...leftLines].sort((a, b) => a.top - b.top);
+  const edge = (rect, sideName) => ({
+    x: sideName === 'right'
+      ? (Math.max(rect.left, w - side + 4) + Math.min(rect.right, w - 8)) / 2
+      : (Math.max(rect.left, 8) + Math.min(rect.right, side - 4)) / 2,
+    y: (rect.top + rect.bottom) / 2,
+    side: sideName,
+  });
+  const wordRect = leftWords[Math.floor(leftWords.length / 2)] ||
+    leftLines[Math.floor(leftLines.length / 2)] ||
+    rightWords[Math.floor(rightWords.length / 2)] ||
+    rightLines[Math.floor(rightLines.length / 2)];
+  const wordSide = leftWords.length || leftLines.length ? 'left' : 'right';
+  const word = wordRect
+    ? edge(wordRect, wordSide)
+    : null;
   // Somewhere in the ribbon with no word under it and no button over
   // it: between two lines, in a paragraph margin, or past the last one.
   const all = [];
@@ -685,9 +716,14 @@ const ribbonPoints = async () => JSON.parse(await evalIn(`(() => {
   const arrowEdge = arrows.length
     ? Math.min(...arrows.filter((a) => a.left > w / 2).map((a) => a.left)) - 10
     : w - 6;
-  const bx = Math.max(w - side + 8, Math.min(arrowEdge, w - 8));
+  const readerRight = document.getElementById('reader-view')
+    .getBoundingClientRect().right;
+  const bx = Math.max(
+    w - side + 8,
+    Math.min(arrowEdge - 12, readerRight - 12, w - 8),
+  );
   let blank = null;
-  for (let y = 40; y < h - 40 && !blank; y += 8) {
+  for (let y = 80; y < h - 40 && !blank; y += 8) {
     if (behindAnArrow(y, y, bx, bx)) continue;
     if (all.some((r) => y > r.top - 3 && y < r.bottom + 3 && bx > r.left - 3 && bx < r.right + 3))
       continue;
@@ -697,10 +733,7 @@ const ribbonPoints = async () => JSON.parse(await evalIn(`(() => {
     frame: { left: box.left, right: box.right, width: box.width },
     window: w,
     lines: lines.length,
-    word: word ? {
-      x: Math.max(Math.min(word.right - 14, w - 8), w - side + 4),
-      y: (word.top + word.bottom) / 2,
-    } : null,
+    word,
     blank,
   });
 })()`));
@@ -748,10 +781,13 @@ if (spots.word) {
   await realClick(spots.word.x, spots.word.y, 1);
   await settle();
   const afterRealClick = JSON.parse(await evalIn(probe));
+  const wordDirection = spots.word.side === 'right' ? 1 : -1;
   check('a real click on a word still turns the page',
-    afterRealClick.fraction > before.fraction,
+    wordDirection > 0
+      ? afterRealClick.fraction > before.fraction
+      : afterRealClick.fraction < before.fraction,
     `${before.fraction} -> ${afterRealClick.fraction}`);
-  await realClick(6, spots.word.y, 1);
+  await realClick(wordDirection > 0 ? 6 : spots.window - 6, spots.word.y, 1);
   await settle();
 }
 
@@ -811,7 +847,7 @@ if (touchable) {
   const beforeTouchTap = JSON.parse(await evalIn(probe));
   await S('Input.dispatchTouchEvent', {
     type: 'touchStart',
-    touchPoints: [{ x: Math.round(spots.word ? spots.word.x : innerWidthGuess - 6), y }],
+    touchPoints: [{ x: Math.round(innerWidthGuess - 6), y }],
   });
   await S('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
   await new Promise((r) => setTimeout(r, 250));

--- a/internal/webui/testdata/readerfirefox.mjs
+++ b/internal/webui/testdata/readerfirefox.mjs
@@ -25,7 +25,7 @@ const at = (s) => { step = s; };
 setTimeout(() => {
   console.error('firefox harness stuck at: ' + step);
   process.exit(2);
-}, 90000);
+}, 120000);
 
 const profile = mkdtempSync(join(tmpdir(), 'ffsmoke-'));
 // Firefox will not resolve a made-up hostname, and unlike Chromium it
@@ -221,6 +221,92 @@ await new Promise((r) => setTimeout(r, 700));
 const unthemed = JSON.parse(await evalIn(probe));
 check('reset restores the publisher styling',
   unthemed.colour.replace(/\s/g, '') === 'rgb(17,34,51)', unthemed.colour);
+
+// A risk-focused slice of the Chromium chrome/tap matrix. Gecko is
+// where this can differ: frameElement coordinates, PointerEvent
+// delivery inside a blob chapter, `:has()` in the chrome CSS, and
+// caretPositionFromPoint standing in for Blink's caretRangeFromPoint
+// when the reader decides whether a click landed on a word.
+at('auto-hiding chrome');
+const chromeState = () => evalIn(`JSON.stringify({
+  state: document.body.dataset.readerChrome,
+  bar: getComputedStyle(document.querySelector('.reader-bar')).opacity,
+})`);
+const ffTap = (where, kind) => evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  const win = doc.defaultView;
+  const box = win.frameElement.getBoundingClientRect();
+  const xs = { left: 6, right: window.innerWidth - 6 };
+  const x = xs['${where}'] - box.left, y = window.innerHeight / 2 - box.top;
+  const at = (type, extra) => doc.body.dispatchEvent(new win.PointerEvent(type, {
+    bubbles: true, button: 0, pointerType: '${kind}', clientX: x, clientY: y, ...extra,
+  }));
+  at('pointerdown');
+  at('pointerup');
+  doc.body.dispatchEvent(new win.MouseEvent('click', {
+    bubbles: true, button: 0, detail: 1, clientX: x, clientY: y,
+  }));
+  return true;
+})()`);
+
+await new Promise((r) => setTimeout(r, 2600));
+const ffParked = JSON.parse(await chromeState());
+check('the chrome steps aside while reading',
+  ffParked.state === 'hidden' && ffParked.bar === '0', JSON.stringify(ffParked));
+
+await evalIn(`(() => {
+  document.dispatchEvent(new PointerEvent('pointermove', {
+    bubbles: true, clientX: window.innerWidth / 2, clientY: 4,
+  }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
+const ffReached = JSON.parse(await chromeState());
+check('reaching for the top of the window brings the chrome back',
+  ffReached.state === 'visible' && ffReached.bar === '1', JSON.stringify(ffReached));
+
+await new Promise((r) => setTimeout(r, 2600));
+const ffBefore = JSON.parse(await evalIn(probe));
+await ffTap('right', 'touch');
+await new Promise((r) => setTimeout(r, 900));
+const ffForward = JSON.parse(await evalIn(probe));
+check('a tap on the right of the text turns the page',
+  ffForward.fraction > ffBefore.fraction,
+  `${ffBefore.fraction} -> ${ffForward.fraction}`);
+
+// The mouse path is the one that has to ask Gecko where the caret is.
+await ffTap('right', 'mouse');
+await new Promise((r) => setTimeout(r, 1200));
+const ffMouse = JSON.parse(await evalIn(probe));
+check('a mouse click on the right of the text turns the page',
+  ffMouse.fraction > ffForward.fraction,
+  `${ffForward.fraction} -> ${ffMouse.fraction}`);
+
+await evalIn(`(() => {
+  const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
+  doc.getSelection().selectAllChildren(doc.body);
+  const box = doc.defaultView.frameElement.getBoundingClientRect();
+  doc.body.dispatchEvent(new MouseEvent('click', {
+    bubbles: true, button: 0, detail: 1,
+    clientX: window.innerWidth - 6 - box.left,
+    clientY: window.innerHeight / 2 - box.top,
+  }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 1200));
+const ffSelected = JSON.parse(await evalIn(probe));
+check('a click while text is selected is not a page turn',
+  ffSelected.fraction === ffMouse.fraction,
+  `${ffMouse.fraction} -> ${ffSelected.fraction}`);
+await evalIn(`(() => {
+  document.querySelector('foliate-view').renderer.getContents()[0]
+    .doc.getSelection().removeAllRanges();
+  document.getElementById('reader-settings-form').autohide.checked = false;
+  document.getElementById('reader-settings-form').autohide
+    .dispatchEvent(new Event('input', { bubbles: true }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
 
 // The same hostile battery as the Chromium harness, judged by Firefox.
 at('hostile chapter');

--- a/scripts/screenshots.sh
+++ b/scripts/screenshots.sh
@@ -262,10 +262,12 @@ READER=${BOOK_IDS[0]}
 # once the engine has a rendered chapter to show — in the dark theme,
 # which is a browser-local preference rather than something the server
 # knows, and clipped to the window, because a full-page capture resizes
-# the frame the book is in and gets a white rectangle. Everything else
-# is ready when the page is.
+# the frame the book is in and gets a white rectangle. Auto-hiding is
+# switched off in the same breath: the bar steps aside after a couple of
+# idle seconds, and a photograph of the reader with no bar in it says
+# nothing about the reader. Everything else is ready when the page is.
 WAIT=$'\n\n'"document.querySelector('foliate-view')?.renderer?.getContents?.()[0]?.doc"$'\n\n'
-EVAL=$'\n\n'"(() => { const r = document.querySelector('#reader-settings-form input[name=\"theme\"][value=\"dark\"]'); r.checked = true; r.dispatchEvent(new Event('input', { bubbles: true })); return 'dark' })()"$'\n\n'
+EVAL=$'\n\n'"(() => { const r = document.querySelector('#reader-settings-form input[name=\"theme\"][value=\"dark\"]'); r.checked = true; r.dispatchEvent(new Event('input', { bubbles: true })); const a = document.querySelector('#reader-settings-form input[name=\"autohide\"]'); a.checked = false; a.dispatchEvent(new Event('input', { bubbles: true })); return 'dark' })()"$'\n\n'
 
 cd internal/webui
 SHOT_CHROME="$CHROME" \


### PR DESCRIPTION
What changed

Reader controls now hide while reading and return when the pointer reaches the top or the reader taps the page. Tapping the left or right edge turns pages even when controls are hidden. A new setting keeps the controls visible.

Why

The reader can offer an unobstructed page without leaving touch users without navigation.

Checks

- go test -race -timeout 300s ./internal/webui
- go vet ./...