### PR TITLE
feat: Count reading sessions in the web reader

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -326,7 +326,9 @@ form an inferred session with `origin: "inferred"`, always
 distinguishable from measured ones and excluded from speed statistics by
 default. Better than nothing, honest about being so. KOReader's
 statistics plugin, where installed, reports measured sessions via the
-koplugin adapter instead.
+koplugin adapter instead. The web reader measures its own
+([ADR-0030](adr/0030-web-reader-reading-sessions.md)): a sitting bounded
+by the tab's visibility, with a three-minute idle cap per page.
 
 ## 7. Legacy adapters
 

--- a/docs/adr/0007-web-reader.md
+++ b/docs/adr/0007-web-reader.md
@@ -225,7 +225,9 @@ additions rather than migrations.
 
 The reader uses `/v1/ops`, `/v1/changes` and `/v1/sessions` exactly as the
 Android and desktop clients do. It is not given privileged access and
-gets no new sync surface.
+gets no new sync surface. (What a sitting is in a browser — when it
+opens, when it closes, what counts as idle — is decided in
+[ADR-0030](0030-web-reader-reading-sessions.md).)
 
 Its credential is minted from the web session it is already running
 under: a cookie-authenticated, CSRF-protected endpoint returns a token

--- a/docs/adr/0030-web-reader-reading-sessions.md
+++ b/docs/adr/0030-web-reader-reading-sessions.md
@@ -1,0 +1,119 @@
+# ADR-0030: The web reader counts its sittings
+
+- **Status:** Accepted; implemented
+- **Date:** 2026-09-03
+- **Amends:** [ADR-0007](0007-web-reader.md), which said the reader
+  uses `/v1/sessions` "exactly as the Android and desktop clients do"
+  and, until this decision, did not
+
+## Context
+
+Reading statistics are computed from `sessions` rows and their daily
+rollups (design §6). A position pushed to `/v1/ops` moves "Continue
+reading" and nothing else. The web reader pushed positions only, so an
+evening spent reading in a browser advanced the book and added zero
+minutes, zero sessions and no day to a streak — a dashboard that
+quietly disagreed with the reader who had just used it.
+
+ADR-0007 already lists `/v1/sessions` among the routes the reader uses.
+The server side was in place: the route exists, validates the payload
+(progressions in `[0,1]`, `ended_at ≥ started_at`, `idle_ms` no longer
+than the span), and the reader's short-lived token carries the `sync`
+scope it needs. What was missing was the client deciding what a
+sitting is in a browser.
+
+A browser is not a phone. There is no foreground/background callback
+pair; there is `visibilitychange`, `pagehide` and `beforeunload`, of
+which only the first is reliable on mobile. There is no local database
+to hold an unsent session across a crash. And there is no way to tell
+a difficult page from a tab left open all night behind another one.
+
+## Decision
+
+The reader records a session per sitting, with these rules. The
+arithmetic lives in one pure module (`static/reader-session.js`) with
+no DOM and no network in it, so the rules are tested by stating a
+sequence of moments and reading off the answer.
+
+**A sitting is bounded by visibility.** It opens once the book is on
+screen with a work resolved and a position measured, and it closes —
+and is sent — when the document becomes hidden, on `pagehide`, or on
+`beforeunload`, whichever comes first; the later events find it already
+closed and do nothing. Coming back to a visible tab opens a new sitting.
+This is what Android does: leaving the foreground finishes a session,
+and returning starts one.
+
+**Idle is a cap, not a timer.** A key, a tap or a scroll is activity.
+A gap between two moments of activity — or between the last one and the
+close — longer than **three minutes** credits three minutes of reading
+and counts the rest as idle. KOReader's statistics cap a page's time the
+same way. Computed from the sequence of moments, it needs no timer and
+cannot drift while a tab is throttled.
+
+A relocate is not activity. The engine relocates on a resize or a font
+change as readily as on a page turn, so an untouched page would earn
+another three minutes for every layout pass. A relocate updates where
+the sitting is; only input says somebody was there.
+
+**Two clocks, as on Android.** The bounds are wall-clock Dates because
+that is what the server files a sitting under. Reading time is counted
+on `performance.now()`. The server derives active time as the span less
+`idle_ms`, so `idle_ms` is sent as the span less the monotonic reading
+time — the same arithmetic as the Android client's `finish` — and a
+laptop correcting its clock by an hour mid-book puts that hour in idle,
+not in reading. Clamped to `[0, span]` because the server refuses
+anything else.
+
+**A sitting under ten seconds of reading is not sent.** A mis-click
+that opened a book is not a session. Idle time does not count towards
+the ten seconds.
+
+**Progressions are what was measured.** `start_progression` is the
+first finite fraction seen in the sitting, `end_progression` the last;
+a non-finite fraction is never a progression (the same guard as the
+position-jumps fix), and a sitting that never measured one is not sent.
+
+**The payload is built once and replayed byte for byte.** The session
+id is drawn when the sitting opens; the payload is built at close and
+kept until the server confirms it, exactly as the reader already does
+for a position op. A `2xx` or a `409` (the id already names this
+sitting) settles it; any other `4xx` — an unknown work, say — is dropped,
+because replaying the same refused payload cannot help; a server error
+or no answer leaves it to be replayed on the next activity or close. The
+request is sent with `keepalive` so the close that unloads the page
+still delivers.
+
+**Nothing is persisted locally.** A tab that crashes, or whose final
+request is lost, loses that sitting. The Android client keeps an open
+session in its database and closes it at the last checkpoint on the next
+launch; the browser has nowhere as trustworthy to do that, and a stored
+half-sitting replayed from `localStorage` a week later would be a guess
+wearing a timestamp. This is a known, bounded loss and can be revisited.
+
+`edition_sha` is omitted: the reader resolves a work, not an edition,
+and the server treats the field as optional.
+
+## Consequences
+
+- Reading in the browser now counts. Minutes, sessions, streak days and
+  pace on the dashboard and under `/v1/insights` include it, with
+  `origin: native` and the browser's stable device identity.
+- The sessions figure rises with every tab switch, because each
+  visible stretch is one sitting. Android behaves the same way.
+- `idle_ms` is an estimate with a three-minute floor per page, as
+  KOReader's is. A reader who genuinely spends ten minutes on a page is
+  credited three. That is the trade the cap makes on purpose.
+- A reader who turns pages only through a relocate the page cannot see
+  as input — a browser extension scrolling for them, say — is credited
+  three minutes per sitting. Every page turn the reader itself offers
+  is a key, a tap or a scroll, so this is an edge, not a path.
+- Pages stay at zero for a reflowable book read this way unless the
+  edition has a page count, per the rule that page numbers are never
+  fabricated.
+- A crashed tab loses its sitting. Position is unaffected: it was pushed
+  on every page turn.
+- Testing: the pure module has node unit tests that run in CI without a
+  browser (`TestReaderSessionAccounting`); the wiring is proved in a
+  real Chromium by `TestReaderRecordsReadingSessions`, which winds both
+  clocks forward, fakes the document's visibility, and reads the rows
+  back from the store.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,6 +54,7 @@ loose ends that must come before any of it, are in
 | [0027](0027-explicit-per-user-folder-access.md) | Explicit per-user folder access | MVP | Accepted; implemented | Folder grants across storage, catalog surfaces, administration and CLI; amends [0017](0017-folders-not-pipelines.md) |
 | [0028](0028-annotation-sync.md) | Annotations are mutable reading state, not history | Later | Accepted | Phase 1: the `annotations` table, second per-user counter and store methods in both backends, with the storetest suite |
 | [0029](0029-a-folder-somebody-can-read.md) | A folder somebody can read | MVP | Accepted; implemented | Creator grant in the folder's own transaction, guarded backfill migration 6, a Library page that names which situation it is in; amends [0027](0027-explicit-per-user-folder-access.md) |
+| [0030](0030-web-reader-reading-sessions.md) | The web reader counts its sittings | Later | Accepted; implemented | Visibility-bounded sittings, three-minute idle cap, ten-second minimum, no local persistence; amends [0007](0007-web-reader.md) |
 
 ## Convention
 

--- a/internal/webui/readerbrowser_ext_test.go
+++ b/internal/webui/readerbrowser_ext_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -550,5 +551,68 @@ func TestReaderRefusesANaNPositionButRecovers(t *testing.T) {
 	}
 	if !recovered {
 		t.Error("the finite position pushed after the NaN never reached the op log")
+	}
+}
+
+// TestReaderRecordsReadingSessions is the browser side of ADR-0030: a
+// sitting in the web reader reaches /v1/sessions, and so the statistics,
+// which until then counted only what KOReader and the apps reported.
+// The page is driven with a wound-forward clock and a faked visibility
+// (testdata/readerbrowser.mjs, sessionGuard), and the rows are then read
+// back from the store, because the probe can only see the attempt.
+func TestReaderRecordsReadingSessions(t *testing.T) {
+	chrome := findChrome()
+	if chrome == "" {
+		t.Skip("no chromium; set LISEUR_CHROME to run the browser check")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("no node to drive the browser with")
+	}
+
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "novel", browserTestEPUB(t))
+
+	ts := httptest.NewUnstartedServer(nil)
+	wholeServer(t, f, ts, "")
+	cookie := f.loginTo(t, ts, "alice")
+
+	cmd := exec.Command(node, filepath.Join("testdata", "readerbrowser.mjs"))
+	cmd.Env = append(os.Environ(),
+		"SMOKE_CHROME="+chrome,
+		"SMOKE_URL="+ts.URL+"/ui/books/"+bookID+"/read",
+		"SMOKE_COOKIE="+cookie.Name+"="+cookie.Value,
+		"SMOKE_HOST="+strings.TrimPrefix(ts.URL, "http://"),
+		"SMOKE_SESSIONS=1",
+		"SMOKE_SHOT=",
+	)
+	out, err := cmd.CombinedOutput()
+	t.Logf("%s", out)
+	if err != nil {
+		t.Fatalf("the reader did not record its sittings: %v", err)
+	}
+
+	// Two sittings were closed with something to say and one was a
+	// glance; the store must hold exactly the two, with the figures the
+	// page computed rather than something the server made up.
+	rows, err := f.st.SessionsInRange(t.Context(), "u1",
+		time.Now().Add(-time.Hour), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("sessions in store: got %d, want 2", len(rows))
+	}
+	sort.Slice(rows, func(i, j int) bool { return rows[i].StartedAt.Before(rows[j].StartedAt) })
+	if rows[0].EndProg != 0.47 || rows[0].IdleMs != 0 {
+		t.Errorf("first sitting: end %v idle %d, want 0.47 and 0", rows[0].EndProg, rows[0].IdleMs)
+	}
+	if d := rows[1].IdleMs - 7*60*1000; d < -1000 || d > 1000 {
+		t.Errorf("second sitting: idle %d, want about 7 minutes", rows[1].IdleMs)
+	}
+	for _, s := range rows {
+		if s.Origin != store.OriginNative || s.DeviceID == "" {
+			t.Errorf("session %s: origin %q device %q", s.SessionID, s.Origin, s.DeviceID)
+		}
 	}
 }

--- a/internal/webui/readersession_ext_test.go
+++ b/internal/webui/readersession_ext_test.go
@@ -1,0 +1,28 @@
+package webui_test
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestReaderSessionAccounting runs the node unit tests for the reader's
+// session arithmetic (static/reader-session.js). The module has no DOM
+// and no fetch in it precisely so that its rules — the idle cap, the
+// minimum, the clamps — can be checked without a browser; this is the
+// one reader check that runs in CI.
+func TestReaderSessionAccounting(t *testing.T) {
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("no node to run the session tests with")
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, node, "--test", filepath.Join("testdata", "readersession.test.mjs"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("session accounting tests failed: %v\n%s", err, out)
+	}
+}

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -14,6 +14,7 @@
 
 import "./vendor/foliate/view.js";
 import { Overlayer } from "./vendor/foliate/overlayer.js";
+import { openSession } from "./reader-session.js";
 
 const el = document.getElementById("reader-config");
 // Every URL is relative, computed server-side, so the reader keeps
@@ -228,6 +229,7 @@ function buildAnnotationList() {
       entry.href = "#";
       entry.addEventListener("click", (e) => {
         e.preventDefault();
+        noteActivity();
         toggleTOC(false);
         if (!view) return;
         const fall = () => {
@@ -484,12 +486,107 @@ function schedulePush() {
   pending = setTimeout(push, 1500);
 }
 
+// ------------------------------------------------------- sessions
+
+// A sitting (ADR-0030) is bounded the way Android bounds one: it opens
+// when the book is on screen with a position measured, and closes when
+// the tab is hidden or unloaded, which is the last moment a browser
+// reliably lets a page speak. Coming back opens a new one. The
+// arithmetic — idle cap, minimum, clamps — lives in reader-session.js.
+let session = null;
+// Closed sittings the server has not yet confirmed. Each is kept whole
+// and replayed byte for byte, like retryOp: the server compares
+// payloads under the session id, and a figure that moved between
+// attempts would be refused as a different session wearing the same
+// name.
+let unsent = [];
+
+function beginSession() {
+  if (session || !workID || document.hidden) return;
+  if (!here || !finite(here.fraction)) return;
+  session = openSession({
+    id: opID(),
+    workID: workID,
+    startedAt: new Date(),
+    now: performance.now(),
+    fraction: here.fraction,
+  });
+}
+
+function noteActivity() {
+  if (session) {
+    session.activity(performance.now(), here && here.fraction);
+  } else {
+    beginSession();
+  }
+  if (unsent.length) pushSession();
+}
+
+// noteProgress follows a relocate. It is not activity: the engine
+// relocates on a resize or a font change too, and only a key, a tap or
+// a scroll says somebody was there.
+function noteProgress() {
+  if (session) session.progress(here && here.fraction);
+  else beginSession();
+}
+
+function endSession() {
+  if (!session) return;
+  const payload = session.close(
+    performance.now(),
+    new Date(),
+    here && here.fraction,
+  );
+  session = null;
+  if (payload) unsent.push(payload);
+  pushSession(true);
+}
+
+let sessionInFlight = false;
+
+// pushSession sends every unconfirmed sitting in one batch. A retry
+// prodded by activity waits for the request already out; a close does
+// not, because the page may not be here when that one comes back, and
+// the server holds the same payload twice as once.
+async function pushSession(closing) {
+  if (!unsent.length || (sessionInFlight && !closing)) return;
+  const batch = unsent.slice();
+  sessionInFlight = true;
+  try {
+    const resp = await api("v1/sessions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      keepalive: true,
+      body: JSON.stringify({ sessions: batch }),
+    });
+    // 2xx: filed (re-posting the same payload is idempotently a 2xx too).
+    // 409: this session_id was already used with a *different* payload —
+    // a collision, not a repeat of this sitting — and replaying the same
+    // batch cannot fix that. Any other 4xx is a payload the server will
+    // refuse however often it is sent — an unknown work, say. Only a
+    // server error or no answer at all leaves the batch to try again.
+    if (resp.ok || (resp.status >= 400 && resp.status < 500)) {
+      unsent = unsent.filter((p) => !batch.includes(p));
+    }
+  } catch (err) {
+    /* offline: the next activity or close replays these exact sittings */
+  } finally {
+    sessionInFlight = false;
+  }
+}
+
 document.addEventListener("visibilitychange", () => {
-  if (!document.hidden && here && !finite(here.fraction)) {
+  if (document.hidden) {
+    endSession();
+    return;
+  }
+  beginSession();
+  if (here && !finite(here.fraction)) {
     fractionRetryAttempt = 0;
     scheduleFractionRetry();
   }
 });
+window.addEventListener("pagehide", endSession);
 
 function cfiOf(op) {
   const fragments =
@@ -1053,9 +1150,13 @@ function wireChapterPointer(doc) {
     },
     { passive: true },
   );
+  // A scroll is the one way to move through a book that is neither a
+  // key nor a tap, so it counts as activity for the sitting.
+  doc.addEventListener("wheel", noteActivity, { passive: true });
   doc.addEventListener(
     "pointerdown",
     (e) => {
+      noteActivity();
       if (gesture.id !== null && gesture.id !== e.pointerId) {
         gesture.spoiled = true; // a second finger: not a tap any more
         return;
@@ -1253,6 +1354,7 @@ tocList.addEventListener("click", (e) => {
   const a = e.target && e.target.closest && e.target.closest("a[data-href]");
   if (!a) return;
   e.preventDefault();
+  noteActivity();
   toggleTOC(false);
   if (view) view.goTo(a.dataset.href).catch(() => {});
 });
@@ -1380,6 +1482,7 @@ const spoilStage = (e) => {
 stageArea.addEventListener("pointercancel", spoilStage, { passive: true });
 stageArea.addEventListener("lostpointercapture", spoilStage, { passive: true });
 stageArea.addEventListener("pointerup", (e) => {
+  noteActivity();
   if (stageGesture.id !== null && stageGesture.id !== e.pointerId) {
     stageGesture.spoiled = true;
     return;
@@ -1419,6 +1522,7 @@ stageArea.addEventListener("click", (e) => {
 // alone goes deaf — the engine re-emits its load event per chapter, so
 // each document gets wired as it arrives.
 function handleKeys(e) {
+  noteActivity();
   const helpDialog = document.getElementById("reader-help");
   // Arrow keys inside the settings panel adjust its controls, not the
   // book; Escape puts the panel away from the keyboard.
@@ -1504,6 +1608,7 @@ document.addEventListener("keydown", handleKeys);
 window.addEventListener("beforeunload", () => {
   clearTimeout(pending);
   push();
+  endSession();
 });
 
 // ------------------------------------------------------------ open
@@ -1528,6 +1633,7 @@ window.addEventListener("beforeunload", () => {
       if (finite(e.detail.fraction)) {
         clearFractionRetry();
         schedulePush();
+        noteProgress();
       } else {
         cancelScheduledPush();
         scheduleFractionRetry();

--- a/internal/webui/static/reader-session.js
+++ b/internal/webui/static/reader-session.js
@@ -1,0 +1,105 @@
+// Reading-session accounting for the web reader (ADR-0030).
+//
+// A sitting is what POST /v1/sessions carries: when it began and ended,
+// where in the book it began and ended, and how much of that span was
+// not reading. This module works those out from a sequence of moments
+// and nothing else — no DOM, no fetch, no clock of its own — so the
+// rules can be tested by stating a sequence and reading off the answer.
+//
+// Two clocks are involved, as on Android. The bounds are wall-clock
+// Dates because that is what the server files a sitting under; the
+// arithmetic is done on a monotonic millisecond count the caller
+// supplies (performance.now), so a laptop correcting its clock mid-book
+// cannot add or remove reading time.
+
+// A gap between two moments of activity longer than this credits the
+// threshold and counts the rest as idle. KOReader's statistics cap a
+// page's time the same way: a clock cannot tell a difficult page from a
+// tab left open on the sofa, so past a point it stops guessing.
+export const IDLE_AFTER_MS = 3 * 60 * 1000;
+
+// A sitting with less reading than this is not sent. A mis-click that
+// opened a book is not a session.
+export const MIN_ACTIVE_MS = 10 * 1000;
+
+function finite(v) {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+function clamp01(v) {
+  return Math.max(0, Math.min(1, v));
+}
+
+// openSession begins a sitting. `id` is the idempotency key the server
+// compares payloads under; `now` is monotonic ms; `startedAt` is the
+// wall-clock Date; `fraction` may be non-finite, in which case the start
+// progression is the first finite one progress() or activity() reports.
+export function openSession({ id, workID, startedAt, now, fraction }) {
+  let last = now;
+  let idle = 0;
+  let startProg = finite(fraction) ? clamp01(fraction) : null;
+  let endProg = startProg;
+  let closed = null;
+
+  const settle = (at) => {
+    const gap = at - last;
+    if (gap > IDLE_AFTER_MS) idle += gap - IDLE_AFTER_MS;
+    if (gap > 0) last = at;
+  };
+  const note = (frac) => {
+    if (!finite(frac)) return;
+    const p = clamp01(frac);
+    if (startProg === null) startProg = p;
+    endProg = p;
+  };
+
+  return {
+    id,
+    // progress records where the reader is without treating it as
+    // activity. The engine relocates on a resize or a font change as
+    // readily as on a page turn, and an untouched page must not earn
+    // another three minutes for it.
+    progress(frac) {
+      if (closed) return;
+      note(frac);
+    },
+    // activity records a moment the reader did something: a key, a
+    // tap, a scroll. Ignored once closed.
+    activity(at, frac) {
+      if (closed) return;
+      settle(at);
+      note(frac);
+    },
+    // close ends the sitting and returns the payload to send, or null
+    // when there is nothing worth sending: too little reading, or no
+    // position ever measured. A second close returns null too, so two
+    // unload events cannot produce two sessions.
+    close(at, endedAt, frac) {
+      if (closed) return null;
+      settle(at);
+      note(frac);
+      closed = true;
+      const active = at - now - idle;
+      if (!(active >= MIN_ACTIVE_MS)) return null;
+      if (startProg === null) return null;
+      const started = startedAt.getTime();
+      const ended = Math.max(started, endedAt.getTime());
+      // The server works active time out as the span less idle_ms, so
+      // idle is what the wall clock saw beyond what the monotonic clock
+      // credited — as on Android — and a clock corrected mid-sitting
+      // lands in idle, not in reading. Bounded to the span because the
+      // server refuses anything else.
+      const span = ended - started;
+      const idleMs = Math.max(0, Math.min(Math.round(span - active), span));
+      return {
+        session_id: id,
+        work_id: workID,
+        started_at: new Date(started).toISOString(),
+        ended_at: new Date(ended).toISOString(),
+        start_progression: startProg,
+        end_progression: endProg,
+        idle_ms: idleMs,
+      };
+    },
+  };
+}

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -17,6 +17,9 @@ const withAnnotations = process.env.SMOKE_ANNOTATIONS === '1';
 // NaN-guard mode (the position-jumps fix): synthetic relocate events
 // with a NaN then a finite fraction, watching whether the reader pushes.
 const nan = process.env.SMOKE_NAN === '1';
+// Session mode (ADR-0030): hides and shows the tab with a skewed clock,
+// watching what the reader posts to /v1/sessions.
+const sessions = process.env.SMOKE_SESSIONS === '1';
 
 const profile = mkdtempSync(join(tmpdir(), 'smoke-'));
 const proc = spawn(chrome, [
@@ -113,6 +116,12 @@ check('page loads', typeof title === 'string' && title.length > 0, title);
 // page-turn and annotation battery below, so it runs and exits here.
 if (nan) {
   await nanGuard(evalIn, check);
+  ws.close();
+  proc.kill();
+  process.exit(fail.length ? 1 : 0);
+}
+if (sessions) {
+  await sessionGuard(evalIn, check);
   ws.close();
   proc.kill();
   process.exit(fail.length ? 1 : 0);
@@ -1169,4 +1178,115 @@ async function nanGuard(evalIn, check) {
     } catch (e) { /* leaves prog null, the check below reports it */ }
   }
   check('the recovered push carries the finite progression', prog === 0.47, String(prog));
+}
+
+// sessionGuard proves that reading in the browser is counted (ADR-0030).
+// The reader opens a sitting once a position is measured and closes it
+// when the tab goes away, so the probe stands in for the tab: it skews
+// performance.now to make minutes pass, turns a page, then says the
+// document is hidden. The observable thing is the POST to /v1/sessions;
+// the Go side then checks the row reached the store with the figures
+// the page said.
+async function sessionGuard(evalIn, check) {
+  await evalIn(`(() => {
+    window.__pushedSessions = [];
+    const orig = window.fetch;
+    window.fetch = function (input, init) {
+      const url = typeof input === 'string' ? input : (input && input.url) || '';
+      const method = ((init && init.method) || (input && input.method) || 'GET').toUpperCase();
+      if (method === 'POST' && url.indexOf('v1/sessions') >= 0) {
+        window.__pushedSessions.push(String((init && init.body) || ''));
+      }
+      return orig.apply(this, arguments);
+    };
+    // A clock the probe can wind forward, and a visibility the probe
+    // can set: the page consults both through the usual names.
+    const base = performance.now.bind(performance);
+    window.__skew = 0;
+    performance.now = () => base() + window.__skew;
+    // Both clocks move together, as they would in a real sitting; the
+    // server refuses idle past the wall-clock span, so winding only
+    // the monotonic one would be refused as a lie.
+    const RealDate = Date;
+    window.Date = class extends RealDate {
+      constructor(...args) {
+        if (args.length) super(...args);
+        else super(RealDate.now() + window.__skew);
+      }
+      static now() { return RealDate.now() + window.__skew; }
+    };
+    window.__hidden = false;
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => window.__hidden });
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => window.__hidden ? 'hidden' : 'visible' });
+    return true;
+  })()`);
+
+  const relocate = (frac) => `(() => {
+    document.querySelector('foliate-view').dispatchEvent(
+      new CustomEvent('relocate', { detail: {
+        fraction: ${frac},
+        cfi: 'epubcfi(/6/8!/4/2/1:0)',
+        section: { current: 1, total: 12 },
+        tocItem: { label: 'Chowder' },
+      } }));
+    return true;
+  })()`;
+  const setHidden = (hidden) => evalIn(`(() => {
+    window.__hidden = ${hidden};
+    document.dispatchEvent(new Event('visibilitychange'));
+    return true;
+  })()`);
+  const wind = (ms) => evalIn(`(() => { window.__skew += ${ms}; return true; })()`);
+  const pushed = async () =>
+    JSON.parse(await evalIn('JSON.stringify(window.__pushedSessions)')).flatMap((body) => {
+      try { return JSON.parse(body).sessions; } catch (e) { return []; }
+    });
+  const settle = () => new Promise((r) => setTimeout(r, 1500));
+
+  // The book opened with a real relocate, so a sitting is already open.
+  // Four minutes of reading with a TOC tap in the middle, then the tab
+  // is hidden. Past the three-minute cap without that tap, so a zero
+  // here proves navigation input resets the gap; the relocate alone
+  // must not, since the engine also relocates on a resize.
+  await wind(2 * 60000);
+  const tappedTOC = await evalIn(`(() => {
+    const link = document.querySelector('#reader-toc-list a[data-href]');
+    if (!link) return false;
+    link.click();
+    return true;
+  })()`);
+  check('the fixture has a TOC navigation tap', tappedTOC === true, String(tappedTOC));
+  await evalIn(relocate('0.47'));
+  await wind(2 * 60000);
+  await setHidden(true);
+  await settle();
+  let got = await pushed();
+  check('hiding the tab posts the sitting', got.length === 1, JSON.stringify(got));
+  const first = got[0] || {};
+  check('the sitting ends where the reader is', first.end_progression === 0.47, String(first.end_progression));
+  check('the sitting began before it ended',
+    typeof first.start_progression === 'number' && first.start_progression <= 0.47, String(first.start_progression));
+  check('a TOC tap resets the idle gap', first.idle_ms === 0, String(first.idle_ms));
+
+  // Back, and away again at once: too short to be a sitting.
+  await setHidden(false);
+  await setHidden(true);
+  await settle();
+  got = await pushed();
+  check('a glance is not a session', got.length === 1, JSON.stringify(got));
+
+  // Back for a long stare at one page: the threshold is credited and
+  // the rest is idle.
+  await setHidden(false);
+  await wind(10 * 60000);
+  await setHidden(true);
+  await settle();
+  got = await pushed();
+  check('a second sitting is a second session', got.length === 2, JSON.stringify(got));
+  const second = got[1] || {};
+  // Real milliseconds pass between the probe's steps, so within a second.
+  check('time past the idle threshold is idle',
+    Math.abs(second.idle_ms - 7 * 60000) < 1000, String(second.idle_ms));
+  check('the two sittings have distinct ids',
+    first.session_id && second.session_id && first.session_id !== second.session_id);
 }

--- a/internal/webui/testdata/readersession.test.mjs
+++ b/internal/webui/testdata/readersession.test.mjs
@@ -1,0 +1,158 @@
+// Unit tests for the reader's session accounting (reader-session.js).
+// Run by TestReaderSessionAccounting through `node --test`; no browser.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { openSession, IDLE_AFTER_MS, MIN_ACTIVE_MS } from '../static/reader-session.js';
+
+const MIN = 60 * 1000;
+const t0 = new Date('2026-09-04T10:00:00Z');
+const wall = (ms) => new Date(t0.getTime() + ms);
+const open = (fraction = 0.1, now = 1000) =>
+  openSession({ id: 's1', workID: 'w1', startedAt: t0, now, fraction });
+
+test('a page every minute is all reading', () => {
+  const s = open();
+  for (let m = 1; m <= 20; m++) s.activity(1000 + m * MIN, 0.1 + m * 0.01);
+  const out = s.close(1000 + 21 * MIN, wall(21 * MIN), 0.31);
+  assert.equal(out.idle_ms, 0);
+  assert.equal(out.start_progression, 0.1);
+  assert.equal(out.end_progression, 0.31);
+  assert.equal(out.started_at, t0.toISOString());
+  assert.equal(out.ended_at, wall(21 * MIN).toISOString());
+  assert.equal(out.session_id, 's1');
+  assert.equal(out.work_id, 'w1');
+});
+
+test('a long gap credits the threshold and counts the rest idle', () => {
+  const s = open();
+  s.activity(1000 + 1 * MIN, 0.11);
+  s.activity(1000 + 11 * MIN, 0.12); // ten minutes on one page
+  const out = s.close(1000 + 12 * MIN, wall(12 * MIN), 0.13);
+  assert.equal(out.idle_ms, 10 * MIN - IDLE_AFTER_MS);
+});
+
+test('silence before closing is idle past the threshold', () => {
+  const s = open();
+  s.activity(1000 + 1 * MIN, 0.11);
+  const out = s.close(1000 + 21 * MIN, wall(21 * MIN), 0.11);
+  assert.equal(out.idle_ms, 20 * MIN - IDLE_AFTER_MS);
+});
+
+test('a sitting under the minimum is not sent', () => {
+  const s = open();
+  s.activity(1000 + 3000, 0.2);
+  assert.equal(s.close(1000 + MIN_ACTIVE_MS - 1, wall(MIN_ACTIVE_MS - 1), 0.2), null);
+});
+
+test('a page left open is credited the threshold and no more', () => {
+  const s = open();
+  // Thirty minutes on screen with no page turned: one threshold of
+  // reading, the rest idle.
+  const out = s.close(1000 + 30 * MIN, wall(30 * MIN), 0.1);
+  assert.equal(out.idle_ms, 30 * MIN - IDLE_AFTER_MS);
+  const span = Date.parse(out.ended_at) - Date.parse(out.started_at);
+  assert.equal(span - out.idle_ms, IDLE_AFTER_MS);
+});
+
+test('a NaN fraction never becomes a progression', () => {
+  const s = open(NaN);
+  s.activity(1000 + MIN, NaN);
+  s.activity(1000 + 2 * MIN, 0.4);
+  s.activity(1000 + 3 * MIN, Infinity);
+  const out = s.close(1000 + 4 * MIN, wall(4 * MIN), undefined);
+  assert.equal(out.start_progression, 0.4);
+  assert.equal(out.end_progression, 0.4);
+});
+
+test('a sitting that never measured a position says nothing', () => {
+  const s = open(NaN);
+  assert.equal(s.close(1000 + 5 * MIN, wall(5 * MIN), NaN), null);
+});
+
+test('progressions are clamped to [0,1]', () => {
+  const s = open(-0.2);
+  const out = s.close(1000 + MIN, wall(MIN), 1.5);
+  assert.equal(out.start_progression, 0);
+  assert.equal(out.end_progression, 1);
+});
+
+test('a second close yields nothing and late activity is ignored', () => {
+  const s = open();
+  const out = s.close(1000 + MIN, wall(MIN), 0.5);
+  assert.ok(out);
+  assert.equal(s.close(1000 + 2 * MIN, wall(2 * MIN), 0.9), null);
+  s.activity(1000 + 3 * MIN, 0.9);
+  assert.equal(s.close(1000 + 3 * MIN, wall(3 * MIN), 0.9), null);
+});
+
+test('ended_at is never before started_at and idle never exceeds the span', () => {
+  // Wall clock jumped backwards while the monotonic clock ran on.
+  const s = open();
+  const out = s.close(1000 + 30 * MIN, wall(-5 * MIN), 0.2);
+  assert.equal(out.ended_at, t0.toISOString());
+  assert.equal(out.idle_ms, 0);
+});
+
+test('a wall clock corrected forward lands in idle, not in reading', () => {
+  // One minute of reading, page turns throughout, but the wall clock
+  // was put right by an hour in the middle of it. The server derives
+  // active time as span minus idle, so the hour must be in idle_ms.
+  const s = open();
+  s.activity(1000 + 30000, 0.15);
+  const out = s.close(1000 + MIN, wall(61 * MIN), 0.2);
+  const span = Date.parse(out.ended_at) - Date.parse(out.started_at);
+  assert.equal(span, 61 * MIN);
+  assert.equal(span - out.idle_ms, MIN);
+});
+
+test('a relocate the reader did not cause is not activity', () => {
+  const s = open();
+  // Twenty minutes of the engine re-anchoring on resizes, no input.
+  for (let m = 1; m <= 20; m++) s.progress(0.1 + m * 0.001);
+  const out = s.close(1000 + 20 * MIN, wall(20 * MIN), 0.13);
+  assert.equal(out.idle_ms, 20 * MIN - IDLE_AFTER_MS);
+  assert.equal(out.end_progression, 0.13);
+  assert.equal(out.start_progression, 0.1);
+});
+
+test('progress supplies the first position when the open had none', () => {
+  const s = open(NaN);
+  s.progress(0.3);
+  s.activity(1000 + MIN, NaN);
+  const out = s.close(1000 + 2 * MIN, wall(2 * MIN), NaN);
+  assert.equal(out.start_progression, 0.3);
+  assert.equal(out.end_progression, 0.3);
+});
+
+test('a monotonic clock that steps back adds nothing', () => {
+  const s = open(0.1, 5000);
+  s.activity(1000, 0.2); // before the open moment
+  const out = s.close(5000 + MIN, wall(MIN), 0.3);
+  assert.equal(out.idle_ms, 0);
+  assert.equal(out.end_progression, 0.3);
+});
+
+test('server invariants hold for random event sequences', () => {
+  let seed = 42;
+  const rnd = () => (seed = (seed * 1103515245 + 12345) & 0x7fffffff) / 0x7fffffff;
+  for (let i = 0; i < 500; i++) {
+    const s = openSession({ id: 'r', workID: 'w', startedAt: t0, now: 0, fraction: rnd() });
+    let at = 0;
+    const n = Math.floor(rnd() * 30);
+    for (let k = 0; k < n; k++) {
+      at += Math.floor(rnd() * 10 * MIN);
+      s.activity(at, rnd() < 0.2 ? NaN : rnd() * 1.2 - 0.1);
+    }
+    at += Math.floor(rnd() * 10 * MIN);
+    const drift = Math.floor((rnd() - 0.5) * 2000);
+    const out = s.close(at, wall(at + drift), rnd());
+    if (!out) continue;
+    const started = Date.parse(out.started_at);
+    const ended = Date.parse(out.ended_at);
+    assert.ok(ended >= started);
+    assert.ok(out.idle_ms >= 0 && out.idle_ms <= ended - started, `${out.idle_ms} > ${ended - started}`);
+    for (const p of [out.start_progression, out.end_progression]) {
+      assert.ok(Number.isFinite(p) && p >= 0 && p <= 1);
+    }
+  }
+});


### PR DESCRIPTION
Reading in the browser now counts towards statistics. Previously the
web reader only pushed position updates, so a session spent reading
there advanced "Continue reading" but added zero minutes, zero
sessions and no streak day — silently disagreeing with the reader who
had just used it.

The reader now records a session per sitting, bounded by tab
visibility (open when the book becomes visible, closed and sent on
hide/pagehide/unload). Idle time beyond a three-minute cap per gap is
excluded, matching KOReader's page-time accounting; sittings under ten
seconds of active reading are dropped as accidental opens. The
accounting itself lives in a pure, dependency-free module so the rules
are covered by plain unit tests, with a real-Chromium test proving the
wiring end to end.

See ADR-0030 for the full rationale and the edge cases considered
(idle handling, crash loss, relocate-vs-input distinction).