### PR TITLE
Show the same page number as the app in the web reader

### DIFF
--- a/docs/adr/0012-reader-engine-foliate.md
+++ b/docs/adr/0012-reader-engine-foliate.md
@@ -6,6 +6,10 @@
 - **Supersedes:** the renderer choice in ADR-0007. Everything else in
   that record — client-side unzip, the CSP, the token lifecycle, the
   locator envelope — stands unchanged.
+- **Amended by:** [ADR-0031](0031-web-reader-footer.md), which moved the
+  figures out of the top bar;
+  [ADR-0032](0032-reader-pages-are-readium-positions.md), which patches
+  the vendored engine in three places
 
 ## Context
 
@@ -103,7 +107,10 @@ mechanism.
   loaders are dynamic imports that are simply absent.
 - Upstream has no releases; the pin is a commit hash recorded in
   `foliate-js.LICENSE`. Updating is a deliberate re-copy, which for a
-  security-sensitive component is a feature.
+  security-sensitive component is a feature. A re-copy must reapply the
+  three additive patches listed in
+  [ADR-0032](0032-reader-pages-are-readium-positions.md); each is
+  marked `liseur-sync patch` in the vendored source.
 - The user stylesheet the engine injects after the publication's own is
   what reader appearance settings (theme, font, size, spacing, layout,
   and whether the bar and page-turn arrows hide themselves while you

--- a/docs/adr/0031-web-reader-footer.md
+++ b/docs/adr/0031-web-reader-footer.md
@@ -4,6 +4,9 @@
 - **Date:** 2026-09-03
 - **Amends:** [ADR-0012](0012-reader-engine-foliate.md), which put the
   chapter name and the percentage in the top bar
+- **Amended by:** [ADR-0032](0032-reader-pages-are-readium-positions.md),
+  which replaces the engine's locations with Readium's positions so that
+  the page here is the page the app shows
 
 ## Context
 
@@ -47,6 +50,14 @@ server's edition page count, which the web reader does not have. The
 "never fabricate page numbers" rule in the design is about
 *statistics*; nothing here is sent anywhere, and a locations counter
 is the engine's honest measure of the book, not a guess.
+
+> **Amended by [ADR-0032](0032-reader-pages-are-readium-positions.md).**
+> The same idea as the app's positions turned out not to be the same
+> number: foliate's locations are 1500 uncompressed bytes and Readium's
+> positions are 1024 stored ones, so the two clients showed different
+> pages for the same paragraph. The reader now counts Readium's
+> positions. Everything else in this section stands — including why it
+> is neither the print page-list nor the server's edition count.
 
 **The middle slot cycles.** Chapter title by default, then time left
 in chapter, then time left in book, then empty, then round again. A

--- a/docs/adr/0032-reader-pages-are-readium-positions.md
+++ b/docs/adr/0032-reader-pages-are-readium-positions.md
@@ -1,0 +1,120 @@
+# ADR-0032: The reader's page is the app's page
+
+- **Status:** Accepted; implemented
+- **Date:** 2026-09-03
+- **Amends:** [ADR-0031](0031-web-reader-footer.md), which put a page
+  number in the footer and took it from the engine's locations;
+  [ADR-0012](0012-reader-engine-foliate.md), whose vendored engine
+  gains three small patches
+
+## Context
+
+ADR-0031 gave the web reader a footer and said its page was "the same
+idea as the app's positions". Same idea, different arithmetic — and a
+reader holding a phone in one hand and a laptop in the other sees two
+numbers for the same paragraph:
+
+| Client | Shown | Count |
+|---|---|---|
+| Web reader (foliate-js) | `853 of 1156` | `ceil(Σ uncompressed spine bytes / 1500)` |
+| Android app (Readium 3.3.0) | `427 of 578` | `Σ max(1, ceil(stored entry bytes / 1024))` |
+
+Both from the same file: *Dominium Mundi Livre 2*, 14 linear spine
+items, 1,733,097 uncompressed bytes.
+
+It looks like a doubling and is not. The ratio is
+`(uncompressed / stored) × (1024 / 1500)`, so it tracks how well each
+book compresses: 2.00× for that book, 1.54× for *Red Rising 3* (768
+against 498). Two units that happened to land on a round number once.
+
+Readium's number is the one the reader already trusts, because it is
+the one on the device they read on most, and it is the number the app
+has always shown. It comes from
+`ReflowableStrategy.recommended` — `ArchiveEntryLength(pageLength =
+1024)` — which counts each reading-order resource as
+`max(1, ceil(archiveEntryLength / 1024))` and sums them. The archive
+entry length is the resource as it is *stored*: the compressed length
+for a deflated entry, the plain length for a stored one, falling back
+to the resource's own length when the container cannot say. Non-linear
+spine items never enter the reading order, so they count for nothing.
+
+Foliate's locations are a perfectly honest measure of a book. They are
+simply a different one.
+
+## Decision
+
+**The web reader counts Readium's positions.** The footer's `n of m`
+is the position count above, computed from the book the browser already
+holds. For every EPUB, the browser and the app now name the same page
+for the same spot.
+
+**It is display only.** The `progression` fraction the reader pushes is
+the engine's, untouched, so no stored op changes meaning, nothing is
+migrated, and there is no server or API change. Two consequences of
+that are deliberate:
+
+- **The percentage stays as it is.** Foliate weights it by uncompressed
+  bytes and Readium by positions, so the two disagree slightly — 74%
+  against 73% on the book above, under a tenth of a percent apart.
+  Making them agree would mean changing the number every web reader
+  sends the server, which is a great deal of risk to buy a rounding.
+- **"Time left" stays as it is.** Foliate estimates from a fixed 1600
+  bytes per minute; the app measures the reader's own pace. That is a
+  real disagreement in the same footer and a separate decision.
+
+**The arithmetic lives in our tree, not the engine's.**
+`static/reader-positions.js` is pure functions over a book's sections —
+`positionTable`, `pageAt` — with no DOM and no engine in it, so the
+agreement it exists to guarantee is checked by `node --test` in CI
+rather than only by a browser check that skips.
+
+**The engine's own locations remain the fallback.** A book the recipe
+cannot measure — nothing linear, no lengths — leaves `location.current`
+and `location.total` saying what page it is, exactly as before. A
+footer that has nothing honest to say still says nothing rather than
+inventing something, per ADR-0031.
+
+**Three patches to the vendored engine**, all additive, all recorded
+here because ADR-0012 makes updating foliate-js a deliberate re-copy
+and a re-copy must reapply them:
+
+1. `view.js`, `makeZipLoader`: a `getCompressedSize` beside `getSize`,
+   reading the zip entry's `compressedSize` and falling back to its
+   `uncompressedSize`. `makeDirectoryLoader` aliases it to `getSize`: a
+   loose directory has no archive entry, which is the fallback Readium
+   takes too.
+2. `epub.js`: the loader's `getCompressedSize` is carried onto each
+   section as `compressedSize`, beside the existing `size`.
+3. `view.js`, `#onRelocate`: `sectionFraction` on `lastLocation`. The
+   engine has the within-section fraction in hand there and nowhere
+   else, and the position containing a spot is computed from it.
+
+`progress.js` is deliberately untouched. Its `fraction` and its `time`
+are what the reader syncs and what the middle slot says; leaving it
+alone is what makes this change display only.
+
+## Consequences
+
+- `TestReaderPositionArithmetic` runs
+  `testdata/readerpositions.test.mjs` under `node --test`, alongside
+  the session tests. It pins the per-resource floor, the exclusion of
+  non-linear sections, the fallback to the resource's own length, the
+  clamps, monotonicity across a section boundary, and the fourteen real
+  stored lengths that must come out at 578.
+- The browser check asserts the footer's `m` exactly. The expected
+  value is computed in Go from the fixture archive with the same
+  recipe and passed as `SMOKE_PAGES`, because the fixture is deflated
+  by whatever Go compiles the test and a written-down total would be a
+  test of Go's compressor.
+- **A position is not a screen.** A short chapter is one position
+  however many screens it takes at a large font, so turning a page can
+  leave the number where it was. That is what a stable page number
+  costs and what the app has always done; the browser check's
+  "counts forward" is `>=` with an overall rise, not a step per turn.
+- A third page count still exists and is untouched:
+  `editions.page_count`, KOReader's own, arriving through the koplugin
+  adapter and used by insights and the dashboard. The reader does not
+  have it and does not want it — it is per user and per edition, and
+  absent for most books.
+- No `docs/openapi.yaml` change, no `docs/integrating.md` change, no
+  migration, nothing new stored server-side.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,6 +56,7 @@ loose ends that must come before any of it, are in
 | [0029](0029-a-folder-somebody-can-read.md) | A folder somebody can read | MVP | Accepted; implemented | Creator grant in the folder's own transaction, guarded backfill migration 6, a Library page that names which situation it is in; amends [0027](0027-explicit-per-user-folder-access.md) |
 | [0030](0030-web-reader-reading-sessions.md) | The web reader counts its sittings | Later | Accepted; implemented | Visibility-bounded sittings, three-minute idle cap, ten-second minimum, no local persistence; amends [0007](0007-web-reader.md) |
 | [0031](0031-web-reader-footer.md) | The web reader's footer mirrors the app | Later | Accepted; implemented | Percent, middle slot, page in the engine's bottom margin; pages are engine locations, never fabricated; click cycles the middle; a browser preference; amends [0012](0012-reader-engine-foliate.md) |
+| [0032](0032-reader-pages-are-readium-positions.md) | The reader's page is the app's page | Later | Accepted; implemented | Pages counted as Readium positions so the browser and the app name the same page; display only, no server or API change; three recorded patches to the vendored engine; amends [0031](0031-web-reader-footer.md) and [0012](0012-reader-engine-foliate.md) |
 
 ## Convention
 

--- a/internal/webui/readerbrowser_ext_test.go
+++ b/internal/webui/readerbrowser_ext_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -183,6 +184,50 @@ func browserTestEPUB(t *testing.T) []byte {
 // its first section is obvious rather than borderline.
 const browserTestChapters = 12
 
+// browserTestPages is how many pages the footer must show for the
+// fixture: Readium's positions, which is what the reader now counts
+// (ADR-0032) so that the browser and the app name the same page.
+//
+// It is computed from the archive rather than written down because the
+// fixture is deflated by whatever Go is compiling the test, and a
+// hard-coded total would be a test of Go's compressor. The recipe is
+// Readium's: per linear spine item, its stored length over 1024 rounded
+// up, at least one, summed.
+func browserTestPages(t *testing.T, epub []byte) int {
+	t.Helper()
+	spine := []string{"OEBPS/pagetitre.xhtml", "OEBPS/chapter1.xhtml"}
+	for i := 2; i <= browserTestChapters; i++ {
+		spine = append(spine, fmt.Sprintf("OEBPS/chapter%d.xhtml", i))
+	}
+	r, err := zip.NewReader(bytes.NewReader(epub), int64(len(epub)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored := make(map[string]uint64, len(r.File))
+	for _, f := range r.File {
+		// A stored entry has no compressed length of its own, which is
+		// where Readium falls back to the resource's own length.
+		if f.Method == zip.Store {
+			stored[f.Name] = f.UncompressedSize64
+			continue
+		}
+		stored[f.Name] = f.CompressedSize64
+	}
+	total := 0
+	for _, name := range spine {
+		length, ok := stored[name]
+		if !ok {
+			t.Fatalf("fixture has no spine entry %q", name)
+		}
+		pages := (length + 1023) / 1024
+		if pages < 1 {
+			pages = 1
+		}
+		total += int(pages)
+	}
+	return total
+}
+
 // seededStaleOpID names the op the test plants before the browser
 // opens: a stored position whose CFI has a valid spine step for this
 // book but a garbage path inside the chapter. The engine only walks
@@ -341,7 +386,8 @@ func TestReaderOpensInARealBrowser(t *testing.T) {
 	}
 
 	f := newBooksFixture(t)
-	bookID := f.addBook(t, "novel", browserTestEPUB(t))
+	epub := browserTestEPUB(t)
+	bookID := f.addBook(t, "novel", epub)
 
 	// The API is mounted beside the UI, as it is in the binary, so the
 	// reader's sync calls are real and their failures are visible.
@@ -358,6 +404,7 @@ func TestReaderOpensInARealBrowser(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"SMOKE_CHROME="+chrome,
 		"SMOKE_URL="+ts.URL+"/ui/books/"+bookID+"/read",
+		"SMOKE_PAGES="+strconv.Itoa(browserTestPages(t, epub)),
 		"SMOKE_COOKIE="+cookie.Name+"="+cookie.Value,
 		"SMOKE_HOST="+strings.TrimPrefix(ts.URL, "http://"),
 		"SMOKE_ANNOTATIONS=1",
@@ -400,7 +447,8 @@ func TestDetachedReaderOpensInARealBrowser(t *testing.T) {
 	}
 
 	f := newBooksFixture(t)
-	bookID := f.addBook(t, "novel", browserTestEPUB(t))
+	epub := browserTestEPUB(t)
+	bookID := f.addBook(t, "novel", epub)
 	ts, readerHost := splitOriginServer(t, f)
 	cookie := f.loginTo(t, ts, "alice")
 
@@ -411,6 +459,7 @@ func TestDetachedReaderOpensInARealBrowser(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"SMOKE_CHROME="+chrome,
 		"SMOKE_URL="+ts.URL+"/ui/books/"+bookID+"/read",
+		"SMOKE_PAGES="+strconv.Itoa(browserTestPages(t, epub)),
 		"SMOKE_COOKIE="+cookie.Name+"="+cookie.Value,
 		"SMOKE_HOST="+strings.TrimPrefix(ts.URL, "http://"),
 		"SMOKE_MAP="+readerHost,
@@ -515,7 +564,8 @@ func TestReaderRefusesANaNPositionButRecovers(t *testing.T) {
 	}
 
 	f := newBooksFixture(t)
-	bookID := f.addBook(t, "novel", browserTestEPUB(t))
+	epub := browserTestEPUB(t)
+	bookID := f.addBook(t, "novel", epub)
 
 	ts := httptest.NewUnstartedServer(nil)
 	wholeServer(t, f, ts, "")
@@ -526,6 +576,7 @@ func TestReaderRefusesANaNPositionButRecovers(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"SMOKE_CHROME="+chrome,
 		"SMOKE_URL="+ts.URL+"/ui/books/"+bookID+"/read",
+		"SMOKE_PAGES="+strconv.Itoa(browserTestPages(t, epub)),
 		"SMOKE_COOKIE="+cookie.Name+"="+cookie.Value,
 		"SMOKE_HOST="+strings.TrimPrefix(ts.URL, "http://"),
 		"SMOKE_NAN=1",
@@ -571,7 +622,8 @@ func TestReaderRecordsReadingSessions(t *testing.T) {
 	}
 
 	f := newBooksFixture(t)
-	bookID := f.addBook(t, "novel", browserTestEPUB(t))
+	epub := browserTestEPUB(t)
+	bookID := f.addBook(t, "novel", epub)
 
 	ts := httptest.NewUnstartedServer(nil)
 	wholeServer(t, f, ts, "")
@@ -581,6 +633,7 @@ func TestReaderRecordsReadingSessions(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"SMOKE_CHROME="+chrome,
 		"SMOKE_URL="+ts.URL+"/ui/books/"+bookID+"/read",
+		"SMOKE_PAGES="+strconv.Itoa(browserTestPages(t, epub)),
 		"SMOKE_COOKIE="+cookie.Name+"="+cookie.Value,
 		"SMOKE_HOST="+strings.TrimPrefix(ts.URL, "http://"),
 		"SMOKE_SESSIONS=1",

--- a/internal/webui/readerpositions_ext_test.go
+++ b/internal/webui/readerpositions_ext_test.go
@@ -1,0 +1,37 @@
+package webui_test
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestReaderPositionArithmetic runs the node unit tests for the footer's
+// page number (static/reader-positions.js). The page is a Readium
+// position, counted the same way the Android app counts it, so that the
+// two clients name the same page for the same spot; the module is pure
+// arithmetic over a book's sections precisely so that agreement can be
+// checked without a browser.
+func TestReaderPositionArithmetic(t *testing.T) {
+	runNodeTests(t, "readerpositions.test.mjs")
+}
+
+// runNodeTests runs one `node --test` file from testdata. These are the
+// reader checks that run in CI: the browser check needs a Chromium and
+// skips without one.
+func runNodeTests(t *testing.T, file string) {
+	t.Helper()
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skipf("no node to run %s with", file)
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, node, "--test", filepath.Join("testdata", file))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", file, err, out)
+	}
+}

--- a/internal/webui/readersession_ext_test.go
+++ b/internal/webui/readersession_ext_test.go
@@ -1,28 +1,13 @@
 package webui_test
 
 import (
-	"context"
-	"os/exec"
-	"path/filepath"
 	"testing"
-	"time"
 )
 
 // TestReaderSessionAccounting runs the node unit tests for the reader's
 // session arithmetic (static/reader-session.js). The module has no DOM
 // and no fetch in it precisely so that its rules — the idle cap, the
-// minimum, the clamps — can be checked without a browser; this is the
-// one reader check that runs in CI.
+// minimum, the clamps — can be checked without a browser.
 func TestReaderSessionAccounting(t *testing.T) {
-	node, err := exec.LookPath("node")
-	if err != nil {
-		t.Skip("no node to run the session tests with")
-	}
-	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, node, "--test", filepath.Join("testdata", "readersession.test.mjs"))
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("session accounting tests failed: %v\n%s", err, out)
-	}
+	runNodeTests(t, "readersession.test.mjs")
 }

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -15,6 +15,7 @@
 import "./vendor/foliate/view.js";
 import { Overlayer } from "./vendor/foliate/overlayer.js";
 import { openSession } from "./reader-session.js";
+import { positionTable, pageAt } from "./reader-positions.js";
 
 const el = document.getElementById("reader-config");
 // Every URL is relative, computed server-side, so the reader keeps
@@ -62,6 +63,10 @@ let tokenExpiry = 0;
 let pending = null;
 let here = null;
 let faviconObjectURL = null;
+// The book's positions, counted once when it opens. Null for a book
+// this recipe cannot measure, which leaves the engine's own locations
+// to say what page it is.
+let positions = null;
 
 function say(message, isError) {
   status.textContent = message;
@@ -1283,16 +1288,32 @@ function paint(location) {
     progressBar.style.width = (fraction * 100).toFixed(1) + "%";
     progressText.textContent = Math.round(fraction * 100) + "%";
   }
-  // The page is the engine's location: a fixed slice of the book's
-  // text, so the count does not move when the font does. The same
+  // The page is a Readium position: a fixed slice of the book as it is
+  // stored, so the count does not move when the font does and it is the
+  // same number the app shows for the same spot. A book the recipe
+  // cannot measure falls back to the engine's own locations. The same
   // rule as the fraction — an unusable value leaves the last one up.
-  const loc = location.location || {};
-  if (finite(loc.current) && finite(loc.total) && loc.total > 0) {
-    const page = Math.min(Math.max(1, Math.floor(loc.current) + 1), loc.total);
-    pageText.textContent = page + " of " + loc.total;
-  }
+  const page = readerPage(location);
+  if (page) pageText.textContent = page;
   chapterText.textContent = footerMiddle(location);
   markTOC(location.tocItem);
+}
+
+// readerPage is the footer's "n of m" for this spot, or null when
+// neither the positions nor the engine can name one.
+function readerPage(location) {
+  const section = location.section || {};
+  const n = pageAt(positions, section.current, location.sectionFraction);
+  if (n) return n + " of " + positions.total;
+  const loc = location.location || {};
+  if (finite(loc.current) && finite(loc.total) && loc.total > 0) {
+    return (
+      Math.min(Math.max(1, Math.floor(loc.current) + 1), loc.total) +
+      " of " +
+      loc.total
+    );
+  }
+  return null;
 }
 
 // footerMiddle is what the middle slot says for this spot under the
@@ -1748,6 +1769,9 @@ window.addEventListener("beforeunload", () => {
       new File([blob], "book.epub", { type: "application/epub+zip" }),
     );
     stripScripts(view.book);
+    // Counted before the first relocate paints a footer, so the very
+    // first page the reader sees is already the app's number.
+    positions = positionTable(view.book.sections);
     buildTOC(view.book.toc);
     // The renderer exists once the book is open; settings applied here
     // shape the very first page rather than repainting it.

--- a/internal/webui/static/reader-positions.js
+++ b/internal/webui/static/reader-positions.js
@@ -1,0 +1,95 @@
+// The footer's page number, counted the way the Android app counts it.
+//
+// A page here is a Readium "position": a fixed slice of the book as it
+// is stored, so the number does not move when the font does and — the
+// point of this module — it is the same number on the phone and in the
+// browser. Readium 3.3.0 computes it with
+// `ReflowableStrategy.recommended`, which is
+// `ArchiveEntryLength(pageLength = 1024)`: for each item of the reading
+// order, `max(1, ceil(archiveEntryLength / 1024))` positions, summed.
+// The archive entry length is the *stored* length — the compressed one
+// for a deflated entry, the plain one for a stored entry — and falls
+// back to the resource's own length when the container cannot say.
+//
+// The engine has its own answer to this question (`location.current` and
+// `location.total`, slices of 1500 uncompressed bytes) and it is a
+// perfectly honest measure of a book; it is simply a different unit, and
+// a reader holding two devices does not want two units. The engine's
+// numbers remain the fallback for a book this recipe cannot measure.
+//
+// Nothing here is sent anywhere. The progression fraction the reader
+// syncs is the engine's, untouched.
+
+/** Bytes per position, from Readium's recommended strategy. */
+export const PAGE_LENGTH = 1024;
+
+/**
+ * positionTable counts the positions of each section of an open book and
+ * where each section starts, from `view.book.sections`.
+ *
+ * Non-linear sections get none: Readium drops them from the reading
+ * order before it counts anything, so a book's total must not include
+ * them either. A book with nothing measurable in it returns null, which
+ * is this module saying it has no opinion rather than an opinion of
+ * zero.
+ */
+export function positionTable(sections) {
+  if (!Array.isArray(sections) || sections.length === 0) return null;
+  const counts = [];
+  const starts = [];
+  let total = 0;
+  for (const section of sections) {
+    starts.push(total);
+    const count = positionCount(section);
+    counts.push(count);
+    total += count;
+  }
+  if (total <= 0) return null;
+  return { counts, starts, total };
+}
+
+// positionCount is Readium's per-resource count for one section.
+function positionCount(section) {
+  if (!section || section.linear === "no") return 0;
+  // The archive entry length, else the resource's own length — the same
+  // fallback chain Readium walks. `compressedSize` is absent only for a
+  // book that did not come out of an archive.
+  const length = finite(section.compressedSize)
+    ? section.compressedSize
+    : finite(section.size)
+      ? section.size
+      : 0;
+  if (length <= 0) return 1;
+  return Math.max(1, Math.ceil(length / PAGE_LENGTH));
+}
+
+/**
+ * pageAt is the 1-based page for a spot in the book, given the section
+ * the reader is in and how far into it they are.
+ *
+ * Readium spreads a resource's positions evenly across it — position
+ * `p` of a resource starts at `(p - 1) / positionCount` — so the
+ * position containing a fraction is the inverse of that.
+ *
+ * A section with no positions of its own (a non-linear one, which the
+ * reader can still reach by following a link into it) yields the page of
+ * the boundary it sits on rather than a number outside the book.
+ */
+export function pageAt(table, index, fractionInSection) {
+  if (!table) return null;
+  const { counts, starts, total } = table;
+  if (!finite(index) || index < 0 || index >= counts.length) return null;
+  const count = counts[index];
+  if (count <= 0) return clamp(starts[index], 1, total);
+  const fraction = finite(fractionInSection)
+    ? Math.min(Math.max(fractionInSection, 0), 1)
+    : 0;
+  // A fraction of exactly 1 is the end of the section, which is the last
+  // of its positions and not the first of the next one's.
+  const within = Math.min(Math.floor(fraction * count), count - 1);
+  return clamp(starts[index] + within + 1, 1, total);
+}
+
+const finite = (v) => typeof v === "number" && Number.isFinite(v);
+
+const clamp = (v, lo, hi) => Math.min(Math.max(v, lo), hi);

--- a/internal/webui/static/vendor/foliate/epub.js
+++ b/internal/webui/static/vendor/foliate/epub.js
@@ -933,10 +933,12 @@ export class EPUB {
     parser = new DOMParser()
     #loader
     #encryption
-    constructor({ loadText, loadBlob, getSize, sha1 }) {
+    constructor({ loadText, loadBlob, getSize, getCompressedSize, sha1 }) {
         this.loadText = loadText
         this.loadBlob = loadBlob
         this.getSize = getSize
+        // liseur-sync patch: see `compressedSize` on each section below.
+        this.getCompressedSize = getCompressedSize ?? getSize
         this.#encryption = new Encryption(deobfuscators(sha1))
     }
     async #loadXML(uri) {
@@ -989,6 +991,11 @@ ${doc.querySelector('parsererror').innerText}`)
                 unload: () => this.#loader.unloadItem(item),
                 createDocument: () => this.loadDocument(item),
                 size: this.getSize(item.href),
+                // liseur-sync patch: the length of this section as it
+                // is stored in the archive. `size` is what the engine
+                // measures progress with; this is what the footer
+                // counts Readium's positions from.
+                compressedSize: this.getCompressedSize(item.href),
                 cfi: this.resources.cfis[index],
                 linear,
                 pageSpread: getPageSpread(properties),

--- a/internal/webui/static/vendor/foliate/view.js
+++ b/internal/webui/static/vendor/foliate/view.js
@@ -39,7 +39,13 @@ const makeZipLoader = async file => {
     const loadText = load(entry => entry.getData(new TextWriter()))
     const loadBlob = load((entry, type) => entry.getData(new BlobWriter(type)))
     const getSize = name => map.get(name)?.uncompressedSize ?? 0
-    return { entries, loadText, loadBlob, getSize }
+    // liseur-sync patch: the archive entry's stored length, which is
+    // what Readium's positions are counted from. A STORED entry has no
+    // compressed length of its own and reports the uncompressed one,
+    // which is the fallback Readium takes as well.
+    const getCompressedSize = name =>
+        map.get(name)?.compressedSize ?? map.get(name)?.uncompressedSize ?? 0
+    return { entries, loadText, loadBlob, getSize, getCompressedSize }
 }
 
 const getFileEntries = async entry => entry.isFile ? entry
@@ -62,7 +68,10 @@ const makeDirectoryLoader = async entry => {
     const loadText = async name => decode(await getBuffer(name))
     const loadBlob = name => map.get(name)
     const getSize = name => map.get(name)?.size ?? 0
-    return { loadText, loadBlob, getSize }
+    // liseur-sync patch: a loose directory has no archive at all, so
+    // the entry length is the file length — the same fallback Readium
+    // takes for a resource with no archive properties.
+    return { loadText, loadBlob, getSize, getCompressedSize: getSize }
 }
 
 export class ResponseError extends Error {}
@@ -331,7 +340,11 @@ export class View extends HTMLElement {
         const tocItem = this.#tocProgress?.getProgress(index, range)
         const pageItem = this.#pageProgress?.getProgress(index, range)
         const cfi = this.getCFI(index, range)
-        this.lastLocation = { ...progress, tocItem, pageItem, cfi, range }
+        // liseur-sync patch: `sectionFraction` is how far into this
+        // section the reader is. The engine has it in hand here and
+        // nowhere else; the footer's page number is counted from it.
+        this.lastLocation = { ...progress, tocItem, pageItem, cfi, range,
+            sectionFraction: fraction }
         if (reason === 'snap' || reason === 'page' || reason === 'scroll')
             this.history.replaceState(cfi)
         this.#emit('relocate', this.lastLocation)

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -20,6 +20,10 @@ const nan = process.env.SMOKE_NAN === '1';
 // Session mode (ADR-0030): hides and shows the tab with a skewed clock,
 // watching what the reader posts to /v1/sessions.
 const sessions = process.env.SMOKE_SESSIONS === '1';
+// How many pages the fixture has, counted from the archive by the Go
+// side with Readium's recipe (ADR-0032). The footer has to agree, or the
+// browser and the app are naming different pages again.
+const expectedPages = Number(process.env.SMOKE_PAGES) || 0;
 
 const profile = mkdtempSync(join(tmpdir(), 'smoke-'));
 const proc = spawn(chrome, [
@@ -203,8 +207,9 @@ check('the engine rendered a chapter', diag.hasDoc && diag.text.length > 10,
 check('the title came out of the publication', diag.title === 'Moby-Dick', diag.title);
 check('reader shows the book: own chapter label',
   diag.chapter === 'Title Page', diag.chapter);
-// The footer's page is the engine's location, "n of m", and it is a
-// page of the book, not a fabrication: n is within m.
+// The footer's page is a Readium position — the same page the app names
+// for the same spot (ADR-0032) — and it is a page of the book, not a
+// fabrication: n is within m.
 const pageOf = (t) => {
   const m = /^(\d+) of (\d+)$/.exec(t || '');
   return m ? { n: +m[1], of: +m[2] } : null;
@@ -212,6 +217,11 @@ const pageOf = (t) => {
 check('the footer shows a page of the book',
   pageOf(diag.page) && pageOf(diag.page).n >= 1 && pageOf(diag.page).n <= pageOf(diag.page).of,
   diag.page);
+if (expectedPages) {
+  check('the page count is the book\'s positions, as the app counts them',
+    pageOf(diag.page)?.of === expectedPages,
+    `${diag.page} want m=${expectedPages}`);
+}
 check('the footer is on screen with the book', diag.footerShown, String(diag.footerShown));
 // The chapter frame lives in a closed shadow root: nothing on the
 // page — including anything a publication managed to smuggle onto it —

--- a/internal/webui/testdata/readerpositions.test.mjs
+++ b/internal/webui/testdata/readerpositions.test.mjs
@@ -1,0 +1,113 @@
+// Unit tests for the footer's page number (reader-positions.js).
+// Run by TestReaderPositionArithmetic through `node --test`; no browser.
+//
+// The numbers these pin down are Readium's, because that is the whole
+// point of the module: the page the app shows and the page the browser
+// shows have to be the same page.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { positionTable, pageAt, PAGE_LENGTH } from '../static/reader-positions.js';
+
+const section = (compressedSize, extra = {}) => ({ compressedSize, ...extra });
+const table = (...sections) => positionTable(sections);
+
+test('a resource is at least one page, however short', () => {
+  const t = table(section(1), section(0), section(1023));
+  assert.deepEqual(t.counts, [1, 1, 1]);
+  assert.equal(t.total, 3);
+});
+
+test('a resource is its stored bytes over 1024, rounded up', () => {
+  assert.equal(PAGE_LENGTH, 1024);
+  const t = table(section(1024), section(1025), section(4096));
+  assert.deepEqual(t.counts, [1, 2, 4]);
+  assert.deepEqual(t.starts, [0, 1, 3]);
+  assert.equal(t.total, 7);
+});
+
+test('non-linear sections count for nothing', () => {
+  // Readium drops them from the reading order before it counts, so they
+  // must not swell the total either.
+  const t = table(
+    section(4096),
+    section(999999, { linear: 'no' }),
+    section(2048),
+  );
+  assert.deepEqual(t.counts, [4, 0, 2]);
+  assert.equal(t.total, 6);
+});
+
+test('a section with no archive length falls back to its own length', () => {
+  // A book that did not come out of an archive: the same fallback chain
+  // Readium walks when a resource has no archive properties.
+  const t = positionTable([{ size: 4096 }, { size: 2048 }]);
+  assert.deepEqual(t.counts, [4, 2]);
+});
+
+test('the archive length wins over the resource length', () => {
+  const t = table(section(1024, { size: 999999 }));
+  assert.deepEqual(t.counts, [1]);
+});
+
+test('a book with nothing measurable in it has no opinion', () => {
+  assert.equal(positionTable([]), null);
+  assert.equal(positionTable(null), null);
+  assert.equal(positionTable([{ linear: 'no', compressedSize: 4096 }]), null);
+});
+
+test('the first page is 1 and the last page is the total', () => {
+  const t = table(section(4096), section(2048));
+  assert.equal(pageAt(t, 0, 0), 1);
+  assert.equal(pageAt(t, 1, 1), t.total);
+  assert.equal(t.total, 6);
+});
+
+test('pages march forward within a resource and across its edge', () => {
+  const t = table(section(4096), section(4096));
+  // Readium spreads a resource's positions evenly: position p starts at
+  // (p - 1) / count.
+  assert.deepEqual([0, 0.25, 0.5, 0.75].map((f) => pageAt(t, 0, f)), [1, 2, 3, 4]);
+  // The very end of a section is its last page, never the next one's
+  // first.
+  assert.equal(pageAt(t, 0, 1), 4);
+  assert.equal(pageAt(t, 1, 0), 5);
+  assert.deepEqual([0.25, 0.5, 0.75, 1].map((f) => pageAt(t, 1, f)), [6, 7, 8, 8]);
+});
+
+test('a page never leaves the book', () => {
+  const t = table(section(4096));
+  assert.equal(pageAt(t, 0, -5), 1);
+  assert.equal(pageAt(t, 0, 5), t.total);
+  assert.equal(pageAt(t, 0, NaN), 1);
+  assert.equal(pageAt(t, 0, undefined), 1);
+});
+
+test('a section the reader can reach but Readium never counted', () => {
+  // Following a link into a non-linear section: the page is the
+  // boundary it sits on, not a number outside the book.
+  const t = table(section(4096), section(999999, { linear: 'no' }), section(2048));
+  assert.equal(pageAt(t, 1, 0.5), 4);
+});
+
+test('nothing to say, said as nothing', () => {
+  const t = table(section(4096));
+  assert.equal(pageAt(null, 0, 0), null);
+  assert.equal(pageAt(t, -1, 0), null);
+  assert.equal(pageAt(t, 9, 0), null);
+  assert.equal(pageAt(t, undefined, 0), null);
+});
+
+test('a real book comes out at the number the app shows', () => {
+  // "Dominium Mundi Livre 2", 14 spine items, stored lengths as they sit
+  // in the archive. Readium 3.3.0 counts 578 positions; foliate's own
+  // locations counter says 1156, and that disagreement is what this
+  // module exists to end.
+  const stored = [
+    392, 1456, 325, 858, 321, 117517, 134039, 321,
+    72116, 108814, 119685, 26728, 1270, 521,
+  ];
+  const t = table(...stored.map((n) => section(n)));
+  assert.equal(t.total, 578);
+  assert.equal(pageAt(t, 0, 0), 1);
+  assert.equal(pageAt(t, stored.length - 1, 1), 578);
+});


### PR DESCRIPTION
The web reader and the Android app showed different page numbers for the same
place in a book. Reading *Dominium Mundi Livre 2*, a browser said `853 of 1156`
where the phone said `427 of 578`.

They were counting different things. The app uses Readium's positions, which
measure a book as it is stored in the file. The web reader used its engine's own
unit, which measures the text after unpacking. The gap tracks how well each book
compresses, so it looked like a doubling here and would have been 768 against
498 for another book on the shelf.

The web reader now counts pages the way the app does, so both name the same page
for the same spot.

Only the number on screen changes. The reading position that syncs between
devices is the same value as before, so nothing already stored changes meaning
and there is no server or API change.

Two other figures in the same footer still disagree between the two clients: the
percentage (74% against 73%) and the "time left in book" estimate. Both are left
alone on purpose, and ADR-0032 says why.

## Testing

- A new unit test runs in CI without a browser and covers the counting rules,
  including the real section sizes from the book above.
- The browser check now asserts the exact page total, worked out from the test
  book itself rather than written down.
- Full web UI suite with the race detector, plus vet and lint.
- Checked in a real browser that the total and the page within a chapter both
  move as they should.
