### PR TITLE
Jump to page or percentage from reader footer

### DIFF
--- a/internal/webui/reader.templ
+++ b/internal/webui/reader.templ
@@ -251,13 +251,25 @@ templ readerPage(v ReaderView, csrf string) {
 					<div
 						id="reader-footer"
 						class="reader-footer"
-						role="button"
-						tabindex="0"
-						title="Click to change what the middle shows"
 					>
-						<span id="reader-progress-text" class="reader-footer-edge"></span>
-						<span id="reader-chapter" class="reader-footer-mid"></span>
-						<span id="reader-page" class="reader-footer-edge"></span>
+						<button
+							type="button"
+							id="reader-progress-text"
+							class="reader-footer-edge"
+							title="Go to percentage"
+						></button>
+						<button
+							type="button"
+							id="reader-chapter"
+							class="reader-footer-mid"
+							title="Click to change what the middle shows"
+						></button>
+						<button
+							type="button"
+							id="reader-page"
+							class="reader-footer-edge"
+							title="Go to page"
+						></button>
 					</div>
 				</div>
 				<button id="reader-next" class="reader-turn" type="button" aria-label="Next page">&rsaquo;</button>
@@ -274,6 +286,7 @@ templ readerPage(v ReaderView, csrf string) {
 						<tr><td><kbd>l</kbd> <kbd>h</kbd>, <kbd>j</kbd> <kbd>k</kbd></td><td>Next / previous page</td></tr>
 						<tr><td><kbd>Home</kbd> / <kbd>End</kbd></td><td>Beginning / end of book</td></tr>
 						<tr><td><kbd>t</kbd></td><td>Table of contents</td></tr>
+						<tr><td><kbd>g</kbd></td><td>Go to page or percentage</td></tr>
 						<tr><td><kbd>f</kbd></td><td>Full screen</td></tr>
 						<tr><td><kbd>z</kbd></td><td>Show or hide the bars</td></tr>
 						<tr><td><kbd>?</kbd></td><td>This help</td></tr>
@@ -286,6 +299,26 @@ templ readerPage(v ReaderView, csrf string) {
 					while you read; &ldquo;Auto-hide bars&rdquo; under Aa turns that off.
 				</p>
 				<form method="dialog"><button>Close</button></form>
+			</dialog>
+			<dialog id="reader-goto" class="reader-goto" aria-labelledby="reader-goto-title">
+				<form id="reader-goto-form" method="dialog">
+					<h2 id="reader-goto-title">Go to</h2>
+					<div class="reader-goto-row">
+						<label for="reader-goto-input" id="reader-goto-label" class="reader-goto-label">Location</label>
+						<input
+							type="number"
+							id="reader-goto-input"
+							class="reader-goto-input"
+							required
+							autocomplete="off"
+						/>
+						<span id="reader-goto-unit" class="reader-goto-unit"></span>
+					</div>
+					<div class="reader-goto-actions">
+						<button type="button" id="reader-goto-cancel">Cancel</button>
+						<button type="submit" id="reader-goto-submit" class="btn primary">Go</button>
+					</div>
+				</form>
 			</dialog>
 			<script type="module" src={ v.StaticBase + "reader-app.js" } nonce={ v.ScriptNonce }></script>
 		</body>

--- a/internal/webui/readerpage_ext_test.go
+++ b/internal/webui/readerpage_ext_test.go
@@ -159,6 +159,7 @@ func TestReaderPageOffersTheChromeControls(t *testing.T) {
 	for _, want := range []string{
 		`name="autohide"`,
 		`<kbd>z</kbd>`,
+		`<kbd>g</kbd>`,
 		`reader-help-note`,
 	} {
 		if !strings.Contains(page, want) {
@@ -182,6 +183,8 @@ func TestReaderPageCarriesTheReadingFooter(t *testing.T) {
 		`id="reader-progress-text"`,
 		`id="reader-chapter"`,
 		`id="reader-page"`,
+		`id="reader-goto"`,
+		`id="reader-goto-input"`,
 		`name="footer" value="chapter"`,
 		`name="footer" value="time-chapter"`,
 		`name="footer" value="time-book"`,

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -1392,16 +1392,20 @@ async function goToPage(page) {
   if (positions) {
     const loc = pageLocation(positions, page);
     if (loc && view.renderer) {
-      await view.renderer.goTo(loc);
-      const landedIndex = view.lastLocation?.section?.current;
-      const state =
-        landedIndex === loc.index && view.lastLocation?.cfi
-          ? view.lastLocation.cfi
-          : loc.index;
-      if (view.history && view.history.pushState) {
-        view.history.pushState(state);
+      try {
+        await view.renderer.goTo(loc);
+        const landedIndex = view.lastLocation?.section?.current;
+        const state =
+          landedIndex === loc.index && view.lastLocation?.cfi
+            ? view.lastLocation.cfi
+            : loc.index;
+        if (view.history && view.history.pushState) {
+          view.history.pushState(state);
+        }
+        return;
+      } catch (e) {
+        /* fall through to engine fraction fallback */
       }
-      return;
     }
   }
   const loc = here && here.location;

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -15,7 +15,7 @@
 import "./vendor/foliate/view.js";
 import { Overlayer } from "./vendor/foliate/overlayer.js";
 import { openSession } from "./reader-session.js";
-import { positionTable, pageAt } from "./reader-positions.js";
+import { positionTable, pageAt, pageLocation } from "./reader-positions.js";
 
 const el = document.getElementById("reader-config");
 // Every URL is relative, computed server-side, so the reader keeps
@@ -50,6 +50,14 @@ const progressText = document.getElementById("reader-progress-text");
 const chapterText = document.getElementById("reader-chapter");
 const pageText = document.getElementById("reader-page");
 const footer = document.getElementById("reader-footer");
+const gotoDialog = document.getElementById("reader-goto");
+const gotoForm = document.getElementById("reader-goto-form");
+const gotoTitle = document.getElementById("reader-goto-title");
+const gotoLabel = document.getElementById("reader-goto-label");
+const gotoInput = document.getElementById("reader-goto-input");
+const gotoUnit = document.getElementById("reader-goto-unit");
+const gotoCancel = document.getElementById("reader-goto-cancel");
+let gotoKind = "percent";
 const titleText = document.getElementById("reader-title-text");
 const tocPanel = document.getElementById("reader-toc");
 const tocList = document.getElementById("reader-toc-list");
@@ -954,6 +962,7 @@ function setChrome(visible) {
 // something it owns is open, an error is on screen — a failure must
 // never hide behind an invisible bar — or the keyboard is in it.
 function chromeBusy() {
+  if (gotoDialog && gotoDialog.open) return true;
   if (tocPanel && !tocPanel.hidden) return true;
   if (settingsPanel && settingsPanel.open) return true;
   if (status && !status.hidden) return true;
@@ -1295,6 +1304,11 @@ function paint(location) {
   // rule as the fraction — an unusable value leaves the last one up.
   const page = readerPage(location);
   if (page) pageText.textContent = page;
+  const hasPageTotal = !!(
+    (positions && positions.total > 0) ||
+    (location.location && finite(location.location.total) && location.location.total > 0)
+  );
+  pageText.disabled = !hasPageTotal;
   chapterText.textContent = footerMiddle(location);
   markTOC(location.tocItem);
 }
@@ -1373,12 +1387,119 @@ function cycleFooter() {
   applySettings();
 }
 
+async function goToPage(page) {
+  if (!view) return;
+  if (positions) {
+    const loc = pageLocation(positions, page);
+    if (loc && view.renderer) {
+      await view.renderer.goTo(loc);
+      const landedIndex = view.lastLocation?.section?.current;
+      const state =
+        landedIndex === loc.index && view.lastLocation?.cfi
+          ? view.lastLocation.cfi
+          : loc.index;
+      if (view.history && view.history.pushState) {
+        view.history.pushState(state);
+      }
+      return;
+    }
+  }
+  const loc = here && here.location;
+  if (loc && finite(loc.total) && loc.total > 0) {
+    const frac = Math.min(Math.max((page - 0.5) / loc.total, 0), 1);
+    await view.goToFraction(frac).catch(() => {});
+  }
+}
+
+function openGoto(kind) {
+  if (!gotoDialog || !gotoInput) return;
+  gotoKind = kind;
+  if (kind === "percent") {
+    if (gotoTitle) gotoTitle.textContent = "Go to percentage";
+    if (gotoLabel) gotoLabel.textContent = "Percentage";
+    gotoInput.min = "0";
+    gotoInput.max = "100";
+    gotoInput.step = "1";
+    gotoInput.value =
+      here && finite(here.fraction) ? String(Math.round(here.fraction * 100)) : "";
+    if (gotoUnit) gotoUnit.textContent = "%";
+  } else {
+    const total = positions
+      ? positions.total
+      : here && here.location && finite(here.location.total) && here.location.total > 0
+        ? here.location.total
+        : null;
+    if (!total) return;
+    if (gotoTitle) gotoTitle.textContent = "Go to page";
+    if (gotoLabel) gotoLabel.textContent = "Page number";
+    gotoInput.min = "1";
+    gotoInput.max = String(total);
+    gotoInput.step = "1";
+    let current = null;
+    if (positions && here && here.section) {
+      current = pageAt(positions, here.section.current, here.sectionFraction);
+    } else if (
+      here &&
+      here.location &&
+      finite(here.location.current) &&
+      finite(here.location.total)
+    ) {
+      current = Math.min(
+        Math.max(1, Math.floor(here.location.current) + 1),
+        here.location.total,
+      );
+    }
+    gotoInput.value = current !== null ? String(current) : "";
+    if (gotoUnit) gotoUnit.textContent = "of " + total;
+  }
+  gotoDialog.showModal();
+  gotoInput.select();
+}
+
 if (footer) {
-  footer.addEventListener("click", cycleFooter);
-  footer.addEventListener("keydown", (e) => {
-    if (e.key !== "Enter" && e.key !== " ") return;
+  footer.addEventListener("click", (e) => {
+    const btn = e.target && e.target.closest ? e.target.closest("button") : null;
+    if (btn === progressText) {
+      openGoto("percent");
+    } else if (btn === pageText) {
+      openGoto("page");
+    } else {
+      cycleFooter();
+    }
+  });
+}
+
+if (gotoForm) {
+  gotoForm.addEventListener("submit", async (e) => {
     e.preventDefault();
-    cycleFooter();
+    const val = parseFloat(gotoInput.value);
+    if (!Number.isFinite(val)) return;
+    if (gotoKind === "percent") {
+      const pct = Math.min(Math.max(val, 0), 100);
+      if (view) await view.goToFraction(pct / 100).catch(() => {});
+    } else {
+      await goToPage(val);
+    }
+    if (gotoDialog && gotoDialog.open) gotoDialog.close();
+  });
+}
+
+if (gotoCancel) {
+  gotoCancel.addEventListener("click", () => {
+    if (gotoDialog && gotoDialog.open) gotoDialog.close();
+  });
+}
+
+if (gotoDialog) {
+  gotoDialog.addEventListener("click", (e) => {
+    if (e.target !== gotoDialog) return;
+    const rect = gotoDialog.getBoundingClientRect();
+    const inDialog =
+      rect.top <= e.clientY &&
+      e.clientY <= rect.top + rect.height &&
+      rect.left <= e.clientX &&
+      e.clientX <= rect.left + rect.width;
+    if (!inDialog) gotoDialog.close();
   });
 }
 
@@ -1626,6 +1747,7 @@ stageArea.addEventListener("click", (e) => {
 // each document gets wired as it arrives.
 function handleKeys(e) {
   noteActivity();
+  if (gotoDialog && gotoDialog.open) return;
   const helpDialog = document.getElementById("reader-help");
   // Arrow keys inside the settings panel adjust its controls, not the
   // book; Escape puts the panel away from the keyboard.
@@ -1690,6 +1812,11 @@ function handleKeys(e) {
     case "t":
       e.preventDefault();
       toggleTOC(true);
+      break;
+    case "g":
+      e.preventDefault();
+      revealChrome();
+      openGoto("percent");
       break;
     case "f":
       e.preventDefault();

--- a/internal/webui/static/reader-positions.js
+++ b/internal/webui/static/reader-positions.js
@@ -90,6 +90,29 @@ export function pageAt(table, index, fractionInSection) {
   return clamp(starts[index] + within + 1, 1, total);
 }
 
+/**
+ * pageLocation is the inverse of pageAt: given a 1-based page number, it
+ * returns the { index, anchor } section target for the reader engine, or
+ * null when the page cannot be mapped.
+ */
+export function pageLocation(table, page) {
+  if (!table || !finite(page) || !table.total || table.total <= 0) return null;
+  const p = clamp(Math.round(page), 1, table.total);
+  const { counts, starts } = table;
+  if (!Array.isArray(counts) || !Array.isArray(starts)) return null;
+  for (let i = 0; i < counts.length; i++) {
+    const count = counts[i];
+    if (count <= 0) continue;
+    const start = starts[i];
+    if (p >= start + 1 && p <= start + count) {
+      const within = p - start - 1;
+      const anchor = (within + 0.5) / count;
+      return { index: i, anchor };
+    }
+  }
+  return null;
+}
+
 const finite = (v) => typeof v === "number" && Number.isFinite(v);
 
 const clamp = (v, lo, hi) => Math.min(Math.max(v, lo), hi);

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -874,10 +874,15 @@ button.linkish:hover, button.linkish:focus-visible {
   font-size:min(.78rem,calc(var(--reader-margin,48px) * .7));
   letter-spacing:.01em;line-height:1;
   font-variant-numeric:tabular-nums;color:var(--reader-footer-fg,var(--ink));
-  opacity:.62;cursor:pointer;user-select:none;-webkit-user-select:none;
+  opacity:.62;user-select:none;-webkit-user-select:none;
   transition:opacity .18s ease}
 .reader-footer:hover{opacity:.9}
-.reader-footer:focus-visible{outline:2px solid var(--primary);outline-offset:-2px;border-radius:4px}
+.reader-footer button{background:none;border:none;padding:0;font:inherit;
+  letter-spacing:inherit;line-height:inherit;font-variant-numeric:inherit;
+  color:inherit;cursor:pointer;display:inline-block;border-radius:3px}
+.reader-footer button:focus-visible{outline:2px solid var(--primary);outline-offset:2px}
+.reader-footer button:hover{text-decoration:underline}
+.reader-footer button[disabled]{opacity:.5;cursor:default;text-decoration:none}
 .reader-footer-edge{flex:none;white-space:nowrap}
 .reader-footer-mid{flex:1;min-width:0;text-align:center;
   overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
@@ -926,6 +931,18 @@ button.linkish:hover, button.linkish:focus-visible {
   border-radius:4px;padding:.05rem .35rem;font-size:.8rem;font-family:inherit}
 .reader-help form{margin:.8rem 0 0;text-align:right}
 .reader-help-note{margin:.9rem 0 0;font-size:.85rem;opacity:.75;max-width:26rem}
+.reader-goto{background:var(--surface);color:inherit;border:1px solid var(--line);
+  border-radius:10px;box-shadow:0 12px 32px rgba(0,0,0,.45);padding:1.1rem 1.3rem;
+  min-width:18rem;font-size:.9rem}
+.reader-goto::backdrop{background:rgba(0,0,0,.55)}
+.reader-goto h2{margin:0 0 .7rem;font-size:1rem}
+.reader-goto-row{display:flex;align-items:center;gap:.5rem;margin:.6rem 0}
+.reader-goto-label{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+.reader-goto-input{flex:1;min-width:0;padding:.4rem .6rem;border:1px solid var(--line);
+  border-radius:6px;background:var(--surface-2);color:inherit;font-size:1rem;
+  font-variant-numeric:tabular-nums}
+.reader-goto-unit{font-size:.85rem;opacity:.75;font-variant-numeric:tabular-nums;white-space:nowrap}
+.reader-goto-actions{margin-top:1rem;display:flex;gap:.5rem;justify-content:flex-end}
 .reader-toc{position:fixed;top:0;bottom:0;left:0;z-index:60;
   width:min(22rem,85vw);overflow-y:auto;padding:1rem 1.1rem;
   background:var(--surface);border-right:1px solid var(--line);

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -336,6 +336,42 @@ check('the page number counts forward with the turns',
     `${round.footerMode}: ${JSON.stringify(round.chapter)}`);
 }
 
+// Clicking percentage opens the go-to dialog and lets the reader jump to a percentage.
+{
+  await evalIn(`document.getElementById('reader-progress-text').click()`);
+  const dialogOpen = await evalIn(`document.getElementById('reader-goto')?.open`);
+  check('clicking percentage opens the goto dialog', dialogOpen === true);
+  const title = await evalIn(`document.getElementById('reader-goto-title')?.textContent`);
+  check('dialog title is percentage', title === 'Go to percentage');
+  // Jump to 50%
+  await evalIn(`(() => {
+    const input = document.getElementById('reader-goto-input');
+    input.value = '50';
+    document.getElementById('reader-goto-form').dispatchEvent(new Event('submit', { cancelable: true }));
+  })()`);
+  await new Promise((r) => setTimeout(r, 600));
+  const jumped = JSON.parse(await evalIn(probe));
+  check('percentage jump reached ~50%', Math.abs(jumped.fraction - 0.5) < 0.15, `${jumped.fraction}`);
+}
+
+// Clicking page number opens the go-to dialog and lets the reader jump to a page.
+{
+  await evalIn(`document.getElementById('reader-page').click()`);
+  const dialogOpen = await evalIn(`document.getElementById('reader-goto')?.open`);
+  check('clicking page opens the goto dialog', dialogOpen === true);
+  const title = await evalIn(`document.getElementById('reader-goto-title')?.textContent`);
+  check('dialog title is page', title === 'Go to page');
+  // Jump to page 1
+  await evalIn(`(() => {
+    const input = document.getElementById('reader-goto-input');
+    input.value = '1';
+    document.getElementById('reader-goto-form').dispatchEvent(new Event('submit', { cancelable: true }));
+  })()`);
+  await new Promise((r) => setTimeout(r, 600));
+  const jumped = JSON.parse(await evalIn(probe));
+  check('page jump reached page 1', /^(1 of|1\b)/.test(jumped.page || ''), `${jumped.page}`);
+}
+
 // Going back has to work too, or the reader is a one-way trip.
 await evalIn(`document.getElementById('reader-prev').click()`);
 await new Promise((r) => setTimeout(r, 900));

--- a/internal/webui/testdata/readerpositions.test.mjs
+++ b/internal/webui/testdata/readerpositions.test.mjs
@@ -130,11 +130,11 @@ test('pageLocation skips non-linear sections properly', () => {
   );
   // Total is 4 + 2 = 6 pages
   assert.equal(t.total, 6);
-  // Page 1 is in section 1
+  // Page 1 is in the second section (index 1)
   const loc1 = pageLocation(t, 1);
   assert.equal(loc1.index, 1);
   assert.equal(pageAt(t, loc1.index, loc1.anchor), 1);
-  // Page 5 is in section 3
+  // Page 5 is in the fourth section (index 3)
   const loc5 = pageLocation(t, 5);
   assert.equal(loc5.index, 3);
   assert.equal(pageAt(t, loc5.index, loc5.anchor), 5);

--- a/internal/webui/testdata/readerpositions.test.mjs
+++ b/internal/webui/testdata/readerpositions.test.mjs
@@ -6,7 +6,7 @@
 // shows have to be the same page.
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { positionTable, pageAt, PAGE_LENGTH } from '../static/reader-positions.js';
+import { positionTable, pageAt, pageLocation, PAGE_LENGTH } from '../static/reader-positions.js';
 
 const section = (compressedSize, extra = {}) => ({ compressedSize, ...extra });
 const table = (...sections) => positionTable(sections);
@@ -110,4 +110,50 @@ test('a real book comes out at the number the app shows', () => {
   assert.equal(t.total, 578);
   assert.equal(pageAt(t, 0, 0), 1);
   assert.equal(pageAt(t, stored.length - 1, 1), 578);
+});
+
+test('pageLocation round-trips exactly through pageAt for every page', () => {
+  const t = table(section(1024), section(2048), section(4096));
+  for (let p = 1; p <= t.total; p++) {
+    const loc = pageLocation(t, p);
+    assert.ok(loc, `expected location for page ${p}`);
+    assert.equal(pageAt(t, loc.index, loc.anchor), p);
+  }
+});
+
+test('pageLocation skips non-linear sections properly', () => {
+  const t = table(
+    section(2048, { linear: 'no' }),
+    section(4096),
+    section(1024, { linear: 'no' }),
+    section(2048),
+  );
+  // Total is 4 + 2 = 6 pages
+  assert.equal(t.total, 6);
+  // Page 1 is in section 1
+  const loc1 = pageLocation(t, 1);
+  assert.equal(loc1.index, 1);
+  assert.equal(pageAt(t, loc1.index, loc1.anchor), 1);
+  // Page 5 is in section 3
+  const loc5 = pageLocation(t, 5);
+  assert.equal(loc5.index, 3);
+  assert.equal(pageAt(t, loc5.index, loc5.anchor), 5);
+});
+
+test('pageLocation clamps out-of-range pages and rounds floats', () => {
+  const t = table(section(4096));
+  assert.equal(pageLocation(t, 0).anchor, pageLocation(t, 1).anchor);
+  assert.equal(pageLocation(t, -10).anchor, pageLocation(t, 1).anchor);
+  assert.equal(pageLocation(t, 999).anchor, pageLocation(t, t.total).anchor);
+  assert.equal(pageLocation(t, 2.2).anchor, pageLocation(t, 2).anchor);
+});
+
+test('pageLocation returns null for invalid inputs', () => {
+  const t = table(section(4096));
+  assert.equal(pageLocation(null, 1), null);
+  assert.equal(pageLocation(t, NaN), null);
+  assert.equal(pageLocation(t, Infinity), null);
+  assert.equal(pageLocation(t, -Infinity), null);
+  assert.equal(pageLocation(t, 'not a number'), null);
+  assert.equal(pageLocation({ total: 0 }, 1), null);
 });


### PR DESCRIPTION
Allows clicking the reading percentage or page number in the reader footer to open a dialog for jumping directly to a specific position. The keyboard shortcut `g` also opens the dialog. Clicking the middle slot or elsewhere on the footer continues to cycle the footer display mode as before.