### PR TITLE
Keep reader controls visible until auto-hide is enabled

### DIFF
--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -678,7 +678,7 @@ const SETTINGS_DEFAULTS = Object.freeze({
   flow: "paginated",
   columns: "auto",
   margin: "normal",
-  autohide: true,
+  autohide: false,
   footer: "chapter",
 });
 // What the footer's middle slot shows; a click on the footer walks
@@ -1029,6 +1029,10 @@ function tapAt(x, y) {
     if (chromeVisible()) armChrome(CHROME_IDLE_MS);
     return true;
   }
+  if (!settings.autohide) {
+    setChrome(true);
+    return true;
+  }
   if (chromeVisible()) {
     clearTimeout(chromeTimer);
     setChrome(false);
@@ -1054,7 +1058,7 @@ function toggleChrome() {
 function pointerMoved(x, y, pointerType) {
   if (pointerType === "touch") return; // a finger reveals by tapping
   if (!chromeAuto()) return;
-  if (inTopZone(y) || tapZone(x) !== "chrome") revealChrome();
+  if (inTopZone(y)) revealChrome();
   else if (chromeVisible()) armChrome(CHROME_IDLE_MS);
 }
 
@@ -1190,6 +1194,7 @@ function wireChapterPointer(doc) {
     "pointerdown",
     (e) => {
       noteActivity();
+      if (settingsPanel && settingsPanel.open) settingsPanel.open = false;
       if (gesture.id !== null && gesture.id !== e.pointerId) {
         gesture.spoiled = true; // a second finger: not a tap any more
         return;

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -587,6 +587,19 @@ const chromeState = () => evalIn(`JSON.stringify({
   footer: getComputedStyle(document.getElementById('reader-footer')).display,
 })`);
 const idle = () => new Promise((r) => setTimeout(r, 3000));
+const defaultChrome = JSON.parse(await chromeState());
+const defaultAutoHide = await evalIn(
+  `document.querySelector('#reader-settings-form input[name="autohide"]').checked`,
+);
+check('the chrome stays visible by default',
+  defaultAutoHide === false && defaultChrome.state === 'visible' && defaultChrome.bar === '1',
+  JSON.stringify({ defaultAutoHide, ...defaultChrome }));
+await evalIn(`(() => {
+  const box = document.querySelector('#reader-settings-form input[name="autohide"]');
+  box.checked = true;
+  box.dispatchEvent(new Event('input', { bubbles: true }));
+  return true;
+})()`);
 // Tap the chapter document itself, the way a pointer really does it:
 // pointerdown, pointerup, then the click, in the frame's own
 // coordinates, so the page turned on is the one the reader is looking
@@ -611,6 +624,17 @@ const tapChapter = (where, kind = 'mouse', drift = 0) => evalIn(`(() => {
 })()`);
 const settle = () => new Promise((r) => setTimeout(r, 1200));
 
+const settingsOpened = await evalIn(`(() => {
+  const panel = document.getElementById('reader-settings');
+  panel.querySelector('summary').click();
+  return panel.open;
+})()`);
+check('the Aa menu opens', settingsOpened === true, String(settingsOpened));
+await tapChapter('middle', 'touch');
+await new Promise((r) => setTimeout(r, 400));
+const settingsClosed = await evalIn(`!document.getElementById('reader-settings').open`);
+check('clicking the book closes the Aa menu', settingsClosed === true, String(settingsClosed));
+
 await idle();
 const parked = JSON.parse(await chromeState());
 check('the chrome steps aside while reading',
@@ -620,6 +644,17 @@ check('the chrome steps aside while reading',
 // what a reader glances at mid-page, bars or no bars.
 check('the footer stays while the chrome is hidden',
   parked.footer !== 'none', JSON.stringify(parked));
+
+await evalIn(`(() => {
+  document.dispatchEvent(new PointerEvent('pointermove', {
+    bubbles: true, clientX: window.innerWidth - 4, clientY: window.innerHeight / 2,
+  }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
+const passedSide = JSON.parse(await chromeState());
+check('moving along the side leaves the chrome hidden',
+  passedSide.state === 'hidden' && passedSide.bar === '0', JSON.stringify(passedSide));
 
 await evalIn(`(() => {
   document.dispatchEvent(new PointerEvent('pointermove', {
@@ -1204,16 +1239,10 @@ check('the auto-hide choice persists in the browser',
   String(savedChrome));
 await tapChapter('middle', 'touch');
 await new Promise((r) => setTimeout(r, 500));
-const manuallyHidden = JSON.parse(await chromeState());
-check('a middle tap can still hide fixed chrome',
-  manuallyHidden.state === 'hidden' && manuallyHidden.bar === '0',
-  JSON.stringify(manuallyHidden));
-await tapChapter('middle', 'touch');
-await new Promise((r) => setTimeout(r, 500));
-const manuallyShown = JSON.parse(await chromeState());
-check('a second middle tap restores fixed chrome',
-  manuallyShown.state === 'visible' && manuallyShown.bar === '1',
-  JSON.stringify(manuallyShown));
+const fixedAfterTap = JSON.parse(await chromeState());
+check('a middle tap does not hide fixed chrome',
+  fixedAfterTap.state === 'visible' && fixedAfterTap.bar === '1',
+  JSON.stringify(fixedAfterTap));
 
 // The browser refusing to run the publication's script is verified by
 // confirming the script did not run and no unexpected errors occurred.

--- a/internal/webui/testdata/readerfirefox.mjs
+++ b/internal/webui/testdata/readerfirefox.mjs
@@ -232,6 +232,19 @@ const chromeState = () => evalIn(`JSON.stringify({
   state: document.body.dataset.readerChrome,
   bar: getComputedStyle(document.querySelector('.reader-bar')).opacity,
 })`);
+const defaultChrome = JSON.parse(await chromeState());
+const defaultAutoHide = await evalIn(
+  `document.querySelector('#reader-settings-form input[name="autohide"]').checked`,
+);
+check('the chrome stays visible by default',
+  defaultAutoHide === false && defaultChrome.state === 'visible' && defaultChrome.bar === '1',
+  JSON.stringify({ defaultAutoHide, ...defaultChrome }));
+await evalIn(`(() => {
+  const box = document.querySelector('#reader-settings-form input[name="autohide"]');
+  box.checked = true;
+  box.dispatchEvent(new Event('input', { bubbles: true }));
+  return true;
+})()`);
 const ffTap = (where, kind) => evalIn(`(() => {
   const doc = document.querySelector('foliate-view').renderer.getContents()[0].doc;
   const win = doc.defaultView;
@@ -253,6 +266,17 @@ await new Promise((r) => setTimeout(r, 2600));
 const ffParked = JSON.parse(await chromeState());
 check('the chrome steps aside while reading',
   ffParked.state === 'hidden' && ffParked.bar === '0', JSON.stringify(ffParked));
+
+await evalIn(`(() => {
+  document.dispatchEvent(new PointerEvent('pointermove', {
+    bubbles: true, clientX: window.innerWidth - 4, clientY: window.innerHeight / 2,
+  }));
+  return true;
+})()`);
+await new Promise((r) => setTimeout(r, 400));
+const ffPassedSide = JSON.parse(await chromeState());
+check('moving along the side leaves the chrome hidden',
+  ffPassedSide.state === 'hidden' && ffPassedSide.bar === '0', JSON.stringify(ffPassedSide));
 
 await evalIn(`(() => {
   document.dispatchEvent(new PointerEvent('pointermove', {


### PR DESCRIPTION
## What changed

The reader keeps its navigation controls visible by default. Readers who enable auto-hide still get the top-edge reveal behavior, and tapping the book closes the settings menu without hiding fixed controls.

## Why

Controls are available when a reader opens a book, while auto-hide remains an explicit preference.

## Testing

- `go test -race ./internal/webui -run 'TestReader'`