### PR TITLE
Make a refused sync recoverable

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,14 @@ jobs:
       - name: Test (SQLite + PostgreSQL, race detector)
         env:
           LISEUR_PG_TEST_DSN: postgres://liseur:ci@localhost:5432/liseur_test?sslmode=disable
-        run: go test -race -timeout 300s ./...
+        # The timeout is a guard against a hung test, not a speed budget.
+        # It applies per package binary, and internal/webui already spends
+        # most of five minutes here: argon2id is deliberately expensive and
+        # the suite logs in many times, under the race detector, on a
+        # two-core runner. At 300s a normal run was one slow scheduler away
+        # from failing, so a package that merely grew a few tests would
+        # start "timing out" without anything being wrong.
+        run: go test -race -timeout 900s ./...
 
   lint-openapi:
     runs-on: ubuntu-latest

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -203,8 +203,8 @@ Positions are an **append-only operation log per work per user**:
 {
   "op_id":        "client-generated deterministic opaque id",
   "work_id":      "…",
-  "edition_sha":  "sha256:…",
-  "device_id":    "…",
+  "edition_sha":  "<hex sha256 of the exact file>",
+  "device_id":    "<server-side, from the token; never sent by a client>",
   "client_ts":    "2026-08-10T12:58:04Z",
   "progression":  0.4137,
   "locator":      { "…Readium Locator JSON, opaque to server…" },
@@ -222,7 +222,11 @@ Positions are an **append-only operation log per work per user**:
   kosync pulls, never parsed.
 - `op_id` is a client-generated opaque
   deterministic string. The same local fact must produce the same ID and
-  payload on retry.
+  payload on retry. The server compares the whole stored payload,
+  `device_id` included, when it decides between `duplicate` and
+  `conflict`; a client that wants its replays recognised after a
+  credential lapse keeps its device identity
+  ([ADR-0033](adr/0033-a-device-outlives-its-token.md)).
 
 The server assigns each accepted op a **per-user monotonic `seq`**.
 
@@ -254,7 +258,11 @@ undo, session inference for legacy devices (§6.3), and trust: users can
 see what each device claimed and when.
 
 Retention: ops older than a configurable window (default 180 days) are
-compacted to daily last-op-per-device snapshots.
+compacted to daily last-op-per-device snapshots. The newest op per
+(work, device) is kept whatever its age, and a kosync op not yet
+materialised into an inferred session (§6.3) is kept until it is. The
+horizon is the newest seq compaction removed; a cursor below it gets
+`410 resync_required` and rebuilds from `GET /v1/heads`.
 
 ### 5.4 Conflicts are resolved by clients
 

--- a/docs/adr/0016-token-self-introspection.md
+++ b/docs/adr/0016-token-self-introspection.md
@@ -112,8 +112,9 @@ provided the tests pin the fact that it never reveals a second token.
    tells a client to call this before drawing a menu.
 3. **Stable account identity.** Return `account_id` from `GET /v1/token`,
    document its comparison rules, and cover replacement tokens for the same
-   account and tokens belonging to different accounts. This phase remains to
-   be implemented.
+   account and tokens belonging to different accounts. Implemented: the
+   value is the account's opaque user id, pinned by
+   `TestTokenAccountIDIsStableAcrossTokens`.
 
 ## Acceptance criteria
 

--- a/docs/adr/0033-a-device-outlives-its-token.md
+++ b/docs/adr/0033-a-device-outlives-its-token.md
@@ -1,0 +1,72 @@
+# ADR-0033: A device outlives its token
+
+- **Status:** Accepted; implemented
+- **Date:** 2026-09-04
+- **Amends:** [ADR-0016](0016-token-self-introspection.md), whose phase 3
+  (`account_id`) ships alongside this
+
+## Context
+
+Every token minted through `POST /v1/tokens` draws a fresh `device_id`.
+The op log stamps that id on each op and session, and the store compares
+it when a replayed `op_id` or `session_id` decides between `duplicate` and
+`conflict`. The Android client derives those ids from a key of its own
+that never changes, and relies on the server calling a byte-identical
+replay a duplicate: that is how a push whose answer was lost is simply
+sent again, with no table of requests in flight.
+
+The two agree until the credential lapses. A user who reconnects mints a
+new token, the phone gets a new `device_id`, and every record it stored
+before the lapse but never saw acknowledged now replays under a
+different device. An op comes back `conflict` and the book stays dirty; a
+session comes back `409` and, with the old client, took its whole batch
+down with it. Nothing was wrong on either side. They just disagreed about
+what a device was.
+
+The web reader had already met this: `MintReaderToken` inherits the
+browser's previous device id so that a tab reopened after an hour is not
+a new head in the op log.
+
+## Decision
+
+`POST /v1/tokens` accepts an optional `device_id`. The mint honours it
+when some token of the same account — live, expired or revoked — already
+carries that id; otherwise it answers `400` with `code: unknown_device`.
+A deleted predecessor is gone on purpose and is not a source of identity.
+
+The store keeps comparing `device_id` in `sameOp` and `sameSession`. Two
+phones at the same revision of the same book are two positions and must
+not silence each other; that rule is worth more than the convenience of
+a device-free replay.
+
+`GET /v1/token` gains `account_id`, so a client can tell a replaced
+credential from a different account and keep its cursor and mirrors
+through a reconnect.
+
+## Consequences
+
+A device id is a label in the op log, not a credential. Anyone who can
+log in to an account can make a new token carry any device id that
+account has ever had; that collapses two physical devices into one in
+`GET /v1/heads` and in the statistics, and it crosses no account
+boundary. Two live tokens may share one id.
+
+Only a login-authenticated mint can ask for inheritance. A bearer secret
+pasted from elsewhere carries whatever device id it was minted with, and
+a client that reconnects that way still sees `conflict`/`409` for
+records it never got an answer for. Those are then handled item by item
+and never dropped, but they are not duplicates. A rotation authenticated
+by the old device token itself would close that gap and is future work.
+
+An older server ignores the field and mints a fresh id. A client detects
+that by comparing the returned `device_id` with the one it sent.
+
+## Acceptance criteria
+
+- A revoked predecessor's id is inherited; an op pushed on the old token
+  replays as `duplicate` on the new one; `GET /v1/heads` shows one device.
+- An id no token of the account ever carried, and an id from another
+  account, are refused with `400 unknown_device`.
+- Two live tokens sharing one id both authenticate and both report it.
+- `docs/openapi.yaml` and `docs/integrating.md` describe the field, the
+  error, the old-server fallback and the label-not-credential rule.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@ loose ends that must come before any of it, are in
 | [0030](0030-web-reader-reading-sessions.md) | The web reader counts its sittings | Later | Accepted; implemented | Visibility-bounded sittings, three-minute idle cap, ten-second minimum, no local persistence; amends [0007](0007-web-reader.md) |
 | [0031](0031-web-reader-footer.md) | The web reader's footer mirrors the app | Later | Accepted; implemented | Percent, middle slot, page in the engine's bottom margin; pages are engine locations, never fabricated; click cycles the middle; a browser preference; amends [0012](0012-reader-engine-foliate.md) |
 | [0032](0032-reader-pages-are-readium-positions.md) | The reader's page is the app's page | Later | Accepted; implemented | Pages counted as Readium positions so the browser and the app name the same page; display only, no server or API change; three recorded patches to the vendored engine; amends [0031](0031-web-reader-footer.md) and [0012](0012-reader-engine-foliate.md) |
+| [0033](0033-a-device-outlives-its-token.md) | A device outlives its token | MVP | Accepted; implemented | `POST /v1/tokens` inherits a `device_id` the account already carried, `400 unknown_device` otherwise; `account_id` on `GET /v1/token`; the store keeps comparing devices; amends [0016](0016-token-self-introspection.md) |
 
 ## Convention
 

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -248,25 +248,54 @@ POST /v1/ops
 `op_id` is the idempotency key: generate it once per position event and
 keep it until the server acknowledges it. A network retry then reports
 the original `seq` instead of writing twice. Never reuse an `op_id` for
-a different position; the server rejects it as a conflict.
+a different position; the server rejects it as a conflict. The device
+is part of what "the same op" means: a replay from a token with a
+different `device_id` is a `conflict`, which is why a reconnecting
+client should keep its device identity (see *Keeping one device
+identity across reconnects*).
 
-One refusal is recoverable. Orphan cleanup can delete a work that has
-no catalog mapping and no reading history, and a batch naming it then
-fails (atomically, nothing is stored) with `400` and a structured
-body:
+The per-item `results` are `applied`, `duplicate` or `conflict`. A
+`conflict` is a result, not a refusal: the other items in the batch are
+stored. Treat it as a permanent answer for that `op_id` — report it and
+send that position again under a fresh id; sending the same op again
+will only conflict again.
+
+#### When a batch is refused
+
+The batch is appended atomically, so a `400` means nothing in it was
+stored. The body names the first item that caused it:
 
 ```json
-{ "error": "op <op-id>: unknown work", "code": "unknown_work",
-  "work_id": "…", "op_id": "…" }
+{ "error": "op <op-id>: locator too large", "code": "locator_too_large",
+  "item_index": 3, "op_id": "…", "limit": 16384 }
 ```
 
-`POST /v1/sessions` answers the same shape keyed by `session_id`. Key
-the recovery off `code`, never off the message text: re-resolve the
-book (`POST /v1/works/resolve`, or `/v1/books/{id}/resolve` for a
-catalog book), reseed from the fresh work's positions, rebuild the
-batch under the new `work_id` (the `op_id` derives from it) and
-retry. Any other `400` is malformed input and will never be accepted
-as-is.
+`item_index` is always present for an item-level refusal; `op_id` when
+the item had one (a `missing_field` about the id itself cannot name
+it). Key the recovery off `code`, never off the message text:
+
+- `unknown_work` (with `work_id`): orphan cleanup deleted a work that
+  had no catalog mapping and no reading history. Re-resolve the book
+  (`POST /v1/works/resolve`, or `/v1/books/{id}/resolve` for a catalog
+  book), reseed from the fresh work's positions, rebuild the batch under
+  the new `work_id` and retry.
+- `locator_too_large` (with `limit`): the server's `ops.max_locator_bytes`
+  is configurable and may be smaller than you assumed. Retry that op
+  under the same `op_id` without its locator; the progression still
+  syncs.
+- `batch_too_large` (with `limit`, no `item_index`): split the batch.
+- Anything else (`missing_field`, `bad_time`, `time_in_future`,
+  `progression_out_of_range`) is malformed input and will never be
+  accepted as is. Set that item aside and send the rest.
+
+A body over `ops.max_body_bytes` is `413`; halve the batch and retry.
+
+`POST /v1/sessions` answers the same shape keyed by `session_id`, plus
+`409 {"code": "id_reused", "session_id": …, "item_index": …}` when a
+session id was already accepted with a different payload. Never mark a
+whole refused batch as sent: only the named item is the problem, and
+an hour of reading dropped because a neighbour was malformed is an hour
+that never happened.
 
 `progression` is the lingua franca every device understands. `locator`
 is your reader's exact position: a Readium locator, a CFI, whatever
@@ -284,12 +313,20 @@ GET /v1/changes?since=<cursor>&limit=500
 
 Apply the ops, then set your cursor to the last returned `seq`, or to
 `high_water` when the page is empty. While `has_more` is true, request
-the next page immediately.
+the next page immediately. The page, `high_water` and the compaction
+check are read from one snapshot, so a page you were not told to resync
+from has no holes in it. A `since` that is not a non-negative integer
+is `400`, not a replay from zero.
 
 If the server answers `410 {"error": "resync_required"}`, your cursor
 fell behind the compaction horizon. Fetch `GET /v1/heads`, rebuild your
-local state from those heads, set your cursor to `snapshot_seq`, and
+local state from those heads, set your cursor to its `snapshot_seq`, and
 resume normal delta sync.
+
+A work can also disappear from under a cursor: a reader deleting a work
+(ADR-0024) removes its ops without a tombstone in this feed. A client
+that holds ops for a work the server no longer knows learns so on its
+next push (`unknown_work`), not on pull.
 
 ### Conflicts
 

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -42,6 +42,36 @@ Use `PATCH /v1/tokens/{id}` with the same `scope`/`scopes` shape to
 change capabilities without changing the token secret, device id, or
 retry identity.
 
+### Keeping one device identity across reconnects
+
+Every mint draws a fresh `device_id`, and the server compares
+`device_id` when it decides whether a replayed `op_id` or `session_id`
+is a duplicate. So a client that reconnects with a new token after a
+lost acknowledgement would replay its stored records as `conflict`
+(ops) or `409` (sessions), not `duplicate`.
+
+To stay one device, store the `device_id` the first mint returned and
+send it back on every later mint for the same server:
+
+```json
+POST /v1/tokens
+{"name": "Boox Palma", "scopes": ["sync"], "device_id": "dev_9c21"}
+```
+
+The server honours it when any token of the same account — live,
+expired or revoked — already carries that id. If none does (the
+predecessor was deleted, or the id belongs to another account) it
+answers `400` with `code: unknown_device`; retry once without the field
+and store the fresh id. An older server ignores the field and mints a
+new id: compare the `device_id` in the response with the one you sent,
+and treat a mismatch as "not inherited", nothing more. Never offer a
+device id to a different server.
+
+A device id is a label in the op log, not a credential: two live tokens
+that share one are one device in `GET /v1/heads` and in the statistics.
+Only a mint through `/v1/login` can ask for one; a bearer secret pasted
+from elsewhere carries whatever device id it was minted with.
+
 The scopes are `sync`, `read-insights`, `library-read`,
 `library-manage`, `library-upload`, `library-delete`, and `admin`. `admin` implies every scope and is not
 self-grantable: requesting it returns `403` unless the account is

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -83,6 +83,7 @@ GET /v1/token
 ```json
 {
   "id": "tok_7f3a",
+  "account_id": "usr_31b0",
   "device_id": "dev_9c21",
   "name": "Boox Palma",
   "scopes": ["sync", "library-read"]
@@ -95,6 +96,14 @@ when `library-manage` is present, and the reading statistics when
 `read-insights` is. Probing routes and reading `403`s works, but it
 means the first thing the user sees is an error the client could have
 avoided.
+
+`account_id` is the stable name of the account. Every token minted on
+the account carries the same value, so when the user pastes a new
+secret or reconnects, compare it with the one you stored: equal means
+the same account, keep your catalog mirror, aliases and sync cursor;
+different means an account switch, clear them. Neither `id` nor
+`device_id` is suitable for that comparison: both change with every
+minted token.
 
 The route needs no particular scope (the narrowest token can ask about
 itself) but it is still authenticated: an absent, revoked or expired

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -526,13 +526,25 @@ paths:
                     type: array
                     items: { $ref: "#/components/schemas/OpResult" }
         "400":
-          $ref: "#/components/responses/Error"
           description: |
-            Malformed batch, or one item naming a work the server no
-            longer holds. The whole batch is rejected atomically. An
-            unknown work comes back as `code: unknown_work` with the
-            `work_id` and the offending `op_id`: re-resolve the book to
-            refresh its cached identity, then retry.
+            The batch was refused as a whole; nothing was stored. A
+            batch-level refusal (`ops required`, `code: batch_too_large`
+            with `limit`) has no item to name. An item-level refusal
+            names the first bad item: `code`, its zero-based `item_index`,
+            and its `op_id` when it had one. `unknown_work` is the one a
+            client recovers from by re-resolving the book and retrying
+            under the fresh `work_id`; `locator_too_large` carries the
+            byte `limit` and the op may be retried under the same
+            `op_id` without its locator, since the original batch was
+            never stored.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BatchItemError" }
+        "413":
+          description: Request body over `ops.max_body_bytes`
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /v1/changes:
     get:
@@ -540,11 +552,14 @@ paths:
       summary: Delta-sync every op after a seq
       security: [{ deviceToken: [] }]  # requires sync scope
       parameters:
-        - { name: since, in: query, schema: { type: integer, default: 0 } }
+        - { name: since, in: query, schema: { type: integer, default: 0, minimum: 0 } }
         - { name: limit, in: query, schema: { type: integer, default: 500, maximum: 500 } }
       responses:
         "200":
-          description: Page of ops with the new high-water mark
+          description: |
+            Page of ops with the new high-water mark. The page, the mark
+            and the compaction check come from one snapshot: a page you
+            were not told to resync from has no holes in it.
           content:
             application/json:
               schema:
@@ -555,8 +570,15 @@ paths:
                     items: { $ref: "#/components/schemas/Op" }
                   high_water: { type: integer }
                   has_more: { type: boolean }
+        "400":
+          description: "`since` is not a non-negative integer"
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
         "410":
-          description: Cursor below the compaction horizon
+          description: |
+            Cursor below the compaction horizon. Fetch `heads_endpoint`
+            and resume from its `snapshot_seq`.
           content:
             application/json:
               schema:
@@ -565,6 +587,7 @@ paths:
                   error: { type: string, enum: [resync_required] }
                   high_water: { type: integer }
                   heads_endpoint: { type: string }
+                  message: { type: string }
 
   /v1/heads:
     get:
@@ -642,14 +665,30 @@ paths:
                 type: object
                 properties: { accepted: { type: integer } }
         "400":
-          $ref: "#/components/responses/Error"
           description: |
-            Malformed batch, or one item naming a work the server no
-            longer holds. The whole batch is rejected atomically. An
-            unknown work comes back as `code: unknown_work` with the
-            `work_id` and the offending `session_id`: re-resolve the book
-            to refresh its cached identity, then retry.
-        "409": { $ref: "#/components/responses/Error", description: "session_id reused with different payload" }
+            The batch was refused as a whole; nothing was stored. Same
+            shape as `POST /v1/ops`: a batch-level refusal (`sessions
+            required`, `code: batch_too_large` with `limit`) names no
+            item; an item-level one names the first bad item by `code`,
+            `item_index` and `session_id` when it had one. `unknown_work`
+            is recoverable by re-resolving the book and retrying.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BatchItemError" }
+        "409":
+          description: |
+            A `session_id` in the batch was already accepted with a
+            different payload (live, or archived as a rollup tombstone).
+            `code: id_reused`, with the `session_id` and its `item_index`;
+            the batch was refused as a whole.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/BatchItemError" }
+        "413":
+          description: Request body over `ops.max_body_bytes`
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
 
   /v1/annotations:
     post:
@@ -2130,33 +2169,12 @@ components:
       description: |
         Error with a human-readable reason. Most failures carry only
         `error`; a refusal a client can act on also carries a
-        machine-readable `code` and the identifiers that explain it.
-        Clients must key any recovery off `code`, never off the message
-        text.
+        machine-readable `code` and the identifiers that explain it
+        (see `BatchItemError` for the batch routes). Clients must key
+        any recovery off `code`, never off the message text.
       content:
         application/json:
-          schema:
-            type: object
-            required: [error]
-            properties:
-              error: { type: string }
-              code:
-                type: string
-                enum: [unknown_work]
-                description: |
-                  Present when the refusal is recoverable. `unknown_work`
-                  means a batch item named a work the server no longer
-                  holds — refresh the cached work identity (re-resolve the
-                  book) and retry the batch.
-              work_id:
-                type: string
-                description: The work the server no longer holds.
-              op_id:
-                type: string
-                description: The op that named the unknown work.
-              session_id:
-                type: string
-                description: The session that named the unknown work.
+          schema: { $ref: "#/components/schemas/Error" }
     StatusOK:
       description: OK
       content:
@@ -2166,6 +2184,60 @@ components:
             properties: { status: { type: string } }
 
   schemas:
+    Error:
+      type: object
+      required: [error]
+      properties:
+        error: { type: string }
+        code: { type: string }
+    BatchItemError:
+      type: object
+      description: |
+        A refusal of a batch (`POST /v1/ops`, `POST /v1/sessions`). The
+        batch is appended atomically, so a refusal means nothing was
+        stored, and it names the first item that caused it well enough
+        for a client to set that item aside and send the rest again:
+        `item_index` is always present for an item-level refusal;
+        `op_id`/`session_id` when the item had one (a `missing_field`
+        about the id itself cannot name it). Batch-level refusals
+        (`batch_too_large`) have no `item_index`.
+      required: [error]
+      properties:
+        error: { type: string }
+        code:
+          type: string
+          enum:
+            - unknown_work
+            - missing_field
+            - bad_time
+            - time_in_future
+            - progression_out_of_range
+            - locator_too_large
+            - idle_out_of_range
+            - id_reused
+            - batch_too_large
+          description: |
+            `unknown_work`: the item named a work the server no longer
+            holds; re-resolve the book and retry under the new id.
+            `locator_too_large`: retry that op under the same `op_id`
+            without its locator. `id_reused` (409): the id was already
+            accepted with a different payload; that item will never be
+            taken as is. The validation codes are permanent for that
+            payload. Unrecognised codes should be treated as permanent
+            for the item but reported, not silently dropped.
+        item_index:
+          type: integer
+          description: Zero-based position of the item in the batch.
+        op_id: { type: string }
+        session_id: { type: string }
+        work_id:
+          type: string
+          description: With `unknown_work`, the work the server lacks.
+        limit:
+          type: integer
+          description: |
+            With `locator_too_large`, the byte bound; with
+            `batch_too_large`, the item bound.
     CatalogResolution:
       type: object
       description: |
@@ -2731,7 +2803,15 @@ components:
       type: object
       properties:
         op_id: { type: string }
-        status: { type: string, enum: [applied, duplicate, conflict, invalid] }
+        status:
+          type: string
+          enum: [applied, duplicate, conflict]
+          description: |
+            `applied`: new, with its `seq`. `duplicate`: this `op_id`
+            was already accepted with this exact payload; `seq` is the
+            original. `conflict`: this `op_id` was already accepted with
+            a different payload (or from a different device); the item
+            was not stored and never will be under this id.
         seq: { type: integer }
         reason: { type: string }
     SessionInput:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -226,6 +226,22 @@ paths:
                   description: "Legacy singleton form."
                 scopes: { $ref: "#/components/schemas/ScopeSet" }
                 expires_in_seconds: { type: integer }
+                device_id:
+                  type: string
+                  maxLength: 64
+                  description: |
+                    Ask the new token to carry an existing device identity
+                    instead of a fresh one. Accepted only if a token of
+                    the same account — live, expired or revoked — already
+                    carries it; a client that stored the id from a lapsed
+                    credential stays one device in the op log and its
+                    replays stay `duplicate`. An id this account never
+                    carried (a deleted predecessor, or another account's)
+                    is refused with `400` and `code: unknown_device`.
+                    A device id is a label, not a credential: two live
+                    tokens may share one and are then one device. Older
+                    servers ignore the field; compare the `device_id` in
+                    the response with the one you asked for.
       responses:
         "201":
           description: Token created; secret shown once
@@ -246,7 +262,20 @@ paths:
                   scopes: { $ref: "#/components/schemas/ScopeSet" }
                   secret: { type: string, description: "Bearer secret, returned exactly once" }
                   expires_at: { type: [string, "null"], format: date-time }
-        "400": { $ref: "#/components/responses/Error" }
+        "400":
+          description: |
+            Malformed request, or `device_id` names no device of this
+            account (body carries `code: unknown_device` and echoes
+            `device_id`).
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [error]
+                properties:
+                  error: { type: string }
+                  code: { type: string, enum: [unknown_device] }
+                  device_id: { type: string }
         "401": { $ref: "#/components/responses/Error" }
         "403":
           description: |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2638,9 +2638,17 @@ components:
         uses for the same things; `created_at` and `revoked` are absent
         because a caller that reaches this route is neither revoked nor
         expired.
-      required: [id, device_id, name, scopes]
+      required: [id, account_id, device_id, name, scopes]
       properties:
         id: { type: string }
+        account_id:
+          type: string
+          description: |
+            Opaque, stable name for the account the token belongs to.
+            Every token minted on one account carries the same value;
+            compare it, not `device_id` or `id`, to decide whether a
+            replaced credential is the same account (keep mirrors and
+            cursors) or a different one (clear them).
         device_id: { type: string }
         name: { type: string }
         scope:

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -3,8 +3,10 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -84,17 +86,115 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 // work id.
 const errCodeUnknownWork = "unknown_work"
 
-// writeUnknownWork answers a batch item that named a work the server
-// does not hold. The message stays what it always was; the extra fields
-// let a client recover without parsing it: which work is gone, and
-// which item of the batch blamed it ("op_id" or "session_id").
-func writeUnknownWork(w http.ResponseWriter, msg, itemField, itemID, workID string) {
-	writeJSON(w, http.StatusBadRequest, map[string]string{
-		"error":   msg,
-		"code":    errCodeUnknownWork,
-		"work_id": workID,
-		itemField: itemID,
+// Item-level refusal codes shared by POST /v1/ops and POST /v1/sessions.
+// A batch is appended atomically, so a refusal must name the item that
+// caused it well enough for a client to set that one aside and send the
+// rest again without parsing prose.
+const (
+	errCodeMissingField   = "missing_field"
+	errCodeBadTime        = "bad_time"
+	errCodeTimeInFuture   = "time_in_future"
+	errCodeProgression    = "progression_out_of_range"
+	errCodeLocatorTooBig  = "locator_too_large"
+	errCodeIdleOutOfRange = "idle_out_of_range"
+	errCodeIDReused       = "id_reused"
+	errCodeBatchTooLarge  = "batch_too_large"
+)
+
+// itemRefusal is the body of an item-level 4xx. item_index is always
+// set; the id field ("op_id" or "session_id") only when the item had
+// one — a missing_field about the id itself cannot name it.
+type itemRefusal struct {
+	status  int
+	code    string
+	msg     string
+	idField string
+	id      string
+	index   int
+	workID  string
+	limit   int
+}
+
+func (e itemRefusal) write(w http.ResponseWriter) {
+	body := map[string]any{
+		"error":      e.msg,
+		"code":       e.code,
+		"item_index": e.index,
+	}
+	if e.id != "" {
+		body[e.idField] = e.id
+	}
+	if e.workID != "" {
+		body["work_id"] = e.workID
+	}
+	if e.limit > 0 {
+		body["limit"] = e.limit
+	}
+	writeJSON(w, e.status, body)
+}
+
+// writeItemRefusal answers a validation failure on one item of a batch.
+func writeItemRefusal(w http.ResponseWriter, code, kind, idField, id string, index int, what string, limit int) {
+	label := kind + " " + id
+	if id == "" {
+		label = kind + " " + strconv.Itoa(index)
+	}
+	itemRefusal{
+		status: http.StatusBadRequest, code: code, msg: label + ": " + what,
+		idField: idField, id: id, index: index, limit: limit,
+	}.write(w)
+}
+
+// writeStoreItemError maps a *store.ItemError from an append into the
+// same shape: unknown_work for a work the user lacks, id_reused (409)
+// for an idempotency key replayed with a different payload. Anything
+// else is a genuine failure. Reports whether it answered.
+func writeStoreItemError(w http.ResponseWriter, err error, kind, idField string) bool {
+	var item *store.ItemError
+	if !errors.As(err, &item) {
+		return false
+	}
+	label := kind + " " + item.ID
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		itemRefusal{
+			status: http.StatusBadRequest, code: errCodeUnknownWork, msg: label + ": unknown work",
+			idField: idField, id: item.ID, index: item.Index, workID: item.WorkID,
+		}.write(w)
+	case errors.Is(err, store.ErrIDMismatch):
+		itemRefusal{
+			status: http.StatusConflict, code: errCodeIDReused,
+			msg:     label + ": " + idField + " reused with a different payload",
+			idField: idField, id: item.ID, index: item.Index,
+		}.write(w)
+	default:
+		return false
+	}
+	return true
+}
+
+// writeBatchTooLarge is the batch-level refusal; limit says how many
+// items a request may carry.
+func writeBatchTooLarge(w http.ResponseWriter, limit int) {
+	writeJSON(w, http.StatusBadRequest, map[string]any{
+		"error": "batch too large", "code": errCodeBatchTooLarge, "limit": limit,
 	})
+}
+
+// decodeBatch reads a JSON batch body under the configured byte bound.
+// A body over the bound is 413, like the annotations route; anything
+// else that fails to decode is 400. Reports whether it answered.
+func decodeBatch(w http.ResponseWriter, r *http.Request, maxBytes int64, into any) bool {
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBytes)).Decode(into); err != nil {
+		var tooBig *http.MaxBytesError
+		if errors.As(err, &tooBig) {
+			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")
+		} else {
+			writeError(w, http.StatusBadRequest, "invalid JSON body")
+		}
+		return true
+	}
+	return false
 }
 
 // LogServerErrors wraps a handler and logs every 5xx response, so a

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -961,7 +961,7 @@ func TestUnknownWorkRefusal(t *testing.T) {
 	if out["error"] != "op op-gone: unknown work" {
 		t.Fatalf("error message changed: %v", out)
 	}
-	if out["code"] != "unknown_work" || out["work_id"] != "w-gone" || out["op_id"] != "op-gone" {
+	if out["code"] != "unknown_work" || out["work_id"] != "w-gone" || out["op_id"] != "op-gone" || out["item_index"] != 1.0 {
 		t.Fatalf("structured fields: %v", out)
 	}
 
@@ -1002,16 +1002,18 @@ func TestUnknownWorkRefusal(t *testing.T) {
 		t.Fatalf("re-push after rejection: %d %v", code, out)
 	}
 
-	// Every other 400 keeps its old shape: the message, and nothing a
-	// client could mistake for a recoverable refusal.
+	// Every item-level 400 keeps its message and now also names itself:
+	// a code, the item's position, and its id when it had one. A
+	// batch-level refusal has no item to name.
 	code, out = post(t, ts.URL+"/v1/ops", devTok, map[string]any{"ops": []map[string]any{}})
 	if code != 400 || out["error"] != "ops required" || out["code"] != nil {
 		t.Fatalf("empty batch: %d %v", code, out)
 	}
 	code, out = post(t, ts.URL+"/v1/ops", devTok, map[string]any{
-		"ops": []map[string]any{op("op-bad", "")},
+		"ops": []map[string]any{op("op-fine", "w-real"), op("op-bad", "")},
 	})
-	if code != 400 || out["error"] != "op op-bad: work_id required" || out["code"] != nil {
+	if code != 400 || out["error"] != "op op-bad: work_id required" ||
+		out["code"] != "missing_field" || out["item_index"] != 1.0 || out["op_id"] != "op-bad" {
 		t.Fatalf("missing work_id: %d %v", code, out)
 	}
 	bad := sess("s-bad", "w-real")
@@ -1019,7 +1021,8 @@ func TestUnknownWorkRefusal(t *testing.T) {
 	code, out = post(t, ts.URL+"/v1/sessions", devTok, map[string]any{
 		"sessions": []map[string]any{bad},
 	})
-	if code != 400 || out["error"] != "session s-bad: ended_at before started_at" || out["code"] != nil {
+	if code != 400 || out["error"] != "session s-bad: ended_at before started_at" ||
+		out["code"] != "bad_time" || out["item_index"] != 0.0 || out["session_id"] != "s-bad" {
 		t.Fatalf("inverted session: %d %v", code, out)
 	}
 }

--- a/internal/api/ops.go
+++ b/internal/api/ops.go
@@ -31,13 +31,20 @@ type opReqJSON struct {
 // HandlePushOps implements POST /v1/ops — batch, idempotent on op_id.
 // The token's server-side device_id stamps every op; a client-supplied
 // device_id is ignored.
+//
+// Validation stops at the first bad item and refuses the whole batch:
+// the append is atomic, so partial state is never an option, and the
+// refusal names the item (code, item_index, op_id) so the client can
+// set it aside and send the rest again. Whether the work exists is
+// decided by the store inside the append transaction, not here — a
+// check before the transaction could pass and the work be deleted
+// before the insert, turning a recoverable refusal into a 500.
 func (s *Server) HandlePushOps(w http.ResponseWriter, r *http.Request) {
 	tok, _ := auth.TokenFrom(r)
 	var body struct {
 		Ops []opReqJSON `json:"ops"`
 	}
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, s.Cfg.Ops.MaxBodyBytes)).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if decodeBatch(w, r, s.Cfg.Ops.MaxBodyBytes, &body) {
 		return
 	}
 	if len(body.Ops) == 0 {
@@ -45,50 +52,46 @@ func (s *Server) HandlePushOps(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(body.Ops) > s.Cfg.Ops.MaxBatch {
-		writeError(w, http.StatusBadRequest, "batch too large")
+		writeBatchTooLarge(w, s.Cfg.Ops.MaxBatch)
 		return
 	}
 
-	// Validate all items up front; any invalid item fails the batch with
-	// per-item reasons (native clients are expected to be well-formed;
-	// failing loudly beats partial state).
 	ops := make([]store.Op, len(body.Ops))
 	for i, in := range body.Ops {
+		refuse := func(code, what string, limit int) {
+			writeItemRefusal(w, code, "op", "op_id", in.OpID, i, what, limit)
+		}
 		if in.OpID == "" || len(in.OpID) > 64 {
-			writeError(w, http.StatusBadRequest, "op "+strconv.Itoa(i)+": op_id required")
+			in.OpID = ""
+			refuse(errCodeMissingField, "op_id required", 0)
 			return
 		}
 		if in.WorkID == "" {
-			writeError(w, http.StatusBadRequest, "op "+in.OpID+": work_id required")
+			refuse(errCodeMissingField, "work_id required", 0)
 			return
 		}
 		if in.Progression == nil {
-			writeError(w, http.StatusBadRequest, "op "+in.OpID+": progression required")
+			refuse(errCodeMissingField, "progression required", 0)
 			return
 		}
 		// Written as the negation of the in-range test so a NaN (both
 		// comparisons false) is rejected rather than let through, which
 		// the naive `p < 0 || p > 1` would do.
 		if p := *in.Progression; !(p >= 0 && p <= 1) {
-			writeError(w, http.StatusBadRequest, "op "+in.OpID+": progression out of range [0,1]")
+			refuse(errCodeProgression, "progression out of range [0,1]", 0)
 			return
 		}
 		if len(in.Locator) > s.Cfg.Ops.MaxLocatorBytes {
-			writeError(w, http.StatusBadRequest, "op "+in.OpID+": locator too large")
+			refuse(errCodeLocatorTooBig, "locator too large", s.Cfg.Ops.MaxLocatorBytes)
 			return
 		}
 		ts, err := time.Parse(time.RFC3339Nano, in.ClientTS)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "op "+in.OpID+": bad client_ts")
+			refuse(errCodeBadTime, "bad client_ts", 0)
 			return
 		}
 		if ts.After(time.Now().Add(24 * time.Hour)) {
-			writeError(w, http.StatusBadRequest, "op "+in.OpID+": client_ts in the future")
-			return
-		}
-		// Verify the work belongs to the user.
-		if _, err := s.St.WorkByID(r.Context(), tok.UserID, in.WorkID); err != nil {
-			writeUnknownWork(w, "op "+in.OpID+": unknown work", "op_id", in.OpID, in.WorkID)
+			refuse(errCodeTimeInFuture, "client_ts in the future", 0)
 			return
 		}
 		ops[i] = store.Op{
@@ -105,6 +108,9 @@ func (s *Server) HandlePushOps(w http.ResponseWriter, r *http.Request) {
 
 	results, err := s.St.AppendOps(r.Context(), tok.UserID, tok.DeviceID, ops)
 	if err != nil {
+		if writeStoreItemError(w, err, "op", "op_id") {
+			return
+		}
 		writeError(w, http.StatusInternalServerError, "append failed")
 		return
 	}
@@ -124,9 +130,21 @@ func (s *Server) HandlePushOps(w http.ResponseWriter, r *http.Request) {
 }
 
 // HandleChanges implements GET /v1/changes?since=<seq>&limit=<n>.
+//
+// A cursor that does not parse, or is negative, is refused rather than
+// read as zero: zero means "replay everything", and a client that sent
+// garbage should hear so, not silently get a full history.
 func (s *Server) HandleChanges(w http.ResponseWriter, r *http.Request) {
 	tok, _ := auth.TokenFrom(r)
-	since, _ := strconv.ParseInt(r.URL.Query().Get("since"), 10, 64)
+	var since int64
+	if raw := r.URL.Query().Get("since"); raw != "" {
+		v, err := strconv.ParseInt(raw, 10, 64)
+		if err != nil || v < 0 {
+			writeError(w, http.StatusBadRequest, "since must be a non-negative integer")
+			return
+		}
+		since = v
+	}
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
 	if limit <= 0 || limit > 500 {
 		limit = 500
@@ -141,7 +159,7 @@ func (s *Server) HandleChanges(w http.ResponseWriter, r *http.Request) {
 			"error":          "resync_required",
 			"high_water":     page.HighWater,
 			"heads_endpoint": "/v1/heads",
-			"message":        "since is below the compaction horizon; fetch /v1/heads and resume from high_water",
+			"message":        "since is below the compaction horizon; fetch /v1/heads and resume from its snapshot_seq",
 		})
 		return
 	}
@@ -168,8 +186,11 @@ func (s *Server) HandlePositions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
-	if limit <= 0 || limit > 200 {
+	switch {
+	case limit <= 0:
 		limit = 50
+	case limit > 200:
+		limit = 200
 	}
 	ops, err := s.St.Positions(r.Context(), tok.UserID, workID, limit)
 	if err != nil {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -157,9 +157,12 @@ func (s *Server) HandleListTokens(w http.ResponseWriter, r *http.Request) {
 // resources with different credentials, and the URL says so.
 //
 // The field names are the ones GET /v1/tokens already uses for the same
-// things, so a client parses one token shape. Nothing else is returned:
-// not the secret, not its hash, not the other tokens on the account, not
-// the user's identity beyond what the caller already proved.
+// things, so a client parses one token shape. account_id is the one
+// addition: an opaque, stable name for the account the token belongs to,
+// the same for every token minted on it, so a client can tell a replaced
+// credential from a different account without discarding its mirrors and
+// cursors. Nothing else is returned: not the secret, not its hash, not
+// the other tokens on the account.
 func (s *Server) HandleToken(w http.ResponseWriter, r *http.Request) {
 	tok, ok := auth.TokenFrom(r)
 	if !ok {
@@ -167,13 +170,14 @@ func (s *Server) HandleToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, struct {
-		ID       string         `json:"id"`
-		DeviceID string         `json:"device_id"`
-		Name     string         `json:"name"`
-		Scope    *store.Scope   `json:"scope,omitempty"`
-		Scopes   store.ScopeSet `json:"scopes"`
+		ID        string         `json:"id"`
+		AccountID string         `json:"account_id"`
+		DeviceID  string         `json:"device_id"`
+		Name      string         `json:"name"`
+		Scope     *store.Scope   `json:"scope,omitempty"`
+		Scopes    store.ScopeSet `json:"scopes"`
 	}{
-		ID: tok.ID, DeviceID: tok.DeviceID, Name: tok.Name,
+		ID: tok.ID, AccountID: tok.UserID, DeviceID: tok.DeviceID, Name: tok.Name,
 		Scope: legacyScope(tok.Scopes), Scopes: tok.Scopes,
 	})
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -68,6 +68,7 @@ func (s *Server) HandleCreateToken(w http.ResponseWriter, r *http.Request) {
 		Scope     *store.Scope    `json:"scope,omitempty"`
 		Scopes    *store.ScopeSet `json:"scopes,omitempty"`
 		ExpiresIn int             `json:"expires_in_seconds,omitempty"`
+		DeviceID  string          `json:"device_id,omitempty"`
 	}
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64<<10)).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid JSON body")
@@ -75,6 +76,10 @@ func (s *Server) HandleCreateToken(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Name == "" {
 		writeError(w, http.StatusBadRequest, "name required")
+		return
+	}
+	if len(req.DeviceID) > 64 {
+		writeError(w, http.StatusBadRequest, "device_id too long")
 		return
 	}
 	scopes, err := requestedScopes(req.Scope, req.Scopes)
@@ -87,10 +92,20 @@ func (s *Server) HandleCreateToken(w http.ResponseWriter, r *http.Request) {
 		t := time.Now().Add(time.Duration(req.ExpiresIn) * time.Second)
 		expires = &t
 	}
-	secret, tok, err := s.Auth.CreateToken(r.Context(), mustLoginSecret(r), req.Name, scopes, expires)
+	secret, tok, err := s.Auth.CreateToken(r.Context(), mustLoginSecret(r), req.Name, scopes, expires, req.DeviceID)
 	if err != nil {
 		if errors.Is(err, auth.ErrAdminGrantRequiresAdmin) {
 			writeError(w, http.StatusForbidden, err.Error())
+			return
+		}
+		if errors.Is(err, auth.ErrUnknownDevice) {
+			// Structured so a client can tell "start over with a fresh
+			// device" from any other refusal of the mint.
+			writeJSON(w, http.StatusBadRequest, map[string]any{
+				"error":     "device_id names no device of this account",
+				"code":      "unknown_device",
+				"device_id": req.DeviceID,
+			})
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "token creation failed")

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -1,9 +1,7 @@
 package api
 
 import (
-	"encoding/json"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/auth"
@@ -28,66 +26,69 @@ type sessionReqJSON struct {
 
 // HandlePushSessions implements POST /v1/sessions — batch, idempotent
 // on session_id, append-only. The token's device_id stamps each row.
+// Refusals follow the same shape as POST /v1/ops: the first bad item
+// names itself (code, item_index, session_id) and the whole batch is
+// refused; the work check and the idempotency check live in the store,
+// inside the append transaction.
 func (s *Server) HandlePushSessions(w http.ResponseWriter, r *http.Request) {
 	tok, _ := auth.TokenFrom(r)
 	var body struct {
 		Sessions []sessionReqJSON `json:"sessions"`
 	}
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, s.Cfg.Ops.MaxBodyBytes)).Decode(&body); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid JSON body")
+	if decodeBatch(w, r, s.Cfg.Ops.MaxBodyBytes, &body) {
 		return
 	}
 	if len(body.Sessions) == 0 {
 		writeError(w, http.StatusBadRequest, "sessions required")
 		return
 	}
-	if len(body.Sessions) > 1000 {
-		writeError(w, http.StatusBadRequest, "batch too large")
+	if len(body.Sessions) > maxSessionBatch {
+		writeBatchTooLarge(w, maxSessionBatch)
 		return
 	}
 
 	sessions := make([]store.Session, len(body.Sessions))
 	for i, in := range body.Sessions {
+		refuse := func(code, what string) {
+			writeItemRefusal(w, code, "session", "session_id", in.SessionID, i, what, 0)
+		}
 		if in.SessionID == "" || len(in.SessionID) > 64 {
-			writeError(w, http.StatusBadRequest, "session "+strconv.Itoa(i)+": session_id required")
+			in.SessionID = ""
+			refuse(errCodeMissingField, "session_id required")
 			return
 		}
 		if in.WorkID == "" {
-			writeError(w, http.StatusBadRequest, "session "+in.SessionID+": work_id required")
+			refuse(errCodeMissingField, "work_id required")
 			return
 		}
 		started, err := time.Parse(time.RFC3339Nano, in.StartedAt)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "session "+in.SessionID+": bad started_at")
+			refuse(errCodeBadTime, "bad started_at")
 			return
 		}
 		ended, err := time.Parse(time.RFC3339Nano, in.EndedAt)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "session "+in.SessionID+": bad ended_at")
+			refuse(errCodeBadTime, "bad ended_at")
 			return
 		}
 		if ended.Before(started) {
-			writeError(w, http.StatusBadRequest, "session "+in.SessionID+": ended_at before started_at")
+			refuse(errCodeBadTime, "ended_at before started_at")
 			return
 		}
 		if in.StartProg == nil || in.EndProg == nil {
-			writeError(w, http.StatusBadRequest, "session "+in.SessionID+": progression required")
+			refuse(errCodeMissingField, "progression required")
 			return
 		}
 		// Negation of the in-range test so a NaN (both comparisons
 		// false) is rejected rather than let through.
 		sp, ep := *in.StartProg, *in.EndProg
 		if !(sp >= 0 && sp <= 1) || !(ep >= 0 && ep <= 1) {
-			writeError(w, http.StatusBadRequest, "session "+in.SessionID+": progression out of range [0,1]")
+			refuse(errCodeProgression, "progression out of range [0,1]")
 			return
 		}
 		durMs := ended.Sub(started).Milliseconds()
 		if in.IdleMs < 0 || in.IdleMs > durMs {
-			writeError(w, http.StatusBadRequest, "session "+in.SessionID+": idle_ms out of range")
-			return
-		}
-		if _, err := s.St.WorkByID(r.Context(), tok.UserID, in.WorkID); err != nil {
-			writeUnknownWork(w, "session "+in.SessionID+": unknown work", "session_id", in.SessionID, in.WorkID)
+			refuse(errCodeIdleOutOfRange, "idle_ms out of range")
 			return
 		}
 		sessions[i] = store.Session{
@@ -105,8 +106,7 @@ func (s *Server) HandlePushSessions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.St.AppendSessions(r.Context(), tok.UserID, sessions); err != nil {
-		if err == store.ErrIDMismatch {
-			writeError(w, http.StatusConflict, "session_id reused with a different payload")
+		if writeStoreItemError(w, err, "session", "session_id") {
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "append failed")
@@ -114,3 +114,6 @@ func (s *Server) HandlePushSessions(w http.ResponseWriter, r *http.Request) {
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"accepted": len(sessions)})
 }
+
+// maxSessionBatch is how many sessions one request may carry.
+const maxSessionBatch = 1000

--- a/internal/api/syncbatch_test.go
+++ b/internal/api/syncbatch_test.go
@@ -1,0 +1,266 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// syncFixture: one user with one work and a sync token; a batch item
+// factory for each of the two batch routes.
+func syncFixture(t *testing.T) (url string, st store.Store, tok string) {
+	t.Helper()
+	ts, st := testServer(t)
+	ctx := t.Context()
+	hash, _ := auth.HashPassword("hunter2hunter")
+	u := store.User{ID: "u1", Name: "alice", Argon2Hash: hash, CreatedAt: time.Now()}
+	if err := st.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	tok, _, _ = auth.NewService(st).MintToken(ctx, u.ID, "phone", store.ScopeSet{store.ScopeSync}, nil)
+	w := store.Work{ID: "w1", UserID: u.ID, CreatedAt: time.Now()}
+	if err := st.CreateWork(ctx, w, &store.Edition{UserID: u.ID, SHA256: "abc123", WorkID: "w1"},
+		[]store.Identifier{{Kind: "sha256", Value: "abc123"}}); err != nil {
+		t.Fatal(err)
+	}
+	return ts.URL, st, tok
+}
+
+func anOp(id string, prog float64) map[string]any {
+	return map[string]any{
+		"op_id": id, "work_id": "w1", "client_ts": "2026-01-01T00:00:00Z", "progression": prog,
+	}
+}
+
+func aSession(id string, endProg float64) map[string]any {
+	return map[string]any{
+		"session_id": id, "work_id": "w1",
+		"started_at": "2026-01-01T00:00:00Z", "ended_at": "2026-01-01T01:00:00Z",
+		"start_progression": 0.1, "end_progression": endProg, "idle_ms": 0,
+	}
+}
+
+// TestPushOpsRefusalsNameTheItem: every item-level refusal on POST
+// /v1/ops carries a code, the item's position and its id, and the whole
+// batch is refused. A client can then set that item aside without
+// parsing the message.
+func TestPushOpsRefusalsNameTheItem(t *testing.T) {
+	url, _, tok := syncFixture(t)
+	cases := []struct {
+		name string
+		bad  map[string]any
+		code string
+		id   any
+	}{
+		{"no op_id", map[string]any{"work_id": "w1", "client_ts": "2026-01-01T00:00:00Z", "progression": 0.1}, "missing_field", nil},
+		{"long op_id", anOp(strings.Repeat("x", 65), 0.1), "missing_field", nil},
+		{"no progression", map[string]any{"op_id": "p", "work_id": "w1", "client_ts": "2026-01-01T00:00:00Z"}, "missing_field", "p"},
+		{"progression 1.5", anOp("q", 1.5), "progression_out_of_range", "q"},
+		{"bad ts", func() map[string]any { o := anOp("r", 0.1); o["client_ts"] = "yesterday"; return o }(), "bad_time", "r"},
+		{"future ts", func() map[string]any {
+			o := anOp("s", 0.1)
+			o["client_ts"] = time.Now().Add(48 * time.Hour).UTC().Format(time.RFC3339)
+			return o
+		}(), "time_in_future", "s"},
+		{"locator too large", func() map[string]any {
+			o := anOp("u", 0.1)
+			o["locator"] = map[string]any{"href": strings.Repeat("a", 17*1024)}
+			return o
+		}(), "locator_too_large", "u"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			code, out := post(t, url+"/v1/ops", tok, map[string]any{
+				"ops": []map[string]any{anOp("fine", 0.2), c.bad},
+			})
+			if code != http.StatusBadRequest || out["code"] != c.code || out["item_index"] != 1.0 {
+				t.Fatalf("%s: %d %v", c.name, code, out)
+			}
+			if got := out["op_id"]; got != c.id {
+				t.Fatalf("%s: op_id %v, want %v", c.name, got, c.id)
+			}
+			if c.code == "locator_too_large" && out["limit"] != float64(16*1024) {
+				t.Fatalf("locator limit not named: %v", out)
+			}
+		})
+	}
+	// Nothing rode along.
+	if _, out := get(t, url+"/v1/changes?since=0", tok); len(out["ops"].([]any)) != 0 {
+		t.Fatalf("a refused batch stored something: %v", out)
+	}
+
+	// Batch-level refusals name the limit, not an item.
+	var many []map[string]any
+	for i := 0; i < 501; i++ {
+		many = append(many, anOp(fmt.Sprintf("m-%d", i), 0.1))
+	}
+	code, out := post(t, url+"/v1/ops", tok, map[string]any{"ops": many})
+	if code != http.StatusBadRequest || out["code"] != "batch_too_large" || out["limit"] != 500.0 || out["item_index"] != nil {
+		t.Fatalf("batch too large: %d %v", code, out)
+	}
+
+	// A body past the byte bound is 413, as on the annotations route.
+	huge := anOp("h", 0.1)
+	huge["locator"] = map[string]any{"pad": strings.Repeat("a", 2<<20)}
+	code, out = post(t, url+"/v1/ops", tok, map[string]any{"ops": []map[string]any{huge}})
+	if code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized body: %d %v", code, out)
+	}
+}
+
+// TestPushOpsConflictLeavesTheRestApplied: a per-item conflict is a
+// result, not a refusal — the other items in the batch are applied and
+// a byte-identical replay is a duplicate.
+func TestPushOpsConflictLeavesTheRestApplied(t *testing.T) {
+	url, _, tok := syncFixture(t)
+	code, out := post(t, url+"/v1/ops", tok, map[string]any{"ops": []map[string]any{anOp("a", 0.1)}})
+	if code != http.StatusOK {
+		t.Fatalf("first push: %d %v", code, out)
+	}
+	code, out = post(t, url+"/v1/ops", tok, map[string]any{
+		"ops": []map[string]any{anOp("a", 0.9), anOp("b", 0.2), anOp("a", 0.1)},
+	})
+	if code != http.StatusOK {
+		t.Fatalf("mixed push: %d %v", code, out)
+	}
+	res := out["results"].([]any)
+	want := []string{"conflict", "applied", "duplicate"}
+	for i, w := range want {
+		if got := res[i].(map[string]any)["status"]; got != w {
+			t.Fatalf("result %d: want %s, got %v (%v)", i, w, got, res)
+		}
+	}
+	if seq := res[2].(map[string]any)["seq"]; seq != 1.0 {
+		t.Fatalf("duplicate must return the original seq: %v", res[2])
+	}
+	_, page := get(t, url+"/v1/changes?since=0", tok)
+	if n := len(page["ops"].([]any)); n != 2 || page["high_water"] != 2.0 {
+		t.Fatalf("want ops a,b stored: %v", page)
+	}
+}
+
+// TestPushSessionsConflictNamesTheItem: a session_id replayed with a
+// different payload is 409 with the item named, including by position
+// when the same id appears twice in one batch; and the batch is atomic.
+func TestPushSessionsConflictNamesTheItem(t *testing.T) {
+	url, _, tok := syncFixture(t)
+	if code, out := post(t, url+"/v1/sessions", tok, map[string]any{
+		"sessions": []map[string]any{aSession("s1", 0.2)},
+	}); code != http.StatusOK {
+		t.Fatalf("first push: %d %v", code, out)
+	}
+	code, out := post(t, url+"/v1/sessions", tok, map[string]any{
+		"sessions": []map[string]any{aSession("s2", 0.3), aSession("s1", 0.2), aSession("s1", 0.5)},
+	})
+	if code != http.StatusConflict || out["code"] != "id_reused" || out["session_id"] != "s1" || out["item_index"] != 2.0 {
+		t.Fatalf("conflict: %d %v", code, out)
+	}
+	// s2 did not ride along: pushing it alone is a fresh accept.
+	code, out = post(t, url+"/v1/sessions", tok, map[string]any{
+		"sessions": []map[string]any{aSession("s2", 0.3)},
+	})
+	if code != http.StatusOK || out["accepted"] != 1.0 {
+		t.Fatalf("s2 after the refused batch: %d %v", code, out)
+	}
+	// Too many, and too big, as for ops.
+	var many []map[string]any
+	for i := 0; i < 1001; i++ {
+		many = append(many, aSession(fmt.Sprintf("m-%d", i), 0.2))
+	}
+	if code, out := post(t, url+"/v1/sessions", tok, map[string]any{"sessions": many}); code != http.StatusBadRequest ||
+		out["code"] != "batch_too_large" || out["limit"] != 1000.0 {
+		t.Fatalf("batch too large: %d %v", code, out)
+	}
+	bad := aSession("i", 0.2)
+	bad["idle_ms"] = 2 * 3600 * 1000
+	if code, out := post(t, url+"/v1/sessions", tok, map[string]any{"sessions": []map[string]any{bad}}); code != http.StatusBadRequest ||
+		out["code"] != "idle_out_of_range" || out["session_id"] != "i" || out["item_index"] != 0.0 {
+		t.Fatalf("idle: %d %v", code, out)
+	}
+}
+
+// TestUnknownWorkIsDecidedInTheAppend: the work check happens inside the
+// append transaction, so a work deleted after the handler would have
+// checked it still yields the recoverable 400, never a 500. Exercised
+// directly: the work is gone before the push.
+func TestUnknownWorkIsDecidedInTheAppend(t *testing.T) {
+	url, st, tok := syncFixture(t)
+	if err := st.DeleteWork(t.Context(), "u1", "w1"); err != nil {
+		t.Fatal(err)
+	}
+	code, out := post(t, url+"/v1/ops", tok, map[string]any{"ops": []map[string]any{anOp("a", 0.1)}})
+	if code != http.StatusBadRequest || out["code"] != "unknown_work" || out["work_id"] != "w1" || out["op_id"] != "a" {
+		t.Fatalf("op for a deleted work: %d %v", code, out)
+	}
+	code, out = post(t, url+"/v1/sessions", tok, map[string]any{"sessions": []map[string]any{aSession("s", 0.2)}})
+	if code != http.StatusBadRequest || out["code"] != "unknown_work" || out["work_id"] != "w1" || out["session_id"] != "s" {
+		t.Fatalf("session for a deleted work: %d %v", code, out)
+	}
+}
+
+// TestChangesCursorAndResync: a malformed or negative cursor is 400,
+// not a silent full replay; a cursor below the compaction horizon is
+// 410 pointing at /v1/heads, whose snapshot_seq resumes the feed.
+func TestChangesCursorAndResync(t *testing.T) {
+	url, st, tok := syncFixture(t)
+	for _, since := range []string{"abc", "-1", "1.5"} {
+		if code, out := get(t, url+"/v1/changes?since="+since, tok); code != http.StatusBadRequest {
+			t.Fatalf("since=%s: %d %v", since, code, out)
+		}
+	}
+	var ops []map[string]any
+	for i := 0; i < 5; i++ {
+		ops = append(ops, anOp(fmt.Sprintf("o-%d", i), float64(i)/10))
+	}
+	if code, out := post(t, url+"/v1/ops", tok, map[string]any{"ops": ops}); code != http.StatusOK {
+		t.Fatalf("push: %d %v", code, out)
+	}
+	// Everything is "old" against a cutoff in the future: only the head
+	// survives and the horizon lands on seq 4.
+	if _, err := st.Compact(t.Context(), "u1", time.Now().Add(time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	code, out := get(t, url+"/v1/changes?since=0", tok)
+	if code != http.StatusGone || out["error"] != "resync_required" || out["heads_endpoint"] != "/v1/heads" {
+		t.Fatalf("below the horizon: %d %v", code, out)
+	}
+	code, heads := get(t, url+"/v1/heads", tok)
+	if code != http.StatusOK || len(heads["ops"].([]any)) != 1 || heads["snapshot_seq"] != 5.0 {
+		t.Fatalf("heads: %d %v", code, heads)
+	}
+	code, out = get(t, url+"/v1/changes?since=5", tok)
+	if code != http.StatusOK || len(out["ops"].([]any)) != 0 || out["high_water"] != 5.0 {
+		t.Fatalf("resume from snapshot_seq: %d %v", code, out)
+	}
+	code, out = get(t, url+"/v1/changes?since=4", tok)
+	if code != http.StatusOK || len(out["ops"].([]any)) != 1 {
+		t.Fatalf("at the horizon: %d %v", code, out)
+	}
+}
+
+// TestPositionsLimitClamps: a limit past the maximum is clamped to it,
+// not reset to the default.
+func TestPositionsLimitClamps(t *testing.T) {
+	url, _, tok := syncFixture(t)
+	var ops []map[string]any
+	for i := 0; i < 60; i++ {
+		ops = append(ops, anOp(fmt.Sprintf("o-%d", i), 0.5))
+	}
+	if code, out := post(t, url+"/v1/ops", tok, map[string]any{"ops": ops}); code != http.StatusOK {
+		t.Fatalf("push: %d %v", code, out)
+	}
+	for _, c := range []struct {
+		q    string
+		want int
+	}{{"", 50}, {"?limit=0", 50}, {"?limit=10", 10}, {"?limit=201", 60}, {"?limit=200", 60}} {
+		code, out := get(t, url+"/v1/works/w1/positions"+c.q, tok)
+		if code != http.StatusOK || len(out["ops"].([]any)) != c.want {
+			t.Fatalf("positions%s: %d, %d ops (want %d)", c.q, code, len(out["ops"].([]any)), c.want)
+		}
+	}
+}

--- a/internal/api/tokendevice_test.go
+++ b/internal/api/tokendevice_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// deviceInheritFixture: two users who can each log in, and a helper that
+// mints a token for one through the API with an optional device_id.
+func deviceInheritFixture(t *testing.T) (url string, st store.Store, login func(name string) string) {
+	t.Helper()
+	ts, st := testServer(t)
+	ctx := t.Context()
+	hash, _ := auth.HashPassword("hunter2hunter")
+	for _, u := range []store.User{
+		{ID: "u1", Name: "alice", Argon2Hash: hash, CreatedAt: time.Now()},
+		{ID: "u2", Name: "bob", Argon2Hash: hash, CreatedAt: time.Now()},
+	} {
+		if err := st.CreateUser(ctx, u); err != nil {
+			t.Fatal(err)
+		}
+	}
+	login = func(name string) string {
+		code, out := post(t, ts.URL+"/v1/login", "", map[string]string{
+			"username": name, "password": "hunter2hunter",
+		})
+		if code != http.StatusOK {
+			t.Fatalf("login %s: %d %v", name, code, out)
+		}
+		return out["auth_token"].(string)
+	}
+	return ts.URL, st, login
+}
+
+func mintWithDevice(t *testing.T, url, login, deviceID string) (int, map[string]any) {
+	t.Helper()
+	body := map[string]any{"name": "phone", "scopes": []string{"sync"}}
+	if deviceID != "" {
+		body["device_id"] = deviceID
+	}
+	return post(t, url+"/v1/tokens", login, body)
+}
+
+// TestTokenInheritsADeviceID: a client whose credential lapsed mints a
+// replacement and asks for the device id it stored. The op log then sees
+// one device, and an op it pushed before the lapse replays as a
+// duplicate, not a conflict.
+func TestTokenInheritsADeviceID(t *testing.T) {
+	url, st, login := deviceInheritFixture(t)
+	ctx := t.Context()
+
+	code, first := mintWithDevice(t, url, login("alice"), "")
+	if code != http.StatusCreated {
+		t.Fatalf("first mint: %d %v", code, first)
+	}
+	device := first["device_id"].(string)
+	firstSecret := first["secret"].(string)
+
+	// Reading happens on the first credential.
+	code, out := post(t, url+"/v1/works/resolve", firstSecret, map[string]any{
+		"identifiers": []map[string]string{{"kind": "sha256", "value": "abc123"}},
+		"title":       "A Book",
+	})
+	if code != http.StatusCreated {
+		t.Fatalf("resolve: %d %v", code, out)
+	}
+	workID := out["work_id"].(string)
+	op := map[string]any{
+		"op_id": "op-1", "work_id": workID, "client_ts": "2026-01-01T00:00:00Z",
+		"progression": 0.5,
+	}
+	if code, out = post(t, url+"/v1/ops", firstSecret, map[string]any{"ops": []any{op}}); code != http.StatusOK {
+		t.Fatalf("push: %d %v", code, out)
+	}
+
+	// The first credential dies; a revoked predecessor is still a valid
+	// source of identity.
+	toks, err := st.ListTokens(ctx, "u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := st.RevokeToken(ctx, "u1", toks[0].ID); err != nil {
+		t.Fatal(err)
+	}
+
+	code, second := mintWithDevice(t, url, login("alice"), device)
+	if code != http.StatusCreated {
+		t.Fatalf("inheriting mint: %d %v", code, second)
+	}
+	if second["device_id"] != device {
+		t.Fatalf("device not inherited: got %v want %s", second["device_id"], device)
+	}
+	secondSecret := second["secret"].(string)
+	code, self := get(t, url+"/v1/token", secondSecret)
+	if code != http.StatusOK || self["device_id"] != device {
+		t.Fatalf("self-read after inherit: %d %v", code, self)
+	}
+
+	// The replay the client never got an answer for is a duplicate.
+	code, out = post(t, url+"/v1/ops", secondSecret, map[string]any{"ops": []any{op}})
+	if code != http.StatusOK {
+		t.Fatalf("replay: %d %v", code, out)
+	}
+	res := out["results"].([]any)[0].(map[string]any)
+	if res["status"] != "duplicate" {
+		t.Fatalf("replay from the inherited device: want duplicate, got %v", res)
+	}
+
+	// Heads see one device.
+	code, out = get(t, url+"/v1/heads", secondSecret)
+	if code != http.StatusOK {
+		t.Fatalf("heads: %d %v", code, out)
+	}
+	if n := len(out["ops"].([]any)); n != 1 {
+		t.Fatalf("heads: want one device head, got %d: %v", n, out)
+	}
+}
+
+// TestTokenDeviceIDIsARequestNotACredential: a device id the account has
+// never carried, or one belonging to another account, is refused with a
+// structured code, and an inherited id may be shared by two live tokens.
+func TestTokenDeviceIDIsARequestNotACredential(t *testing.T) {
+	url, _, login := deviceInheritFixture(t)
+
+	code, out := mintWithDevice(t, url, login("alice"), "never-seen")
+	if code != http.StatusBadRequest || out["code"] != "unknown_device" {
+		t.Fatalf("unknown device: want 400 unknown_device, got %d %v", code, out)
+	}
+
+	code, bobs := mintWithDevice(t, url, login("bob"), "")
+	if code != http.StatusCreated {
+		t.Fatalf("bob's mint: %d %v", code, bobs)
+	}
+	code, out = mintWithDevice(t, url, login("alice"), bobs["device_id"].(string))
+	if code != http.StatusBadRequest || out["code"] != "unknown_device" {
+		t.Fatalf("another account's device: want 400 unknown_device, got %d %v", code, out)
+	}
+
+	// Two live tokens on one device: both work, both are that device.
+	code, alices := mintWithDevice(t, url, login("alice"), "")
+	if code != http.StatusCreated {
+		t.Fatalf("alice's mint: %d %v", code, alices)
+	}
+	device := alices["device_id"].(string)
+	code, twin := mintWithDevice(t, url, login("alice"), device)
+	if code != http.StatusCreated || twin["device_id"] != device {
+		t.Fatalf("live twin: %d %v", code, twin)
+	}
+	for _, secret := range []string{alices["secret"].(string), twin["secret"].(string)} {
+		if code, self := get(t, url+"/v1/token", secret); code != http.StatusOK || self["device_id"] != device {
+			t.Fatalf("twin self-read: %d %v", code, self)
+		}
+	}
+}

--- a/internal/api/tokenself_test.go
+++ b/internal/api/tokenself_test.go
@@ -262,6 +262,48 @@ func TestTokenSelfReadIsReadOnly(t *testing.T) {
 	}
 }
 
+// TestTokenAccountIDIsStableAcrossTokens: a replacement credential on
+// the same account says so, and a token on another account does not,
+// which is what lets a client keep its mirrors and cursor through a
+// reconnect (ADR-0016, phase 3).
+func TestTokenAccountIDIsStableAcrossTokens(t *testing.T) {
+	url, svc, userID, _ := tokenSelfFixture(t)
+	ctx := t.Context()
+	first, _, err := svc.MintToken(ctx, userID, "phone", store.ScopeSet{store.ScopeSync}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, _, err := svc.MintToken(ctx, userID, "phone again", store.ScopeSet{store.ScopeSync}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.St.CreateUser(ctx, store.User{ID: "u2", Name: "bob", CreatedAt: time.Now()}); err != nil {
+		t.Fatal(err)
+	}
+	stranger, _, err := svc.MintToken(ctx, "u2", "bob's", store.ScopeSet{store.ScopeSync}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	account := func(secret string) string {
+		code, out := get(t, url+"/v1/token", secret)
+		if code != http.StatusOK {
+			t.Fatalf("self-read: %d %v", code, out)
+		}
+		id, _ := out["account_id"].(string)
+		if id == "" {
+			t.Fatalf("account_id missing: %v", out)
+		}
+		return id
+	}
+	if a, b := account(first), account(second); a != b {
+		t.Fatalf("two tokens on one account disagree: %q vs %q", a, b)
+	}
+	if a, c := account(first), account(stranger); a == c {
+		t.Fatalf("different accounts share account_id %q", a)
+	}
+}
+
 type headResult struct {
 	code int
 	body int

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -102,9 +102,22 @@ func (s *Service) AuthenticateLogin(ctx context.Context, secret string) (string,
 	return a.UserID, nil
 }
 
+// ErrUnknownDevice is a device id offered for inheritance that no token of
+// this account has ever carried.
+var ErrUnknownDevice = errors.New("unknown device_id")
+
 // CreateToken mints a per-device token for a user authenticated via the
 // login credential. Returns the plaintext secret once.
-func (s *Service) CreateToken(ctx context.Context, loginSecret, name string, scopes store.ScopeSet, expiresAt *time.Time) (plaintext string, tok store.Token, err error) {
+//
+// A non-empty deviceID asks the new token to inherit an existing device
+// identity instead of drawing a fresh one. It is honoured only when a
+// token of this same account — live, expired or revoked — already carries
+// it: the id is a label in the op log, so a client that stored it and
+// comes back after its credential lapsed stays one device and its replays
+// stay duplicates. Deleted predecessors are gone for good, hence
+// ErrUnknownDevice rather than a silent fresh mint. Another account's ids
+// are unknown here by construction.
+func (s *Service) CreateToken(ctx context.Context, loginSecret, name string, scopes store.ScopeSet, expiresAt *time.Time, deviceID string) (plaintext string, tok store.Token, err error) {
 	userID, err := s.AuthenticateLogin(ctx, loginSecret)
 	if err != nil {
 		return "", tok, err
@@ -112,7 +125,23 @@ func (s *Service) CreateToken(ctx context.Context, loginSecret, name string, sco
 	if err := s.CheckScopeGrant(ctx, userID, scopes); err != nil {
 		return "", tok, err
 	}
-	return s.MintToken(ctx, userID, name, scopes, expiresAt)
+	if deviceID != "" {
+		existing, err := s.St.ListTokens(ctx, userID)
+		if err != nil {
+			return "", tok, fmt.Errorf("list tokens: %w", err)
+		}
+		known := false
+		for _, t := range existing {
+			if t.DeviceID == deviceID {
+				known = true
+				break
+			}
+		}
+		if !known {
+			return "", tok, ErrUnknownDevice
+		}
+	}
+	return s.mintToken(ctx, userID, name, scopes, expiresAt, deviceID)
 }
 
 // MintToken creates a token for a known user (admin CLI path).

--- a/internal/store/postgres/ops.go
+++ b/internal/store/postgres/ops.go
@@ -147,14 +147,26 @@ func sameOp(ctx context.Context, tx *sql.Tx, userID string, o store.Op, deviceID
 	return true, nil
 }
 
+// snapshotTx is the read transaction the changes feed and heads use.
+// Postgres defaults to READ COMMITTED, where every statement sees its
+// own snapshot; REPEATABLE READ is what makes the high water, horizon
+// and page agree with each other.
+var snapshotTx = &sql.TxOptions{Isolation: sql.LevelRepeatableRead, ReadOnly: true}
+
+// Changes: see the SQLite implementation's doc comment.
 func (s *Store) Changes(ctx context.Context, userID string, since int64, limit int) (store.ChangesPage, error) {
 	var page store.ChangesPage
-	if err := s.db.QueryRowContext(ctx, q(
+	tx, err := s.db.BeginTx(ctx, snapshotTx)
+	if err != nil {
+		return page, err
+	}
+	defer tx.Rollback()
+	if err := tx.QueryRowContext(ctx, q(
 		`SELECT COALESCE(MAX(seq), 0) FROM ops WHERE user_id = ?`), userID).Scan(&page.HighWater); err != nil {
 		return page, err
 	}
 	var horizon int64
-	err := s.db.QueryRowContext(ctx, q(
+	err = tx.QueryRowContext(ctx, q(
 		`SELECT horizon FROM compaction_state WHERE user_id = ?`), userID).Scan(&horizon)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return page, err
@@ -163,7 +175,7 @@ func (s *Store) Changes(ctx context.Context, userID string, since int64, limit i
 		page.ResyncNeeded = true
 		return page, nil
 	}
-	rows, err := s.db.QueryContext(ctx, q(
+	rows, err := tx.QueryContext(ctx, q(
 		`SELECT `+opCols+` FROM ops WHERE user_id = ? AND seq > ? ORDER BY seq LIMIT ?`),
 		userID, since, limit+1)
 	if err != nil {
@@ -207,7 +219,7 @@ func (s *Store) Positions(ctx context.Context, userID, workID string, limit int)
 }
 
 func (s *Store) HeadsFor(ctx context.Context, userID string) (store.Heads, error) {
-	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	tx, err := s.db.BeginTx(ctx, snapshotTx)
 	if err != nil {
 		return store.Heads{}, err
 	}

--- a/internal/store/postgres/ops.go
+++ b/internal/store/postgres/ops.go
@@ -64,6 +64,12 @@ func appendOpsTx(ctx context.Context, tx *sql.Tx, userID, deviceID string, ops [
 			continue
 		}
 
+		if ok, err := workExistsTx(ctx, tx, userID, o.WorkID); err != nil {
+			return nil, err
+		} else if !ok {
+			return nil, store.UnknownWork("op", o.OpID, i, o.WorkID)
+		}
+
 		var seq int64
 		err = tx.QueryRowContext(ctx, q(
 			`INSERT INTO seq_counters (user_id, next_seq) VALUES (?, 2)

--- a/internal/store/postgres/sessions.go
+++ b/internal/store/postgres/sessions.go
@@ -25,14 +25,14 @@ func (s *Store) AppendSessions(ctx context.Context, userID string, ss []store.Se
 }
 
 func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store.Session, now time.Time) error {
-	for _, ses := range ss {
+	for i, ses := range ss {
 		var archivedFingerprint string
 		err := tx.QueryRowContext(ctx, q(
 			`SELECT fingerprint FROM session_tombstones WHERE user_id = ? AND session_id = ?`),
 			userID, ses.SessionID).Scan(&archivedFingerprint)
 		if err == nil {
 			if archivedFingerprint != store.SessionFingerprint(ses) {
-				return store.ErrIDMismatch
+				return store.IDMismatch("session", ses.SessionID, i)
 			}
 			continue
 		}
@@ -51,9 +51,14 @@ func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store
 				return err
 			}
 			if !same {
-				return store.ErrIDMismatch
+				return store.IDMismatch("session", ses.SessionID, i)
 			}
 			continue
+		}
+		if ok, err := workExistsTx(ctx, tx, userID, ses.WorkID); err != nil {
+			return err
+		} else if !ok {
+			return store.UnknownWork("session", ses.SessionID, i, ses.WorkID)
 		}
 		_, err = tx.ExecContext(ctx, q(
 			`INSERT INTO sessions (user_id, session_id, work_id, edition_sha, device_id,

--- a/internal/store/postgres/works.go
+++ b/internal/store/postgres/works.go
@@ -26,6 +26,17 @@ func lockWorkGraph(ctx context.Context, tx *sql.Tx, userID string) error {
 	return err
 }
 
+// workExistsTx: see the SQLite implementation.
+func workExistsTx(ctx context.Context, tx *sql.Tx, userID, workID string) (bool, error) {
+	var one int
+	err := tx.QueryRowContext(ctx, q(
+		`SELECT 1 FROM works WHERE user_id = ? AND id = ?`), userID, workID).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 // lockAllWorkGraphs excludes per-user work-graph mutations for a transaction
 // that can affect an unknown number of readers.
 func lockAllWorkGraphs(ctx context.Context, tx *sql.Tx) error {

--- a/internal/store/sqlite/ops.go
+++ b/internal/store/sqlite/ops.go
@@ -70,6 +70,15 @@ func (s *Store) appendOpsTx(ctx context.Context, tx *sql.Tx, userID, deviceID st
 			continue
 		}
 
+		// Only a genuinely new op needs its work to exist right now; a
+		// replay was judged above, so a duplicate stays a duplicate even
+		// after its work was deleted.
+		if ok, err := workExistsTx(ctx, tx, userID, o.WorkID); err != nil {
+			return nil, err
+		} else if !ok {
+			return nil, store.UnknownWork("op", o.OpID, i, o.WorkID)
+		}
+
 		// Assign next seq atomically.
 		var seq int64
 		err = tx.QueryRowContext(ctx,

--- a/internal/store/sqlite/ops.go
+++ b/internal/store/sqlite/ops.go
@@ -160,14 +160,25 @@ const opCols = `user_id, seq, op_id, work_id, edition_sha, device_id, client_ts,
 
 // Changes returns ops with seq > since, paginated, plus high-water mark
 // and compaction-horizon signaling.
+//
+// High water, horizon and the page come from one read transaction. Read
+// separately, a compaction committing in between could pass the horizon
+// check and then delete rows out of the page, handing the client a
+// cursor past a gap it will never learn about — the exact thing the
+// horizon exists to prevent.
 func (s *Store) Changes(ctx context.Context, userID string, since int64, limit int) (store.ChangesPage, error) {
 	var page store.ChangesPage
-	if err := s.db.QueryRowContext(ctx,
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return page, err
+	}
+	defer tx.Rollback()
+	if err := tx.QueryRowContext(ctx,
 		`SELECT COALESCE(MAX(seq), 0) FROM ops WHERE user_id = ?`, userID).Scan(&page.HighWater); err != nil {
 		return page, err
 	}
 	var horizon int64
-	if err := s.db.QueryRowContext(ctx,
+	if err := tx.QueryRowContext(ctx,
 		`SELECT COALESCE(horizon, 0) FROM compaction_state WHERE user_id = ?`, userID).Scan(&horizon); err != nil &&
 		!errors.Is(err, sql.ErrNoRows) {
 		return page, err
@@ -176,7 +187,7 @@ func (s *Store) Changes(ctx context.Context, userID string, since int64, limit i
 		page.ResyncNeeded = true
 		return page, nil
 	}
-	rows, err := s.db.QueryContext(ctx,
+	rows, err := tx.QueryContext(ctx,
 		`SELECT `+opCols+` FROM ops WHERE user_id = ? AND seq > ? ORDER BY seq LIMIT ?`,
 		userID, since, limit+1)
 	if err != nil {

--- a/internal/store/sqlite/sessions.go
+++ b/internal/store/sqlite/sessions.go
@@ -9,12 +9,13 @@ import (
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
-// AppendSessions inserts a batch of sessions. Idempotent on
-// (user_id, session_id): identical re-uploads are skipped; same id with
-// a different payload is ErrIDMismatch for that item (reported per-item
-// by the caller layer; here the whole batch fails atomically with
-// per-item status returned via SessionResult in a later milestone —
-// sessions arrive in M3, the store path exists now).
+// AppendSessions inserts a batch of sessions atomically. Idempotent on
+// (user_id, session_id): identical re-uploads are skipped; the same id
+// with a different payload, live or archived as a tombstone, fails the
+// batch with a *store.ItemError wrapping ErrIDMismatch that names the
+// item; a new session naming a work this user lacks fails it with one
+// wrapping ErrNotFound. Replays are judged before the work check, so a
+// duplicate stays a duplicate after its work is gone.
 func (s *Store) AppendSessions(ctx context.Context, userID string, ss []store.Session) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -31,14 +32,14 @@ func (s *Store) AppendSessions(ctx context.Context, userID string, ss []store.Se
 }
 
 func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store.Session, now string) error {
-	for _, ses := range ss {
+	for i, ses := range ss {
 		var archivedFingerprint string
 		err := tx.QueryRowContext(ctx,
 			`SELECT fingerprint FROM session_tombstones WHERE user_id = ? AND session_id = ?`,
 			userID, ses.SessionID).Scan(&archivedFingerprint)
 		if err == nil {
 			if archivedFingerprint != store.SessionFingerprint(ses) {
-				return store.ErrIDMismatch
+				return store.IDMismatch("session", ses.SessionID, i)
 			}
 			continue
 		}
@@ -58,9 +59,14 @@ func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store
 				return err
 			}
 			if !same {
-				return store.ErrIDMismatch
+				return store.IDMismatch("session", ses.SessionID, i)
 			}
 			continue // idempotent duplicate
+		}
+		if ok, err := workExistsTx(ctx, tx, userID, ses.WorkID); err != nil {
+			return err
+		} else if !ok {
+			return store.UnknownWork("session", ses.SessionID, i, ses.WorkID)
 		}
 		_, err = tx.ExecContext(ctx,
 			`INSERT INTO sessions (user_id, session_id, work_id, edition_sha, device_id,

--- a/internal/store/sqlite/works.go
+++ b/internal/store/sqlite/works.go
@@ -26,6 +26,19 @@ func lockWorkGraph(ctx context.Context, tx *sql.Tx, userID string) error {
 	return nil
 }
 
+// workExistsTx reports whether this user has the work, inside the
+// caller's transaction, so an append decides "unknown work" against the
+// same state it inserts into.
+func workExistsTx(ctx context.Context, tx *sql.Tx, userID, workID string) (bool, error) {
+	var one int
+	err := tx.QueryRowContext(ctx,
+		`SELECT 1 FROM works WHERE user_id = ? AND id = ?`, userID, workID).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return err == nil, err
+}
+
 func resolveMatches(ctx context.Context, tx *sql.Tx, userID string, ids []store.Identifier) (map[string]string, error) {
 	out := make(map[string]string, len(ids))
 	for _, id := range ids {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -51,6 +51,46 @@ var (
 	ErrRefreshLeaseLost = errors.New("store: refresh lease lost")
 )
 
+// ItemError names which item of a batch a refusal is about. Batches are
+// appended atomically, so a client that is told "no" needs to know which
+// record to fix or set aside before sending the rest again; a bare
+// sentinel cannot tell it, and searching the batch for the id would pick
+// the wrong occurrence when the same id appears twice.
+type ItemError struct {
+	// Kind is "op" or "session".
+	Kind string
+	// ID is the item's op_id or session_id; empty if the item had none.
+	ID string
+	// Index is the item's zero-based position in the batch.
+	Index int
+	// WorkID is set when the refusal is about the work the item names.
+	WorkID string
+	// Err is the sentinel this wraps: ErrIDMismatch or ErrNotFound.
+	Err error
+}
+
+func (e *ItemError) Error() string {
+	return fmt.Sprintf("%s %q (item %d): %v", e.Kind, e.ID, e.Index, e.Err)
+}
+
+// Unwrap keeps errors.Is(err, ErrIDMismatch) and errors.Is(err,
+// ErrNotFound) true for callers that only care which rule was broken.
+func (e *ItemError) Unwrap() error { return e.Err }
+
+// IDMismatch is the item-level form of ErrIDMismatch.
+func IDMismatch(kind, id string, index int) error {
+	return &ItemError{Kind: kind, ID: id, Index: index, Err: ErrIDMismatch}
+}
+
+// UnknownWork is a new op or session naming a work this user does not
+// have. Decided inside the append transaction, so a work deleted between
+// a handler's check and the insert is still this and never a foreign-key
+// failure. A replay of an already accepted item is judged before this,
+// so a duplicate stays a duplicate even after its work is gone.
+func UnknownWork(kind, id string, index int, workID string) error {
+	return &ItemError{Kind: kind, ID: id, Index: index, WorkID: workID, Err: ErrNotFound}
+}
+
 // TokenPurgeGrace is how long expired or revoked tokens remain listed
 // (for the UI) before Housekeep deletes them.
 const TokenPurgeGrace = 30 * 24 * time.Hour

--- a/internal/store/storetest/compaction.go
+++ b/internal/store/storetest/compaction.go
@@ -1,0 +1,164 @@
+package storetest
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// testCompactionHorizon: the backend-agnostic half of the compaction
+// contract. A cutoff in the future makes every op old, so what survives
+// is exactly the per-(work, device) heads; the horizon is the newest seq
+// deleted; a cursor below it is told to resync; a cursor at or above it
+// reads a complete, gap-free stream; heads are whole and seq is not
+// renumbered. (The SQLite package keeps the day-boundary snapshot test,
+// which needs raw control over received_at.)
+func testCompactionHorizon(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "compact")
+	w := MkWork(t, s, u, "w1", "abc123")
+	future := time.Now().Add(time.Hour)
+
+	push := func(dev string, n int) {
+		var ops []store.Op
+		for i := 0; i < n; i++ {
+			ops = append(ops, store.Op{
+				OpID: fmt.Sprintf("%s-%d", dev, i), WorkID: w.ID, ClientTS: time.Now(),
+				Progression: float64(i) / 10, Origin: store.OriginNative,
+			})
+		}
+		if _, err := s.AppendOps(ctx, u.ID, dev, ops); err != nil {
+			t.Fatal(err)
+		}
+	}
+	push("kobo", 3)  // seq 1..3
+	push("phone", 2) // seq 4..5
+
+	horizon, err := s.Compact(ctx, u.ID, future)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Heads 3 (kobo) and 5 (phone) stay; 1, 2 and 4 go.
+	if horizon != 4 {
+		t.Fatalf("horizon: want 4, got %d", horizon)
+	}
+	if h, err := s.CompactionHorizon(ctx, u.ID); err != nil || h != 4 {
+		t.Fatalf("stored horizon: %d %v", h, err)
+	}
+
+	page, err := s.Changes(ctx, u.ID, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !page.ResyncNeeded || page.HighWater != 5 {
+		t.Fatalf("since=0 below the horizon: %+v", page)
+	}
+	page, err = s.Changes(ctx, u.ID, horizon, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if page.ResyncNeeded || len(page.Ops) != 1 || page.Ops[0].Seq != 5 {
+		t.Fatalf("since=horizon: %+v", page)
+	}
+	heads, err := s.HeadsFor(ctx, u.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(heads.Ops) != 2 || heads.SnapshotSeq != 5 {
+		t.Fatalf("heads after compaction: %+v", heads)
+	}
+
+	// Nothing to delete is a no-op that leaves the horizon alone.
+	if h, err := s.Compact(ctx, u.ID, future); err != nil || h != 0 {
+		t.Fatalf("idle compaction: %d %v", h, err)
+	}
+	if h, _ := s.CompactionHorizon(ctx, u.ID); h != 4 {
+		t.Fatalf("idle compaction moved the horizon to %d", h)
+	}
+}
+
+// testChangesIsASnapshot: the changes feed must never hand out a page
+// with a hole in it. Read piecewise, the horizon check could pass and a
+// compaction commit before the page is read, deleting rows the client
+// then advances past without ever being told to resync. One goroutine
+// appends and compacts as fast as it can; another reads pages and
+// checks that a page it was not told to resync is contiguous and that
+// the high water mark is never behind the last op on the page.
+func testChangesIsASnapshot(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "snapshot")
+	w := MkWork(t, s, u, "w1", "abc123")
+	future := time.Now().Add(time.Hour)
+
+	stop := make(chan struct{})
+	var writer sync.WaitGroup
+	writer.Add(1)
+	var writeErr error
+	go func() {
+		defer writer.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_, err := s.AppendOps(ctx, u.ID, "dev", []store.Op{{
+				OpID: fmt.Sprintf("op-%d", i), WorkID: w.ID, ClientTS: time.Now(),
+				Progression: 0.5, Origin: store.OriginNative,
+			}})
+			if err == nil {
+				_, err = s.Compact(ctx, u.ID, future)
+			}
+			if err != nil {
+				writeErr = err
+				return
+			}
+		}
+	}()
+
+	var since int64
+	for i := 0; i < 300; i++ {
+		page, err := s.Changes(ctx, u.ID, since, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if page.ResyncNeeded {
+			heads, err := s.HeadsFor(ctx, u.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			since = heads.SnapshotSeq
+			continue
+		}
+		for j, o := range page.Ops {
+			if o.Seq != since+int64(j)+1 {
+				t.Fatalf("page has a hole: since=%d ops=%v", since, seqs(page.Ops))
+			}
+			if o.Seq > page.HighWater {
+				t.Fatalf("high water %d behind op %d", page.HighWater, o.Seq)
+			}
+		}
+		if n := len(page.Ops); n > 0 {
+			since = page.Ops[n-1].Seq
+		}
+	}
+	close(stop)
+	writer.Wait()
+	if writeErr != nil {
+		t.Fatal(writeErr)
+	}
+}
+
+func seqs(ops []store.Op) []int64 {
+	out := make([]int64, len(ops))
+	for i, o := range ops {
+		out[i] = o.Seq
+	}
+	return out
+}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -230,6 +230,8 @@ func Run(t *testing.T, open OpenFunc) {
 	t.Run("AtomicWorkResolution", func(t *testing.T) { testAtomicWorkResolution(t, open) })
 	t.Run("AppendOpsIdempotencyAndConflict", func(t *testing.T) { testAppendOps(t, open) })
 	t.Run("ChangesPaginationAndHeads", func(t *testing.T) { testChangesAndHeads(t, open) })
+	t.Run("CompactionHorizon", func(t *testing.T) { testCompactionHorizon(t, open) })
+	t.Run("ChangesIsASnapshot", func(t *testing.T) { testChangesIsASnapshot(t, open) })
 	t.Run("SplitAndMerge", func(t *testing.T) { testSplitAndMerge(t, open) })
 	t.Run("SessionsAppendOnly", func(t *testing.T) { testSessionsAppendOnly(t, open) })
 	t.Run("SessionRollups", func(t *testing.T) { testSessionRollups(t, open) })

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -4,6 +4,7 @@ package storetest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -766,6 +767,23 @@ func testAppendOps(t *testing.T, open OpenFunc) {
 	if res[0].Seq != 2 || res[1].Seq != 3 {
 		t.Fatalf("want seq 2,3 got %+v", res)
 	}
+
+	// A new op naming a work the user lacks fails the batch by item, and
+	// nothing before it in the batch was stored.
+	op5 := op
+	op5.OpID = "018e6f1a-0000-7000-8000-000000000005"
+	orphan := op
+	orphan.OpID = "018e6f1a-0000-7000-8000-000000000006"
+	orphan.WorkID = "no-such-work"
+	_, err = s.AppendOps(ctx, u.ID, "d-phone", []store.Op{op5, orphan})
+	var item *store.ItemError
+	if !errors.As(err, &item) || !errors.Is(err, store.ErrNotFound) ||
+		item.Kind != "op" || item.ID != orphan.OpID || item.Index != 1 || item.WorkID != "no-such-work" {
+		t.Fatalf("unknown work: got %#v", err)
+	}
+	if page, _ := s.Changes(ctx, u.ID, 0, 10); len(page.Ops) != 3 {
+		t.Fatalf("a refused batch stored something: %+v", page.Ops)
+	}
 }
 
 func testChangesAndHeads(t *testing.T, open OpenFunc) {
@@ -896,8 +914,46 @@ func testSessionsAppendOnly(t *testing.T, open OpenFunc) {
 	}
 	ses2 := ses
 	ses2.EndProg = 0.9
-	if err := s.AppendSessions(ctx, u.ID, []store.Session{ses2}); err != store.ErrIDMismatch {
+	if err := s.AppendSessions(ctx, u.ID, []store.Session{ses2}); !errors.Is(err, store.ErrIDMismatch) {
 		t.Fatalf("want ErrIDMismatch, got %v", err)
+	}
+
+	// A refusal names the item, by position: the same id twice in one
+	// batch, identical then changed, must point at the second.
+	err := s.AppendSessions(ctx, u.ID, []store.Session{ses, ses2})
+	var item *store.ItemError
+	if !errors.As(err, &item) || !errors.Is(err, store.ErrIDMismatch) ||
+		item.Kind != "session" || item.ID != "s1" || item.Index != 1 {
+		t.Fatalf("want ItemError{session s1 #1} wrapping ErrIDMismatch, got %#v", err)
+	}
+	// A conflict in the middle of a batch is still named, and nothing
+	// around it was stored.
+	fresh := ses
+	fresh.SessionID = "s-fresh"
+	err = s.AppendSessions(ctx, u.ID, []store.Session{fresh, ses2, fresh})
+	if !errors.As(err, &item) || item.Index != 1 {
+		t.Fatalf("mid-batch conflict: got %#v", err)
+	}
+	if got, _ := s.SessionsForWork(ctx, u.ID, w.ID, 10); len(got) != 1 {
+		t.Fatalf("a refused batch stored something: %+v", got)
+	}
+
+	// A new session naming a work the user lacks is refused by name;
+	// a replay of an accepted one is a duplicate even once its work is
+	// gone.
+	orphan := fresh
+	orphan.SessionID = "s-orphan"
+	orphan.WorkID = "no-such-work"
+	err = s.AppendSessions(ctx, u.ID, []store.Session{fresh, orphan})
+	if !errors.As(err, &item) || !errors.Is(err, store.ErrNotFound) ||
+		item.Index != 1 || item.ID != "s-orphan" || item.WorkID != "no-such-work" {
+		t.Fatalf("unknown work: got %#v", err)
+	}
+	if err := s.DeleteWork(ctx, u.ID, w.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendSessions(ctx, u.ID, []store.Session{ses}); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("session for a deleted work: want ErrNotFound, got %v", err)
 	}
 }
 
@@ -945,8 +1001,12 @@ func testSessionRollups(t *testing.T, open OpenFunc) {
 	}
 	changed := ses
 	changed.EndProg = 0.3
-	if err := s.AppendSessions(ctx, u.ID, []store.Session{changed}); err != store.ErrIDMismatch {
+	if err := s.AppendSessions(ctx, u.ID, []store.Session{changed}); !errors.Is(err, store.ErrIDMismatch) {
 		t.Fatalf("archived mismatch: want ErrIDMismatch, got %v", err)
+	}
+	var item *store.ItemError
+	if err := s.AppendSessions(ctx, u.ID, []store.Session{changed}); !errors.As(err, &item) || item.ID != "old-s1" || item.Index != 0 {
+		t.Fatalf("archived mismatch names its item: got %#v", err)
 	}
 	MkWork(t, s, u, "rollup-target", "rollup-target-sha")
 	if err := s.SplitWork(ctx, u.ID, w.ID, "rollup-sha", nil,

--- a/internal/webui/readerfirefox_ext_test.go
+++ b/internal/webui/readerfirefox_ext_test.go
@@ -18,12 +18,28 @@ func findFirefox() string {
 	if named := os.Getenv("LISEUR_FIREFOX"); named != "" {
 		return named
 	}
+	// Hosted CI images ship Firefox, and this is an opt-in browser
+	// check like the Chromium one: a preinstalled browser must not turn
+	// it into a gate that fails whenever the runner's Firefox is slow to
+	// announce its remote-control port. LISEUR_FIREFOX is the opt-in.
+	if os.Getenv("CI") != "" {
+		return ""
+	}
 	for _, name := range []string{"firefox", "firefox-esr", "firefox-bin"} {
 		if path, err := exec.LookPath(name); err == nil {
 			return path
 		}
 	}
 	return ""
+}
+
+func TestFindFirefoxDoesNotAutoDiscoverInCI(t *testing.T) {
+	t.Setenv("CI", "1")
+	t.Setenv("LISEUR_FIREFOX", "")
+
+	if got := findFirefox(); got != "" {
+		t.Fatalf("findFirefox() = %q in CI without explicit opt-in, want empty", got)
+	}
 }
 
 // TestReaderOpensInFirefox runs the same judgement as the Chromium check


### PR DESCRIPTION
Four changes to make a client's sync recoverable rather than lossy.

## What changed

**A refused batch now names the item it is about.** Positions and reading
sessions are stored all or nothing, so when the server refuses a push the
client has to know which record to set aside. Previously only an unknown
book said so, and a duplicate session id named nothing at all, so the
Android client marked the whole batch sent and dropped up to a thousand
sessions. Every item-level refusal on `POST /v1/ops` and `POST /v1/sessions`
now carries a code, the item's place in the batch and its id. Size refusals
carry the limit, an oversized body is a 413, and a reused session id with a
different payload is a 409 that says which item.

**The changes feed is read from one snapshot.** The high-water mark, the
compaction horizon and the page of records were read separately, so a
compaction running in between could hand a client a cursor past a gap it
would never hear about. Both database backends now read all three inside one
read-only transaction.

**A replacement token can keep its device.** A client whose credential
lapsed came back as a new device, and everything it had sent but never seen
acknowledged replayed as a conflict instead of a duplicate. `POST /v1/tokens`
now accepts the device id it used before and honours it when the account
already owns it.

**A token can say which account it belongs to.** `GET /v1/token` now returns
a stable account id, so a client that reconnects or is handed a replacement
secret can tell it is still the same account instead of throwing away its
cursor.

## Why

All four are the server side of a client that could not tell a permanent
refusal from a temporary one, or itself from a stranger, and lost reading
data because of it.

## Testing

`go build ./...`, `go vet ./...` and `go test -race` over `internal/api`,
`internal/store/...` and `internal/auth` pass. New tests cover batch refusal
shapes, token device inheritance, token self-description, and a compaction
stress test that fails against the old code on both SQLite and Postgres.

## Build fixes picked up along the way

Two problems in the test workflow surfaced on this branch and are fixed
here. The per-package time limit was five minutes and the web UI suite
already used nearly all of it, so a healthy run was one slow moment away
from being reported as a hang; the limit now sits far enough above a
normal run to only mean something is genuinely stuck. And the Firefox
reader check was running on the build server, which has Firefox
installed, even though its Chromium twin deliberately does not. It now
follows the same rule and runs only when asked for by name.
