### PR TITLE
Guide first-run setup into the library

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -147,7 +147,15 @@ promotes and demotes accounts. The role lives on the account, so
 granting it hands nobody a secret, and the last enabled administrator
 cannot be demoted.
 
-Now add the books:
+When the first administrator is created from the web setup page, a fresh
+instance with no folders goes straight to Administration → Folders and
+opens the first-folder form. Point it at the directory that already holds
+the books; the server detects whether it is a plain folder or a Calibre
+library, reads it immediately and keeps watching it. Closing the form or
+using a browser without JavaScript leaves the same form available on the
+Folders page.
+
+You can also add the books from a shell:
 
 ```
 liseur-sync admin -config liseur-sync.toml add-folder Shelf /srv/books

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -153,7 +153,11 @@ opens the first-folder form. Point it at the directory that already holds
 the books; the server detects whether it is a plain folder or a Calibre
 library, reads it immediately and keeps watching it. Closing the form or
 using a browser without JavaScript leaves the same form available on the
-Folders page.
+Folders page. Submitting it goes straight to the library rather than back
+to Folders — watching that first folder was the whole point of the trip.
+The same is true any other time a folder is added while the server had
+none: the admin panel is otherwise unchanged, so a folder added after
+one already exists still lands back on Folders with its usual notice.
 
 You can also add the books from a shell:
 

--- a/internal/webui/adminexpanded_test.go
+++ b/internal/webui/adminexpanded_test.go
@@ -78,14 +78,33 @@ func TestAdminWatchesAndForgetsAFolder(t *testing.T) {
 		t.Fatalf("a refused add created %d folders", len(folders))
 	}
 
-	_, body = postForm(t, ts, cookie, "/ui/admin/folders", url.Values{
+	// The very first folder ever watched sends the browser straight to
+	// the library — there is nothing left worth stopping at on a
+	// Folders page that just went from empty to one entry.
+	req, _ := http.NewRequest("POST", ts.URL+"/ui/admin/folders", strings.NewReader(url.Values{
 		"csrf": {csrf}, "name": {"Shelf"}, "root": {root},
-	})
-	if !strings.Contains(body, "Watching Shelf") {
-		t.Fatalf("add: %s", body)
+	}.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	resp, err := noRedirect().Do(req)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if strings.Contains(body, `data-auto-open="true"`) {
-		t.Fatalf("a successful folder add left the dialog marked for auto-open: %s", body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("add: got %d", resp.StatusCode)
+	}
+	landed, err := req.URL.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if landed.Path != "/ui/library" || landed.Query().Get("notice") == "" {
+		t.Fatalf("first folder add landed at %q, want the library with a notice",
+			resp.Header.Get("Location"))
+	}
+	_, body = page(t, ts, cookie, landed.RequestURI())
+	if !strings.Contains(body, "Watching Shelf") {
+		t.Fatalf("library after first folder add: %s", body)
 	}
 	folders, err := st.ListFolders(ctx, "", "", 10)
 	if err != nil || len(folders) != 1 {
@@ -155,12 +174,47 @@ func TestAdminFolderHonoursTheAllowlist(t *testing.T) {
 	if folders, _ := st.ListFolders(t.Context(), "", "", 10); len(folders) != 0 {
 		t.Fatalf("a refused root still created %d folders", len(folders))
 	}
-	// A directory below an allowed root is allowed.
+	// A directory below an allowed root is allowed. It is also this
+	// store's first folder, so postForm follows the redirect to the
+	// library rather than back to the Folders page (pinned exactly in
+	// TestAdminWatchesAndForgetsAFolder).
 	_, body = postForm(t, ts, cookie, "/ui/admin/folders", url.Values{
 		"csrf": {csrf}, "name": {"Shelf"}, "root": {inside},
 	})
 	if !strings.Contains(body, "Watching Shelf") {
 		t.Fatalf("a root below an allowed one was refused: %s", body)
+	}
+}
+
+// TestAdminSecondFolderStaysOnFoldersPage pins the other half: once the
+// server already watches something, adding another folder still lands
+// back on the Folders admin page with its usual notice, exactly as
+// before this behavior existed for the very first folder.
+func TestAdminSecondFolderStaysOnFoldersPage(t *testing.T) {
+	ts, st := testServerCfg(t, nil, generousReauth)
+	ctx := t.Context()
+	if err := st.SetUserAdmin(ctx, "u1", true); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.CreateFolder(ctx, store.Folder{
+		ID: "existing", Name: "Existing", RootPath: t.TempDir(),
+		Kind: store.FolderPlain, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cookie := loginCookie(t, ts)
+	_, body := page(t, ts, cookie, "/ui/settings?section=admin&view=folders")
+	csrf := extractCSRF(t, body)
+
+	_, body = postForm(t, ts, cookie, "/ui/admin/folders", url.Values{
+		"csrf": {csrf}, "name": {"Second"}, "root": {t.TempDir()},
+	})
+	if !strings.Contains(body, "Watching Second") {
+		t.Fatalf("add: %s", body)
+	}
+	if strings.Contains(body, `data-auto-open="true"`) {
+		t.Fatalf("a successful folder add left the dialog marked for auto-open: %s", body)
 	}
 }
 

--- a/internal/webui/adminexpanded_test.go
+++ b/internal/webui/adminexpanded_test.go
@@ -45,6 +45,14 @@ func TestAdminWatchesAndForgetsAFolder(t *testing.T) {
 	if !strings.Contains(body, "Watch a folder") {
 		t.Fatalf("the add form is not on the page:\n%s", body)
 	}
+	if !strings.Contains(body, `id="folder-dialog"`) ||
+		!strings.Contains(body, "Add your book folder") ||
+		!strings.Contains(body, `data-dialog-open="folder-dialog"`) {
+		t.Fatalf("the empty folder page is missing its onboarding UI:\n%s", body)
+	}
+	if strings.Contains(body, `data-auto-open="true"`) {
+		t.Fatalf("a normal folders visit unexpectedly opened onboarding:\n%s", body)
+	}
 
 	// A blank name is refused, and refused by the same rule the CLI
 	// uses rather than by a second copy of it.
@@ -53,6 +61,9 @@ func TestAdminWatchesAndForgetsAFolder(t *testing.T) {
 	})
 	if !strings.Contains(body, "a folder name is required") {
 		t.Fatalf("a blank name was accepted: %s", body)
+	}
+	if !strings.Contains(body, `data-auto-open="true"`) {
+		t.Fatalf("folder validation did not reopen the add dialog: %s", body)
 	}
 
 	// A path that is not a directory is refused before a row exists.
@@ -72,6 +83,9 @@ func TestAdminWatchesAndForgetsAFolder(t *testing.T) {
 	})
 	if !strings.Contains(body, "Watching Shelf") {
 		t.Fatalf("add: %s", body)
+	}
+	if strings.Contains(body, `data-auto-open="true"`) {
+		t.Fatalf("a successful folder add left the dialog marked for auto-open: %s", body)
 	}
 	folders, err := st.ListFolders(ctx, "", "", 10)
 	if err != nil || len(folders) != 1 {

--- a/internal/webui/adminfolders.go
+++ b/internal/webui/adminfolders.go
@@ -78,7 +78,10 @@ func (s *Server) handleAdminCreateFolder(
 		s.Cfg.Content.FolderRoots, u.ID)
 	logAdminAction(r, u, "add-folder", name, err)
 	if err != nil {
-		s.renderAdminFolders(w, r, a, u, Flash{Error: err.Error()})
+		s.renderAdminFolders(w, r, a, u, Flash{
+			Error:          err.Error(),
+			OpenFolderForm: true,
+		})
 		return
 	}
 	// Tell the running watcher at once. Waiting for the periodic

--- a/internal/webui/adminfolders.go
+++ b/internal/webui/adminfolders.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -72,6 +73,11 @@ func (s *Server) handleAdminCreateFolder(
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
+	hadFolders, err := s.St.HasAnyFolder(r.Context())
+	if err != nil {
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
 	name := strings.TrimSpace(r.FormValue("name"))
 	root := strings.TrimSpace(r.FormValue("root"))
 	folder, err := admin.NewFolder(r.Context(), s.St, name, root,
@@ -100,11 +106,18 @@ func (s *Server) handleAdminCreateFolder(
 		defer cancel()
 		s.Watching.Add(ctx, folder)
 	}
-	s.renderAdminFolders(w, r, a, u, Flash{
-		Notice: "Watching " + folder.Name +
-			". Its books appear in your library as the server reads them. " +
-			"Other accounts see it once you assign it to them from Users.",
-	})
+	notice := "Watching " + folder.Name +
+		". Its books appear in your library as the server reads them. " +
+		"Other accounts see it once you assign it to them from Users."
+	// Nothing on the Folders page is worth stopping at once the server
+	// has gone from no folders to one: the point of that first folder
+	// was to see books, so go see them.
+	if !hadFolders {
+		redirectRel(w, relPrefix(r.URL.Path)+"library?notice="+url.QueryEscape(notice),
+			http.StatusSeeOther)
+		return
+	}
+	s.renderAdminFolders(w, r, a, u, Flash{Notice: notice})
 }
 
 // handleAdminScanFolder runs a pass over one folder now and waits for

--- a/internal/webui/adminfolders.go
+++ b/internal/webui/adminfolders.go
@@ -73,10 +73,15 @@ func (s *Server) handleAdminCreateFolder(
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
+	// Only decides where a successful add lands the browser, so a
+	// failure here must not block the add itself: fall back to the
+	// existing behavior (stay on the Folders page) rather than
+	// aborting a mutation this check has nothing to do with validating.
 	hadFolders, err := s.St.HasAnyFolder(r.Context())
 	if err != nil {
-		http.Error(w, "internal", http.StatusInternalServerError)
-		return
+		slog.Error("could not determine whether this is the first folder",
+			"error", err)
+		hadFolders = true
 	}
 	name := strings.TrimSpace(r.FormValue("name"))
 	root := strings.TrimSpace(r.FormValue("root"))

--- a/internal/webui/adminfolders.templ
+++ b/internal/webui/adminfolders.templ
@@ -4,29 +4,13 @@ package webui
 // is the only page whose subject is the disk rather than a book
 // (ADR-0017).
 
-templ adminFoldersBody(prefix string, csrf string, folders []adminFolderView, next string, roots []string, flash Flash) {
-	<h2>Folders</h2>
-	<p class="muted">
-		Directories this server reads. It never moves, renames or deletes
-		anything under a root, and removing a folder here forgets this
-		server's record of it while leaving every file where it is.
-	</p>
-	<p class="muted">
-		A folder that accepts uploads is the one exception: a reader can
-		send a book to it and the server writes that one new file. It is
-		off until you turn it on, and a folder whose disk is mounted
-		read-only cannot take it.
-	</p>
-	<p class="muted">
-		A folder is read when it changes and again on a slow timer, so
-		this page is not usually where books come from. Scan now is for
-		when it is: a network share, where the kernel tells this server
-		nothing at all about what changed.
-	</p>
-	@adminFlash(flash)
-	<section class="card">
-		<div class="cardhead">
-			<h2>Watched</h2>
+templ adminFoldersBody(prefix string, csrf string, folders []adminFolderView, next string, roots []string, openFolderForm bool, flash Flash) {
+	<header class="folder-heading">
+		<div>
+			<p class="eyebrow">Library sources</p>
+			<h2>Folders</h2>
+		</div>
+		<div class="folder-actions">
 			if len(folders) > 0 {
 				<form
 					class="scanform"
@@ -43,13 +27,64 @@ templ adminFoldersBody(prefix string, csrf string, folders []adminFolderView, ne
 					</button>
 				</form>
 			}
+			<button
+				type="button"
+				class="btn primary"
+				data-dialog-open="folder-dialog"
+				aria-controls="folder-dialog"
+				aria-haspopup="dialog"
+			>Add folder</button>
 		</div>
-		if len(folders) == 0 {
+	</header>
+	<p class="muted folder-intro">
+		Folders are directories this server reads. It never moves, renames or
+		deletes anything under a root, and removing a folder here only forgets
+		this server's record of it.
+	</p>
+	@adminFlash(flash)
+	if len(folders) == 0 {
+		<section class="card onboarding-card">
+			<div class="onboarding-icon" aria-hidden="true">+</div>
+			<div class="onboarding-copy">
+				<p class="eyebrow">First step</p>
+				<h2>Add your book folder</h2>
+				<p>
+					Point liseur-sync at the directory where your books already
+					live. The server will detect the folder type, read its books,
+					and keep the library up to date.
+				</p>
+				<p class="muted">
+					Nothing on disk is changed. Uploads stay off until you
+					explicitly enable them for a folder.
+				</p>
+				<div class="onboarding-actions">
+					<button
+						type="button"
+						class="btn primary"
+						data-dialog-open="folder-dialog"
+						aria-controls="folder-dialog"
+						aria-haspopup="dialog"
+					>
+						Choose a folder
+					</button>
+					<a class="btn" href={ prefix + "." }>Back to dashboard</a>
+				</div>
+			</div>
+		</section>
+	} else {
+		<section class="card">
+			<div class="cardhead">
+				<h2>Watched</h2>
+			</div>
 			<p class="muted">
-				No folders yet. Add one below and its books appear as the
-				server reads them.
+				A folder is read when it changes and again on a slow timer. Scan
+				now is useful for network shares where the kernel tells this
+				server nothing about what changed.
 			</p>
-		} else {
+			<p class="muted">
+				Uploads are off by default. Enabling them is the only time this
+				server writes a new book file under a folder.
+			</p>
 			<table>
 				<tr><th>Name</th><th>Kind</th><th>Root</th><th>Uploads</th><th>Added</th><th></th></tr>
 				for _, f := range folders {
@@ -110,17 +145,64 @@ templ adminFoldersBody(prefix string, csrf string, folders []adminFolderView, ne
 			if next != "" {
 				<p><a href={ next }>Next page →</a></p>
 			}
-		}
+		</section>
+	}
+	@adminFolderDialog(prefix, csrf, roots, openFolderForm)
+	<section class="card folder-form-fallback">
+		<div class="cardhead">
+			<div>
+				<h2>Watch a folder</h2>
+				<p class="muted">
+					Give a directory on this machine. Whether it is an ordinary
+					tree of books or a Calibre library is read off the disk.
+				</p>
+			</div>
+			<button
+				type="button"
+				class="btn"
+				data-dialog-open="folder-dialog"
+				aria-controls="folder-dialog"
+				aria-haspopup="dialog"
+			>Add folder</button>
+		</div>
+		@adminFolderForm(prefix, csrf, roots)
 	</section>
-	<section class="card">
-		<h2>Watch a folder</h2>
-		<p class="muted">
-			Give a directory on this machine. Whether it is an ordinary tree
-			of books or a Calibre library is read off the disk, not chosen
-			here.
-		</p>
+}
+
+templ adminFolderDialog(prefix string, csrf string, roots []string, openFolderForm bool) {
+	if openFolderForm {
+		<dialog id="folder-dialog" class="folder-dialog" data-auto-open="true" aria-labelledby="folder-dialog-title">
+			@adminFolderDialogBody(prefix, csrf, roots)
+		</dialog>
+	} else {
+		<dialog id="folder-dialog" class="folder-dialog" aria-labelledby="folder-dialog-title">
+			@adminFolderDialogBody(prefix, csrf, roots)
+		</dialog>
+	}
+}
+
+templ adminFolderDialogBody(prefix string, csrf string, roots []string) {
+	<div class="dialog-head">
+		<div>
+			<p class="eyebrow">Add to your library</p>
+			<h2 id="folder-dialog-title">Watch a folder</h2>
+		</div>
+		<form method="dialog">
+			<button type="submit" class="dialog-close">Close</button>
+		</form>
+	</div>
+	<p class="muted">
+		Choose an existing directory. liseur-sync reads it without changing
+		the files inside.
+	</p>
+	@adminFolderForm(prefix, csrf, roots)
+}
+
+templ adminFolderForm(prefix string, csrf string, roots []string) {
+	<form class="folder-form" method="post" action={ prefix + "admin/folders" }>
+		<input type="hidden" name="csrf" value={ csrf }/>
 		if len(roots) > 0 {
-			<p class="muted">
+			<p class="muted folder-roots">
 				This server accepts roots under:
 				for i, root := range roots {
 					if i > 0 {
@@ -130,17 +212,16 @@ templ adminFoldersBody(prefix string, csrf string, folders []adminFolderView, ne
 				}
 			</p>
 		}
-		<form method="post" action={ prefix + "admin/folders" }>
-			<input type="hidden" name="csrf" value={ csrf }/>
-			<label>
-				Name
-				<input type="text" name="name" required maxlength="120"/>
-			</label>
-			<label>
-				Root path
-				<input type="text" name="root" required placeholder="/srv/books"/>
-			</label>
-			<button type="submit">Watch it</button>
-		</form>
-	</section>
+		<label>
+			Name
+			<input type="text" name="name" required maxlength="120" autocomplete="off"/>
+		</label>
+		<label>
+			Root path
+			<input type="text" name="root" required placeholder="/srv/books" autocomplete="off"/>
+		</label>
+		<div class="form-actions">
+			<button type="submit" class="primary">Watch this folder</button>
+		</div>
+	</form>
 }

--- a/internal/webui/devices.templ
+++ b/internal/webui/devices.templ
@@ -11,6 +11,9 @@ type Flash struct {
 	// name already taken, a guard that fired. It renders in the danger
 	// colour above the page's forms.
 	Error string
+	// OpenFolderForm keeps a rejected folder form open after the settings
+	// redirect, rather than making the administrator start over.
+	OpenFolderForm bool
 }
 
 templ devicesBody(prefix string, csrf string, toks []store.Token, browsers []browserSession, kosyncDevs []store.KosyncDevice, kopluginDevs []store.KopluginDevice, base string, flash Flash) {

--- a/internal/webui/settings.templ
+++ b/internal/webui/settings.templ
@@ -107,7 +107,7 @@ templ settingsAdminBody(prefix string, csrf string, v settingsView) {
 		@settingsAdminTab(settingsAdminHref(prefix, settingsAdminMaintenance), "Maintenance", v.Admin.View == settingsAdminMaintenance)
 	</nav>
 	if v.Admin.View == settingsAdminFolders {
-		@adminFoldersBody(prefix, csrf, v.Admin.Folders, v.Admin.FoldersNext, v.Admin.Roots, v.Flash)
+		@adminFoldersBody(prefix, csrf, v.Admin.Folders, v.Admin.FoldersNext, v.Admin.Roots, v.Admin.OpenFolderForm, v.Flash)
 	} else if v.Admin.View == settingsAdminUsers {
 		@adminUsersBody(prefix, csrf, v.Admin.Users, v.Admin.UsersNext, v.Admin.Invites, v.Flash)
 	} else if v.Admin.View == settingsAdminUser && v.Admin.HasUser {

--- a/internal/webui/settingsview.go
+++ b/internal/webui/settingsview.go
@@ -23,6 +23,20 @@ const (
 	settingsAdminMaintenance = "maintenance"
 )
 
+const (
+	folderOnboardingQuery = "onboarding"
+	folderOnboardingValue = "folder"
+)
+
+func settingsAdminFoldersOnboardingHref(prefix string) string {
+	return settingsAdminHref(prefix, settingsAdminFolders) +
+		"&" + folderOnboardingQuery + "=" + folderOnboardingValue
+}
+
+func folderOnboardingRequested(r *http.Request) bool {
+	return r.URL.Query().Get(folderOnboardingQuery) == folderOnboardingValue
+}
+
 type settingsDevicesView struct {
 	Tokens   []store.Token
 	Browsers []browserSession
@@ -38,9 +52,10 @@ type settingsAdminView struct {
 	Build  buildinfo.Info
 	Config configFacts
 
-	Folders     []adminFolderView
-	FoldersNext string
-	Roots       []string
+	Folders        []adminFolderView
+	FoldersNext    string
+	Roots          []string
+	OpenFolderForm bool
 
 	Users     []store.User
 	UsersNext string
@@ -142,22 +157,28 @@ func settingsRedirect(
 }
 
 // flashQuery encodes what a redirect has to carry across. It uses the
-// same notice/problem pair the library and reader pages already use.
+// same notice/problem pair the library and reader pages already use,
+// plus the folder dialog marker when a folder form needs reopening.
 func flashQuery(flash Flash) string {
+	var query []string
 	switch {
 	case flash.Error != "":
-		return "problem=" + url.QueryEscape(flash.Error)
+		query = append(query, "problem="+url.QueryEscape(flash.Error))
 	case flash.Notice != "":
-		return "notice=" + url.QueryEscape(flash.Notice)
+		query = append(query, "notice="+url.QueryEscape(flash.Notice))
 	}
-	return ""
+	if flash.OpenFolderForm {
+		query = append(query, folderOnboardingQuery+"="+folderOnboardingValue)
+	}
+	return strings.Join(query, "&")
 }
 
 // flashFromQuery reads back what settingsRedirect sent.
 func flashFromQuery(r *http.Request) Flash {
 	return Flash{
-		Notice: r.URL.Query().Get("notice"),
-		Error:  r.URL.Query().Get("problem"),
+		Notice:         r.URL.Query().Get("notice"),
+		Error:          r.URL.Query().Get("problem"),
+		OpenFolderForm: folderOnboardingRequested(r),
 	}
 }
 
@@ -283,6 +304,7 @@ func (s *Server) settingsAdmin(
 		if err != nil {
 			return err
 		}
+		v.OpenFolderForm = folderOnboardingRequested(r)
 		if len(folders) > adminFoldersPerPage {
 			folders = folders[:adminFoldersPerPage]
 			v.FoldersNext = settingsAdminHref(relPrefix("/ui/settings"), settingsAdminFolders) +

--- a/internal/webui/setup.go
+++ b/internal/webui/setup.go
@@ -88,7 +88,15 @@ func (s *Server) handleSetup(w http.ResponseWriter, r *http.Request) {
 		redirectRel(w, prefix+"login", http.StatusSeeOther)
 		return
 	}
-	redirectRel(w, "./", http.StatusSeeOther)
+	destination := "./"
+	hasFolders, err := s.St.HasAnyFolder(r.Context())
+	if err != nil {
+		slog.Error("could not determine whether first-run setup has a folder",
+			"error", err)
+	} else if !hasFolders {
+		destination = settingsAdminFoldersOnboardingHref(prefix)
+	}
+	redirectRel(w, destination, http.StatusSeeOther)
 }
 
 // isUserError reports whether err is one of the validation refusals

--- a/internal/webui/setup_test.go
+++ b/internal/webui/setup_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/chmouel/liseur-sync/internal/auth"
 	"github.com/chmouel/liseur-sync/internal/config"
@@ -121,6 +122,18 @@ func TestFirstRunSetupOnboarding(t *testing.T) {
 	if resp.StatusCode != http.StatusSeeOther {
 		t.Fatalf("setup: got %d", resp.StatusCode)
 	}
+	base, _ := url.Parse(ts.URL + "/ui/setup")
+	landed, err := base.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if landed.Path != "/ui/settings" ||
+		landed.Query().Get("section") != settingsAdmin ||
+		landed.Query().Get("view") != settingsAdminFolders ||
+		landed.Query().Get(folderOnboardingQuery) != folderOnboardingValue {
+		t.Fatalf("setup landed at %q, want the first-folder onboarding view",
+			resp.Header.Get("Location"))
+	}
 	var cookie *http.Cookie
 	for _, c := range resp.Cookies() {
 		if c.Name == cookieName {
@@ -142,6 +155,44 @@ func TestFirstRunSetupOnboarding(t *testing.T) {
 	// Signed in, and the admin section is open to them.
 	if code, _ := page(t, ts, cookie, "/ui/settings?section=admin"); code != http.StatusOK {
 		t.Fatalf("admin overview after setup: got %d", code)
+	}
+	code, body = page(t, ts, cookie,
+		"/ui/settings?section=admin&view=folders&onboarding=folder")
+	if code != http.StatusOK ||
+		!strings.Contains(body, `id="folder-dialog"`) ||
+		!strings.Contains(body, `data-auto-open="true"`) ||
+		!strings.Contains(body, "Add your book folder") {
+		t.Fatalf("first-folder onboarding view is incomplete: %d\n%s", code, body)
+	}
+}
+
+func TestFirstRunSetupWithExistingFolderKeepsDashboard(t *testing.T) {
+	ts, st := emptyServer(t)
+	if err := st.CreateFolder(t.Context(), store.Folder{
+		ID: "existing-folder", Name: "Existing", RootPath: t.TempDir(),
+		Kind: store.FolderPlain, CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := noRedirect().PostForm(ts.URL+"/ui/setup", url.Values{
+		"username": {"founder"}, "password": {"hunter2hunter"},
+		"repeat": {"hunter2hunter"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("setup: got %d", resp.StatusCode)
+	}
+	base, _ := url.Parse(ts.URL + "/ui/setup")
+	landed, err := base.Parse(resp.Header.Get("Location"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if landed.Path != "/ui/" {
+		t.Fatalf("setup landed at %q, want the dashboard", resp.Header.Get("Location"))
 	}
 }
 

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -321,6 +321,61 @@ details.advanced > summary {
 details.advanced > summary::before { content: "+"; }
 details.advanced[open] > summary::before { content: "−"; }
 
+/* --------------------------------------------------------- folder setup */
+
+.folder-heading {
+	display: flex; align-items: end; justify-content: space-between;
+	gap: 1rem; margin: 0 0 .55rem; flex-wrap: wrap;
+}
+.folder-heading h2 { font-size: 2rem; line-height: 1.1; margin: 0; }
+.folder-actions { display: flex; align-items: center; gap: .5rem; flex-wrap: wrap; }
+.folder-actions .scanform { margin: 0; }
+.folder-intro { max-width: 52rem; margin: 0 0 1.1rem; }
+.onboarding-card {
+	display: flex; align-items: flex-start; gap: 1.1rem;
+	padding: clamp(1.25rem, 4vw, 2.2rem);
+	border-color: color-mix(in srgb, var(--primary) 45%, var(--line));
+	background:
+		linear-gradient(135deg, color-mix(in srgb, var(--primary) 13%, var(--surface)), var(--surface));
+}
+.onboarding-icon {
+	display: flex; align-items: center; justify-content: center;
+	flex: 0 0 2.8rem; height: 2.8rem; border-radius: 50%;
+	background: var(--primary); color: var(--on-primary);
+	font-size: 1.7rem; font-weight: 700; line-height: 1;
+}
+.onboarding-copy { max-width: 43rem; }
+.onboarding-copy h2 { font-size: 1.35rem; margin-bottom: .55rem; }
+.onboarding-copy p { margin: .45rem 0; }
+.onboarding-actions { display: flex; gap: .5rem; flex-wrap: wrap; margin-top: 1rem; }
+.folder-form-fallback { margin-top: 1.2rem; }
+.dialog-supported .folder-form-fallback { display: none; }
+.folder-form-fallback .cardhead { align-items: flex-start; }
+.folder-form-fallback .cardhead p { margin: .25rem 0 0; max-width: 42rem; }
+.folder-form { max-width: 42rem; }
+.folder-form .folder-roots { margin: .2rem 0 .8rem; }
+.folder-form .folder-roots code { overflow-wrap: anywhere; }
+.folder-form .form-actions { margin-top: .9rem; }
+.folder-dialog {
+	display: none;
+	width: min(34rem, calc(100% - 2rem)); max-width: 100%;
+	margin: auto; padding: 1.25rem 1.35rem;
+	background: var(--surface); color: inherit;
+	border: 1px solid var(--line); border-radius: var(--radius);
+	box-shadow: var(--shadow); font-size: .95rem;
+}
+.folder-dialog[open] { display: block; }
+.folder-dialog::backdrop { background: rgb(0 0 0 / .58); }
+.dialog-head {
+	display: flex; align-items: flex-start; justify-content: space-between;
+	gap: 1rem; margin: 0 0 .7rem;
+}
+.dialog-head h2 { font-size: 1.25rem; margin: 0; }
+.dialog-head .eyebrow { margin: 0 0 .15rem; }
+.dialog-head form { margin: 0; }
+.dialog-close { color: var(--muted); }
+.dialog-close:hover { color: var(--ink); }
+
 /* The add-library form: the folder fields only matter once "a folder on
    this server" is picked. Hidden with :has() so it needs no script; a
    browser without :has() shows the whole form, which still works. */
@@ -372,6 +427,11 @@ details.advanced[open] > summary::before { content: "−"; }
 	font-weight: 600;
 }
 .settings-card > form { max-width: 48rem; }
+
+@media (max-width: 42em) {
+	.onboarding-card { flex-direction: column; }
+	.folder-dialog { padding: 1rem; }
+}
 
 /* The admin section's own navigation: one rail entry, several pages. */
 .subnav {

--- a/internal/webui/static/ui.js
+++ b/internal/webui/static/ui.js
@@ -33,16 +33,18 @@
     openDialog(trigger.dataset.dialogOpen);
   });
 
-  document.querySelectorAll('dialog[data-auto-open]').forEach(function (dialog) {
-    openDialog(dialog.id);
-    if (window.history && window.history.replaceState) {
-      const url = new URL(window.location.href);
-      if (url.searchParams.get('onboarding') === 'folder') {
-        url.searchParams.delete('onboarding');
-        window.history.replaceState({}, document.title, url);
+  if (dialogSupported) {
+    document.querySelectorAll('dialog[data-auto-open]').forEach(function (dialog) {
+      openDialog(dialog.id);
+      if (window.history && window.history.replaceState && window.URL) {
+        const url = new URL(window.location.href);
+        if (url.searchParams.get('onboarding') === 'folder') {
+          url.searchParams.delete('onboarding');
+          window.history.replaceState({}, document.title, url.toString());
+        }
       }
-    }
-  });
+    });
+  }
 
   // "/" puts the cursor in the search box, Escape closes the mobile nav.
   document.addEventListener('keydown', function (e) {

--- a/internal/webui/static/ui.js
+++ b/internal/webui/static/ui.js
@@ -12,6 +12,38 @@
 (function () {
   'use strict';
 
+  // Native dialogs provide focus trapping and Escape handling without
+  // adding another UI dependency. Keep the inline form visible when a
+  // browser cannot provide that primitive.
+  const dialogSupported = typeof HTMLDialogElement !== 'undefined' &&
+    typeof HTMLDialogElement.prototype.showModal === 'function';
+  if (dialogSupported) document.documentElement.classList.add('dialog-supported');
+
+  function openDialog(id) {
+    const dialog = document.getElementById(id);
+    if (!dialog) return;
+    if (typeof dialog.showModal === 'function') {
+      if (!dialog.open) dialog.showModal();
+    }
+  }
+
+  document.addEventListener('click', function (e) {
+    const trigger = e.target.closest && e.target.closest('[data-dialog-open]');
+    if (!trigger) return;
+    openDialog(trigger.dataset.dialogOpen);
+  });
+
+  document.querySelectorAll('dialog[data-auto-open]').forEach(function (dialog) {
+    openDialog(dialog.id);
+    if (window.history && window.history.replaceState) {
+      const url = new URL(window.location.href);
+      if (url.searchParams.get('onboarding') === 'folder') {
+        url.searchParams.delete('onboarding');
+        window.history.replaceState({}, document.title, url);
+      }
+    }
+  });
+
   // "/" puts the cursor in the search box, Escape closes the mobile nav.
   document.addEventListener('keydown', function (e) {
     const active = document.activeElement;

--- a/internal/webui/webui_test.go
+++ b/internal/webui/webui_test.go
@@ -120,15 +120,17 @@ func postForm(t *testing.T, ts *httptest.Server, cookie *http.Cookie, path strin
 	defer resp.Body.Close()
 	// A settings mutation answers with Post/Redirect/Get, so the notice
 	// it produced is on the page the browser is sent to, not in this
-	// response. Follow that one hop the way a browser would. Any other
-	// redirect — the bounce to /ui/login a revoked session gets, say —
-	// is returned as it is, because it is the thing under test.
+	// response. Follow that one hop the way a browser would — including
+	// the library, which is where adding a server's first folder sends
+	// it instead of back to Folders. Any other redirect — the bounce to
+	// /ui/login a revoked session gets, say — is returned as it is,
+	// because it is the thing under test.
 	if resp.StatusCode == http.StatusSeeOther {
 		loc, err := req.URL.Parse(resp.Header.Get("Location"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		if strings.HasPrefix(loc.Path, "/ui/settings") {
+		if strings.HasPrefix(loc.Path, "/ui/settings") || loc.Path == "/ui/library" {
 			return page(t, ts, cookie, loc.RequestURI())
 		}
 	}


### PR DESCRIPTION
## Summary
- A fresh server with no accounts now walks a new administrator straight into adding their first folder, with an onboarding dialog on the Folders admin page.
- Once that first folder is added — whether from first-run setup or any other time the server has none — the administrator lands straight in the library instead of back on the Folders admin page, since seeing the books was the point.
- Adding a folder when one already exists is unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `go test -race ./...`