### PR TITLE
Hash passwords more cheaply in test builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,3 +248,11 @@ of them.
   `internal/webui`; extend them when adding routes.
 - Adapter changes must not break the conformance tests in
   `internal/adapter/*/`.
+- **A test binary hashes passwords at a reduced argon2id cost.**
+  `internal/auth` selects its cost with `testing.Testing()`: 64 MiB /
+  t=3 / p=2 in a real build, 8 MiB / t=1 / p=1 under `go test`. The
+  parameters travel inside every encoded hash, so a password an existing
+  deployment stored still verifies at the cost it was written with, and
+  nothing about production changes. `TestProductionPasswordParamsPinned`
+  holds the production baseline in place. Use `auth.HashPassword` in
+  fixtures rather than a hardcoded encoding, so the saving applies.

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/chmouel/liseur-sync/internal/store"
@@ -23,6 +25,51 @@ func TestPasswordRoundTrip(t *testing.T) {
 	}
 	if _, err := CheckPassword("x", "not-a-hash"); err == nil {
 		t.Fatal("want error on malformed hash")
+	}
+}
+
+// TestProductionPasswordParamsPinned guards the parameters that
+// protect stored passwords. Test binaries hash at a reduced cost
+// (issue #31) so that suites which need an account per fixture do not
+// spend their run inside argon2id; nothing else may lower it, and the
+// production baseline stays where OWASP puts it.
+func TestProductionPasswordParamsPinned(t *testing.T) {
+	want := argon2Params{time: 3, memory: 64 * 1024, threads: 2}
+	if productionParams != want {
+		t.Fatalf("production argon2id cost changed: got %+v want %+v", productionParams, want)
+	}
+	if argonKeyLen != 32 || saltLen != 16 {
+		t.Fatalf("key/salt length changed: key=%d salt=%d", argonKeyLen, saltLen)
+	}
+	if got := hashingParams(); got != testParams {
+		t.Fatalf("a test binary must hash at the reduced cost, got %+v", got)
+	}
+
+	// A hash written at the production cost still round-trips: the
+	// parameters travel in the encoding, so the reduced test cost can
+	// never invalidate a password a real deployment stored.
+	encoded, err := hashPasswordWith(productionParams, "correct horse battery staple")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(encoded, "$m=65536,t=3,p=2$") {
+		t.Fatalf("production encoding lost its parameters: %s", encoded)
+	}
+	ok, err := CheckPassword("correct horse battery staple", encoded)
+	if err != nil || !ok {
+		t.Fatalf("want match, got ok=%v err=%v", ok, err)
+	}
+
+	// The dummy burn must cost what a real check on this process costs,
+	// or an unknown username becomes distinguishable by the clock.
+	if !strings.Contains(dummyHashForParams(), fmt.Sprintf("$m=%d,t=%d,p=%d$", testParams.memory, testParams.time, testParams.threads)) {
+		t.Fatalf("dummy hash does not track the hashing cost: %s", dummyHashForParams())
+	}
+	if _, err := CheckPassword("dummy", dummyHashForParams()); err != nil {
+		t.Fatalf("dummy hash is not verifiable: %v", err)
+	}
+	if _, err := CheckPassword("dummy", dummyHash); err != nil {
+		t.Fatalf("production dummy hash is not verifiable: %v", err)
 	}
 }
 

--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -13,6 +13,8 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
+	"testing"
 
 	"golang.org/x/crypto/argon2"
 )
@@ -26,16 +28,50 @@ const (
 	saltLen      = 16
 )
 
+// argon2Params is the cost a new hash is written with. The values a
+// stored hash was written with travel inside its encoding, so this
+// choice only ever affects hashes this process creates: a password
+// hashed by a real deployment still verifies at the cost that
+// deployment used.
+type argon2Params struct {
+	time    uint32
+	memory  uint32
+	threads uint8
+}
+
+var productionParams = argon2Params{time: argonTime, memory: argonMemory, threads: argonThreads}
+
+// testParams is the cost used when the binary was built by `go test`.
+// Argon2id is deliberately slow, and almost every test in this
+// repository needs an account, so at the production cost the suites
+// spend most of their wall clock inside the one function they are not
+// trying to measure (issue #31). The reduced cost exercises the same
+// code path — same algorithm, same encoding, same verify — at a price
+// that does not dominate a run. It is unreachable outside a test
+// binary, and productionParams is pinned by a test.
+var testParams = argon2Params{time: 1, memory: 8 * 1024, threads: 1}
+
+var hashingParams = sync.OnceValue(func() argon2Params {
+	if testing.Testing() {
+		return testParams
+	}
+	return productionParams
+})
+
 // HashPassword hashes a password with argon2id, returning the standard
 // encoded form: $argon2id$v=19$m=...,t=...,p=...$salt$hash
 func HashPassword(password string) (string, error) {
+	return hashPasswordWith(hashingParams(), password)
+}
+
+func hashPasswordWith(p argon2Params, password string) (string, error) {
 	salt := make([]byte, saltLen)
 	if _, err := rand.Read(salt); err != nil {
 		return "", err
 	}
-	key := argon2.IDKey([]byte(password), salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	key := argon2.IDKey([]byte(password), salt, p.time, p.memory, p.threads, argonKeyLen)
 	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s$%s",
-		argon2.Version, argonMemory, argonTime, argonThreads,
+		argon2.Version, p.memory, p.time, p.threads,
 		base64.RawStdEncoding.EncodeToString(salt),
 		base64.RawStdEncoding.EncodeToString(key)), nil
 }
@@ -63,6 +99,36 @@ func CheckPassword(password, encoded string) (bool, error) {
 	}
 	got := argon2.IDKey([]byte(password), salt, time, mem, threads, uint32(len(want)))
 	return subtle.ConstantTimeCompare(got, want) == 1, nil
+}
+
+// dummyHash is a valid argon2id encoding used to equalize timing when
+// the username does not exist. Password "dummy".
+const dummyHash = "$argon2id$v=19$m=65536,t=3,p=2$c2FsdHNhbHRzYWx0c2FsdA$M2DdlP2yhB+CZCm2lp3DKbT8NYDMv0hWQRdnJP0bLcU"
+
+// dummyHashForParams is the encoding CheckDummyPassword actually
+// verifies against. It must carry the same cost as a real hash this
+// process would write, otherwise the burn is no longer equal to the
+// work it stands in for. In production that is dummyHash verbatim;
+// under `go test`, where new hashes are cheap, the same salt and digest
+// are re-encoded at the reduced cost. The compare fails either way —
+// what matters is that both paths run one argon2id derivation.
+var dummyHashForParams = sync.OnceValue(func() string {
+	p := hashingParams()
+	if p == productionParams {
+		return dummyHash
+	}
+	rest := strings.SplitN(dummyHash, "$", 5)[4]
+	return fmt.Sprintf("$argon2id$v=%d$m=%d,t=%d,p=%d$%s", argon2.Version, p.memory, p.time, p.threads, rest)
+})
+
+// CheckDummyPassword burns the same work a real password check would,
+// so an unknown username and a wrong password take comparable time.
+// Argon2id at 64 MiB is slow enough that skipping it is a plainly
+// measurable signal, which turns any login form into a user
+// enumeration oracle. Every path that verifies a password must call
+// this when the user is not found.
+func CheckDummyPassword(password string) {
+	_, _ = CheckPassword(password, dummyHashForParams())
 }
 
 // NewSecret generates a random 256-bit secret, hex-encoded (64 chars).

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -370,17 +370,3 @@ func (s *Service) tokenByHashGlobal(ctx context.Context, hash string) (store.Tok
 	}
 	return store.Token{}, errors.New("store does not support global token lookup")
 }
-
-// dummyHash is a valid argon2id encoding used to equalize timing when
-// the username does not exist. Password "dummy".
-const dummyHash = "$argon2id$v=19$m=65536,t=3,p=2$c2FsdHNhbHRzYWx0c2FsdA$M2DdlP2yhB+CZCm2lp3DKbT8NYDMv0hWQRdnJP0bLcU"
-
-// CheckDummyPassword burns the same work a real password check would,
-// so an unknown username and a wrong password take comparable time.
-// Argon2id at 64 MiB is slow enough that skipping it is a plainly
-// measurable signal, which turns any login form into a user
-// enumeration oracle. Every path that verifies a password must call
-// this when the user is not found.
-func CheckDummyPassword(password string) {
-	_, _ = CheckPassword(password, dummyHash)
-}


### PR DESCRIPTION
Fixes #31.

## What changed

Nearly every test in this repository needs an account, and each one paid
the full argon2id cost that protects a real password. That is 64 MiB and
three passes per hash, twice over once the test signs in, and it added up
to most of the test suite's running time.

A test binary now hashes at a much lower cost. A real build is unchanged
and still uses the OWASP baseline. The parameters a hash was written with
are recorded inside the hash itself, so a password an existing deployment
stored keeps verifying at the cost it was written with, and nothing about
a running server changes.

The timing burn that hides whether a username exists was a hardcoded
full-cost hash. In a test it would have cost sixty times more than the
real check it stands in for, so it now follows whatever cost the process
hashes at.

## Timings

Measured with `-race` and `CI=1`, so the browser checks skip the way they
do in CI:

| | before | after |
|---|---|---|
| `internal/webui` | 125s | 61s |
| whole module | 2m01 | 1m10 |

The web UI package is no longer dominated by hashing. Lowering the test
cost a further four times changed nothing, so what remains is per-test
database setup spread over 235 tests. CI's two-core runners should gain
more than a desktop does.

## Testing

`go vet ./...`, `golangci-lint run ./...` and the full race-enabled suite
pass. A new test pins the production parameters, checks that a test
binary really is on the reduced ones, and verifies that a hash written at
the production cost still round-trips.

The released binary was checked too: it still writes `m=65536,t=3,p=2`,
its help output is byte-identical, and it grew by 9 KB.