### PR TITLE
fix: stop warning that a watched folder is not being watched

### DIFF
--- a/internal/content/watch_linux.go
+++ b/internal/content/watch_linux.go
@@ -192,13 +192,23 @@ func (w *Watcher) Remove(folderID string) {
 // A root that cannot be watched — an inotify limit, an NFS mount — is a
 // warning and not a failure. The folder still gets its periodic pass,
 // which is a slower answer rather than no answer.
+//
+// The periodic pass registers its folders again every half hour, so
+// almost every call here finds the tree already watched and has nothing
+// to add. A folder is on the periodic pass only when nothing under it is
+// watched at all, and then the warning names the failure: an operator
+// told a folder is unwatched, without a reason, has nowhere to look.
 func (w *Watcher) watchTree(folder store.Folder) {
 	if w.notify == nil {
 		return
 	}
-	added := 0
+	covered := 0
+	var walkErr, addErr error
 	err := filepath.WalkDir(folder.RootPath, func(pathname string, entry os.DirEntry, err error) error {
 		if err != nil {
+			if walkErr == nil {
+				walkErr = err
+			}
 			return nil
 		}
 		if !entry.IsDir() {
@@ -208,21 +218,35 @@ func (w *Watcher) watchTree(folder store.Folder) {
 		_, have := w.watchedDirs[pathname]
 		w.mu.Unlock()
 		if have {
+			covered++
 			return nil
 		}
 		if err := w.notify.Add(pathname); err != nil {
+			if addErr == nil {
+				addErr = err
+			}
 			return nil
 		}
 		w.mu.Lock()
 		w.watchedDirs[pathname] = folder.ID
 		w.mu.Unlock()
-		added++
+		covered++
 		return nil
 	})
-	if err != nil || added == 0 {
-		w.log.Warn("watching folder by periodic pass only",
-			"folder", folder.ID, "root", folder.RootPath, "error", err)
+	if err == nil && covered > 0 {
+		return
 	}
+	if err == nil {
+		// A tree can be unreadable and inotify can refuse it. Name what
+		// inotify said first: it is the more actionable of the two.
+		if addErr != nil {
+			err = addErr
+		} else {
+			err = walkErr
+		}
+	}
+	w.log.Warn("watching folder by periodic pass only",
+		"folder", folder.ID, "root", folder.RootPath, "error", err)
 }
 
 // forwardEvents translates filesystem events into folder ids. A

--- a/internal/content/watch_linux.go
+++ b/internal/content/watch_linux.go
@@ -194,16 +194,22 @@ func (w *Watcher) Remove(folderID string) {
 // which is a slower answer rather than no answer.
 //
 // The periodic pass registers its folders again every half hour, so
-// almost every call here finds the tree already watched and has nothing
-// to add. A folder is on the periodic pass only when nothing under it is
-// watched at all, and then the warning names the failure: an operator
-// told a folder is unwatched, without a reason, has nowhere to look.
+// almost every call here finds its own tree already watched and has
+// nothing to add. A folder is on the periodic pass only when no
+// directory of its own is watched, and then the warning names the
+// failure: an operator told a folder is unwatched, without a reason, has
+// nowhere to look.
+//
+// A directory belongs to one folder. If somebody watches a directory and
+// then watches a directory inside it, the inner folder owns none of its
+// own tree and its events are delivered to the outer folder, so it is on
+// the periodic pass whatever inotify thinks, and it says so.
 func (w *Watcher) watchTree(folder store.Folder) {
 	if w.notify == nil {
 		return
 	}
 	covered := 0
-	var walkErr, addErr error
+	var walkErr, addErr, overlapErr error
 	err := filepath.WalkDir(folder.RootPath, func(pathname string, entry os.DirEntry, err error) error {
 		if err != nil {
 			if walkErr == nil {
@@ -215,10 +221,16 @@ func (w *Watcher) watchTree(folder store.Folder) {
 			return nil
 		}
 		w.mu.Lock()
-		_, have := w.watchedDirs[pathname]
+		owner, have := w.watchedDirs[pathname]
 		w.mu.Unlock()
 		if have {
-			covered++
+			switch {
+			case owner == folder.ID:
+				covered++
+			case overlapErr == nil:
+				overlapErr = fmt.Errorf(
+					"%s is already watched as part of folder %s", pathname, owner)
+			}
 			return nil
 		}
 		if err := w.notify.Add(pathname); err != nil {
@@ -237,11 +249,15 @@ func (w *Watcher) watchTree(folder store.Folder) {
 		return
 	}
 	if err == nil {
-		// A tree can be unreadable and inotify can refuse it. Name what
-		// inotify said first: it is the more actionable of the two.
-		if addErr != nil {
+		// Name what inotify said first, then an overlapping folder, then
+		// a directory nobody could read: that is the order an operator
+		// can do something about them in.
+		switch {
+		case addErr != nil:
 			err = addErr
-		} else {
+		case overlapErr != nil:
+			err = overlapErr
+		default:
 			err = walkErr
 		}
 	}

--- a/internal/content/watch_linux_test.go
+++ b/internal/content/watch_linux_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/chmouel/liseur-sync/internal/store"
 )
 
 // captureWatcher builds a watcher that logs where the test can read it.
@@ -107,6 +109,33 @@ func TestAnUnwatchableTreeWarnsWithACause(t *testing.T) {
 		}
 		if !strings.Contains(got[0], "no such file") {
 			t.Fatalf("cause did not name the missing root: %q", got[0])
+		}
+	})
+
+	t.Run("an inner folder is watched as part of an outer one", func(t *testing.T) {
+		w, logged := captureWatcher(t)
+		outer := plainFolder(t)
+		inner := store.Folder{
+			ID: "f2", Name: "Literature", Kind: store.FolderPlain,
+			RootPath: filepath.Join(outer.RootPath, "literature"),
+		}
+		if err := os.Mkdir(inner.RootPath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+
+		w.watchTree(outer)
+		logged.Reset()
+		w.watchTree(inner)
+
+		// The outer folder owns those directories, so the inner folder's
+		// events are delivered to the outer one and the inner folder
+		// really is on the periodic pass.
+		got := periodicPassWarnings(t, logged)
+		if len(got) != 1 {
+			t.Fatalf("warnings: %q", got)
+		}
+		if !strings.Contains(got[0], outer.ID) {
+			t.Fatalf("cause did not name the folder holding the watch: %q", got[0])
 		}
 	})
 

--- a/internal/content/watch_linux_test.go
+++ b/internal/content/watch_linux_test.go
@@ -1,0 +1,132 @@
+//go:build linux
+
+package content
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureWatcher builds a watcher that logs where the test can read it.
+// Only watchTree is exercised, so it needs no folders and no reconciler.
+func captureWatcher(t *testing.T) (*Watcher, *bytes.Buffer) {
+	t.Helper()
+	var logged bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&logged, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	w := NewWatcher(nil, nil, log)
+	if w.notify == nil {
+		t.Skip("no inotify instance available")
+	}
+	t.Cleanup(func() { _ = w.notify.Close() })
+	return w, &logged
+}
+
+func periodicPassWarnings(t *testing.T, logged *bytes.Buffer) []string {
+	t.Helper()
+	var causes []string
+	for _, line := range strings.Split(strings.TrimSpace(logged.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var entry map[string]any
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			t.Fatalf("log line %q: %v", line, err)
+		}
+		if entry["msg"] != "watching folder by periodic pass only" {
+			continue
+		}
+		cause, _ := entry["error"].(string)
+		causes = append(causes, cause)
+	}
+	return causes
+}
+
+// TestARewatchedFolderIsNotReportedAsUnwatched is the second half of
+// issue #33: a folder that was being watched perfectly well was reported
+// as unwatched twice an hour, because every periodic pass registers it
+// again and the second registration has nothing left to add.
+func TestARewatchedFolderIsNotReportedAsUnwatched(t *testing.T) {
+	w, logged := captureWatcher(t)
+	folder := plainFolder(t)
+	writeBook(t, folder.RootPath, "series/one.epub", "One")
+
+	w.watchTree(folder)
+	if got := periodicPassWarnings(t, logged); len(got) != 0 {
+		t.Fatalf("first watch warned %d times: %q", len(got), got)
+	}
+	logged.Reset()
+
+	for range 3 {
+		w.watchTree(folder)
+	}
+	if got := periodicPassWarnings(t, logged); len(got) != 0 {
+		t.Fatalf("re-watching an already watched tree warned %d times: %q", len(got), got)
+	}
+}
+
+// TestAnUnwatchableTreeWarnsWithACause leaves the warning its job. A
+// tree nothing is watching must still say so, and say why: the reporter
+// of issue #33 spent their evening on an error=<nil> that meant nothing.
+func TestAnUnwatchableTreeWarnsWithACause(t *testing.T) {
+	t.Run("inotify refuses the watch", func(t *testing.T) {
+		w, logged := captureWatcher(t)
+		// A closed instance refuses every Add, which is what running out
+		// of inotify watches looks like from here.
+		if err := w.notify.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		w.watchTree(plainFolder(t))
+
+		got := periodicPassWarnings(t, logged)
+		if len(got) != 1 {
+			t.Fatalf("warnings: %v", got)
+		}
+		if got[0] == "" {
+			t.Fatal("a folder on the periodic pass only reported no cause")
+		}
+	})
+
+	t.Run("the root cannot be walked", func(t *testing.T) {
+		w, logged := captureWatcher(t)
+		folder := plainFolder(t)
+		folder.RootPath = filepath.Join(folder.RootPath, "gone")
+
+		w.watchTree(folder)
+
+		got := periodicPassWarnings(t, logged)
+		if len(got) != 1 {
+			t.Fatalf("warnings: %v", got)
+		}
+		if !strings.Contains(got[0], "no such file") {
+			t.Fatalf("cause did not name the missing root: %q", got[0])
+		}
+	})
+
+	t.Run("a subdirectory is unreadable but the root is watched", func(t *testing.T) {
+		if os.Geteuid() == 0 {
+			t.Skip("root reads a 0000 directory")
+		}
+		w, logged := captureWatcher(t)
+		folder := plainFolder(t)
+		closed := filepath.Join(folder.RootPath, "closed")
+		if err := os.Mkdir(closed, 0o000); err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(closed, 0o700) })
+
+		w.watchTree(folder)
+
+		// The root is watched, so events still arrive.
+		if got := periodicPassWarnings(t, logged); len(got) != 0 {
+			t.Fatalf("a watched root warned because of one bad child: %q", got)
+		}
+	})
+}


### PR DESCRIPTION
## What changed

The server re-registers its watched folders every half hour. Every check after the first announced that the folder had fallen back to slow periodic scanning, because the code counted only directories it had newly started watching and there were none left to add. Operators saw a warning per folder, twice an hour, on a healthy setup, and the warning did not say what had gone wrong.

The warning now appears only when a folder really has no watch on it, and it names the cause: the directory the walk could not read, or the reason the kernel refused the watch.

## Why

Reported in #33. The reporter went looking at their container for a problem that was never there, while the real bug in that issue was elsewhere.

## Tests

New tests in `internal/content` cover repeated registration of the same folder, a folder inotify refuses, a root that no longer exists, and one unreadable subdirectory under a watched root. Verified the first of those fails without the fix.

Ran `go vet ./...`, `golangci-lint run ./internal/content/...`, and `go test -race ./internal/content/`.
