### PR TITLE
Explain client position sync expectations

### DIFF
--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -336,6 +336,16 @@ devices, and the last op you acknowledged as baseline. Liseur's
 implementation (`domain/ReadingStateMerge.kt`) is the reference; the
 protocol is shaped so that logic transfers unchanged.
 
+The merge is only half of what makes two clients land on the same page.
+Liseur also pushes every persisted page turn as it happens, queues a
+backstop push when the reader leaves the book, and on open or resume
+*offers* a place another device has read further to rather than
+jumping there. A client that does the same converges with it; one that
+pushes only on close, or that takes the furthest position outright,
+will be seen by Liseur as a device that keeps moving backwards. The
+behaviour is written out, against Kindle Whispersync as the yardstick,
+in [Liseur's ADR-0023](https://github.com/chmouel/liseur/blob/main/docs/adr/0023-position-sync-versus-whispersync.md).
+
 ## Annotations
 
 Highlights, notes and bookmarks sync too (ADR-0028), and they are the


### PR DESCRIPTION
## Summary

Explain the client behaviour required for liseur-sync positions to converge and link the detailed comparison with Kindle Whispersync.

## Changes

- Document live page-turn pushes, the leave-book backstop, and offer-on-resume behaviour.
- Link the liseur client ADR from the integration guide.

## Testing

- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [x] If `.templ` files changed: not applicable
- [x] If `docs/openapi.yaml` changed: not applicable
- [x] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable: documentation-only change.

## Screenshots, logs, or API examples

Not applicable.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.