### PR TITLE
Notify clients about live reading changes

### DIFF
--- a/cmd/liseur-sync/main.go
+++ b/cmd/liseur-sync/main.go
@@ -27,11 +27,17 @@ import (
 	"github.com/chmouel/liseur-sync/internal/auth"
 	"github.com/chmouel/liseur-sync/internal/config"
 	"github.com/chmouel/liseur-sync/internal/content"
+	"github.com/chmouel/liseur-sync/internal/live"
 	"github.com/chmouel/liseur-sync/internal/store"
 	"github.com/chmouel/liseur-sync/internal/store/postgres"
 	"github.com/chmouel/liseur-sync/internal/store/sqlite"
 	"github.com/chmouel/liseur-sync/internal/webui"
 )
+
+// maxLiveStreamsPerAccount bounds concurrent /v1/events subscriptions
+// for one account: a phone, a couple of tabs and a spare, which is a
+// reader rather than a way to hold file descriptors open.
+const maxLiveStreamsPerAccount = 8
 
 func openStore(cfg config.Config) (store.Store, error) {
 	switch cfg.Database.Driver {
@@ -186,6 +192,14 @@ func cmdServe(args []string) error {
 	// One Ingester is both halves of ADR-0023 and ADR-0025: it is the
 	// only thing that writes under a folder root, in either direction.
 	ingester := content.NewIngester(reconciler)
+	// Live notifications (ADR-0034). The hub is process-local, which is
+	// what this deployment is; several replicas would want PostgreSQL
+	// LISTEN/NOTIFY here instead. A backend that cannot take the hook
+	// simply never notifies, and clients keep their own schedules.
+	hub := live.NewHub(maxLiveStreamsPerAccount)
+	if n, ok := st.(store.ChangeNotifying); ok {
+		n.SetChangeNotifier(hub)
+	}
 	apiSrv := &api.Server{
 		St:           st,
 		Auth:         auth.NewService(st),
@@ -196,6 +210,7 @@ func cmdServe(args []string) error {
 		Covers:       cache,
 		Ingest:       ingester,
 		Removal:      ingester,
+		Live:         hub,
 		Kosync: &kosync.Server{
 			St:          st,
 			Cfg:         cfg,
@@ -267,6 +282,10 @@ func cmdServe(args []string) error {
 	}
 
 	bgStop()
+	// Streams are long-lived by design, so Shutdown would wait for
+	// every reader to close a tab. Ending them first is what lets the
+	// ten seconds below mean anything.
+	hub.Close()
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	slog.Info("shutting down")

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -275,6 +275,26 @@ For non-interactive clients, the kosync adapter applies the only safe
 default: `GET` returns the newest op's `foreign_pos`/`progression`,
 which is exactly kosync's semantics today.
 
+### 5.5 Live invalidations
+
+`GET /v1/events` sends topic-only SSE notifications after committed
+position, annotation and session writes. Each subscriber has a bounded
+pending topic set; registering before the opening invalidation covers
+changes made while a client connects. Clients refresh through the
+existing feeds or per-book snapshots and retain their normal cursor,
+merge and retry rules.
+
+The `sync` scope authorizes positions and annotations; `read-insights`
+authorizes insight refreshes. Sessions have no delta feed, so an insight
+notification asks the client to re-fetch displayed statistics. Notifications
+carry no sequence, work or device identity, and duplicate-only writes
+remain silent.
+
+Delivery currently spans one server process. It does not add catalog
+convergence or position-feed recovery for work merges and deletions.
+[ADR-0034](adr/0034-live-notifications-say-only-that-something-changed.md)
+defines the wire and lifecycle contract.
+
 ## 6. Reading statistics
 
 ### 6.1 Sessions are facts, not derived state

--- a/docs/adr/0007-web-reader.md
+++ b/docs/adr/0007-web-reader.md
@@ -217,15 +217,15 @@ before vendoring, because a CSP hole for a convenience path would have
 been a real cost — and the same check was repeated on foliate-js, with
 the same answer.
 
-What the reader still does not do: no full-text search inside a book, no
-annotations, no read-aloud. The locator envelope means those remain
-additions rather than migrations.
+The reader displays annotations written by other clients, including
+highlights over the text and notes in the sidebar. Annotation editing,
+full-text search inside a book and read-aloud remain out of scope.
 
 ### The reader is an ordinary API client with a derived, short-lived token
 
-The reader uses `/v1/ops`, `/v1/changes` and `/v1/sessions` exactly as the
-Android and desktop clients do. It is not given privileged access and
-gets no new sync surface. (What a sitting is in a browser — when it
+The reader writes `/v1/ops` and `/v1/sessions` and reads the current
+work's position and annotation endpoints. It keeps no browser-wide
+changes cursor and gets no privileged access. (What a sitting is in a browser — when it
 opens, when it closes, what counts as idle — is decided in
 [ADR-0030](0030-web-reader-reading-sessions.md).)
 
@@ -240,7 +240,10 @@ hour. Four properties make this safe and workable:
 - **Short-lived, and refreshed by asking again.** There is no refresh
   token. The page re-mints with the cookie it already has. This is the
   same shape as the one-hour login credential, and it means expiry is the
-  only revocation mechanism the reader needs to implement.
+  ordinary renewal boundary. Concurrent calls share one mint; a 401
+  retries once with a replacement. A second refusal stops sync and asks
+  the reader to reopen the book from the library. The detached origin
+  cannot mint and stops on its first refusal.
 - **One web device per user, not one per tab.** The op log's heads are
   per work *and device*, so a device identity per tab would multiply heads
   and make "where did I stop reading" ambiguous between two windows of one
@@ -264,6 +267,60 @@ something a person made or can manage — it is replaced before they could
 finish reading its name — so the Devices page counts browsers instead,
 one row per device id, with a single button that ends browser reading
 everywhere.
+
+### Visible readers subscribe to live invalidations
+
+While the document is visible, the reader opens `GET /v1/events` with a
+Bearer-authenticated streaming fetch. Hiding the tab aborts the fetch
+and any reconnect timer. Only `visibilitychange` drives resuming:
+focusing a publication frame or switching focus within a visible window
+does not open another connection or show an offer.
+
+The stream carries the topic hints defined in
+[ADR-0034](0034-live-notifications-say-only-that-something-changed.md).
+The opening invalidation and later events enter the same coalescing
+queue. A positions hint reads this work's current position; an
+annotations hint replaces this work's complete live set. An event during
+a read owes one follow-up, and a failed read remains owed. The reader
+neither requests insights nor adds a dashboard subscription.
+
+Frames are limited to 64 KiB, including unterminated lines. The parser
+handles split UTF-8 and CRLF without treating EOF as an event delimiter.
+Any received bytes, including heartbeat comments, reset a 60-second
+watchdog. Transport failures back off with jitter, and 429 responses
+honour `Retry-After`. A brief 200 response does not reset the backoff.
+403, 404 and 501 stop live attempts until the next visibility boundary;
+ordinary position writes and resume reads still work against an older
+server without a new warning.
+
+`GET /v1/token` identifies the credential's account and device.
+Replacement credentials invalidate queued reads, offers and annotation
+draws. Responses remain bound to the credential, work and lifecycle
+that requested them. A replacement naming another account stops this
+page's sync before it can send that account the previous reader's data.
+
+### A remote position waits for the reader to return
+
+A notification never moves the open book. The reader holds a candidate
+while visible and offers it after a hidden-to-visible transition, once
+the resume snapshot succeeds. “Continue there” and “Stay here” are
+keyboard-accessible buttons; Escape dismisses the offer. A newer remote
+op cannot change the target of an offer already on screen. Acceptance
+requires the same account, work, op and device, with no intervening local
+reading movement. It uses the stored locator, trying the existing CFI,
+progression and resource fallback.
+
+Web tabs share a server device identity, so that identity alone cannot
+identify this tab's own writes. The reader remembers its actual op ids
+alongside their device ids. A restore paints the destination without
+recording a page turn, minting a position op or crediting activity. The
+next reading input resumes normal position and session accounting.
+
+Annotation refreshes remove the previous overlays before drawing the
+replacement set, including recoloured highlights. Replacement clears
+the colour and failed-CFI caches. Overlay mutations run serially, with
+work and credential checks around asynchronous draws, so a superseded
+draw cannot recreate a deleted highlight.
 
 ## Consequences
 

--- a/docs/adr/0034-live-notifications-say-only-that-something-changed.md
+++ b/docs/adr/0034-live-notifications-say-only-that-something-changed.md
@@ -1,0 +1,169 @@
+# ADR-0034: A live notification says only that something changed
+
+- **Status:** Accepted
+- **Date:** 2026-09-05
+- **Depends on:** [ADR-0007](0007-web-reader.md),
+  [ADR-0028](0028-annotation-sync.md),
+  [ADR-0033](0033-a-device-outlives-its-token.md)
+- **Amends:** [ADR-0007](0007-web-reader.md), which gave the reader "no
+  new sync surface". It gets one, and it carries no reading state.
+
+## Context
+
+Every client here polls. Liseur runs a full sync when a book opens or
+closes, when the user asks, and hourly from WorkManager. The web reader
+fetches a position and a live annotation set when a book opens and then
+never asks again. Both are correct and both are late: a passage
+highlighted on the phone is invisible to the tab already open on the
+desktop until something else happens to make it look.
+
+The durable half of the problem is already solved. `GET /v1/changes`
+and `GET /v1/annotations/changes` are ordered per-user feeds with
+cursors, and Liseur advances a cursor in the same transaction that
+stores the page it covers. Nothing about being told sooner improves
+that. What is missing is only the telling.
+
+The obvious mistake is to send the news itself: the locator, the
+highlight, the progression. That makes the notification a second
+protocol with its own delivery guarantees, its own conflict rules and
+its own way of being wrong, and it puts reading state on a path where a
+dropped connection loses data. The feeds already have all of those
+answers.
+
+## Decision
+
+### The event carries no reading state
+
+`GET /v1/events` is a `text/event-stream` under the same bearer auth,
+transport and CORS policy as the rest of `/v1`. It sends one kind of
+frame:
+
+```
+event: invalidate
+data: {"topics":["positions","annotations"]}
+```
+
+The topics are `positions`, `annotations` and `insights`. There are no
+identifiers in the payload: no work, no book, no locator, no excerpt,
+no device, no count, and no sequence number. A topic names a feed the
+client already knows how to read, and the client answers it by reading
+that feed the way it always has.
+
+There is no aggregate sequence because there is no aggregate. Positions
+and annotations have separate per-user counters, and insights are
+derived from sessions, which have no feed at all. A single high-water
+mark would be a fiction the client would then have to translate back
+into two cursors.
+
+Unknown topics are ignored, so a later topic is an addition rather than
+a version.
+
+### Correctness stays in the feeds
+
+A notification may be lost, duplicated, coalesced or delivered out of
+order without any client being wrong. Losing every notification costs
+latency and nothing else. This is the property that lets the stream
+stay in memory, with no delivery table, no replay window and no
+acknowledgement.
+
+Nothing observes an event to decide *what* changed. A client that
+receives `positions` reads `/v1/changes` from its own cursor; a client
+that receives `annotations` runs the annotation pass it already runs.
+
+### Subscribing is race-free without a cursor
+
+The server registers the subscriber first, then queues an invalidation
+for every topic that credential is allowed. A change committed before
+registration is covered by the read that initial invalidation provokes;
+a change committed during that read is either in the answer or still
+queued. So `/v1/events` takes no `since` parameter and compares no
+cursor, and a client that reconnects after an outage needs no special
+case.
+
+Coalescing is by union of topics, never by replacement, and each
+subscriber holds one pending set and one wake-up slot. `positions` then
+`annotations` collapses to both, never to the later one.
+
+### Authorization is per topic
+
+`positions` and `annotations` require `sync`; `insights` requires
+`read-insights`. The endpoint authenticates once and then filters,
+rather than demanding every scope: the web reader's token carries
+`sync` and `library-read` (ADR-0007) and must keep working without
+being handed insight authority it has no use for. A credential with no
+eligible topic is refused rather than parked on an empty stream.
+
+### The stream is not a longer-lived credential
+
+A stream ends when its token expires, and revocation is rechecked at
+heartbeat boundaries. A connection authenticated at 12:00 must not
+still be authorized at 13:00 because nobody asked again. Once a `200`
+has been written the answer cannot become a `401`, so the server closes
+the stream and lets the reconnect be refused in the ordinary way.
+
+Heartbeat comments go out every 20 seconds and clients treat 60 seconds
+of silence as a dead stream. Both numbers exist to sit under proxy idle
+timeouts. Admission is bounded per account; a refusal is `429` with
+`Retry-After`, and a client that reads too slowly is disconnected
+rather than buffered.
+
+### Notifications are published after a commit, by the store
+
+The signal is raised where the write lands, not in `HandlePushOps`.
+Positions arrive through the native API, through the web reader's
+reading-status writes and through the kosync adapter; sessions arrive
+through three paths of their own. A hook on the HTTP handler would
+cover one of them and quietly miss the rest.
+
+It fires only after a successful commit and only when the state
+actually changed: a rolled-back transaction, a rejected write and a
+batch that was entirely duplicates all notify nobody. That, plus
+idempotent client writes, is what stops two devices from talking each
+other in a circle. There is no source-device suppression, which a
+coalesced event could not express anyway.
+
+### One process
+
+The hub is in memory, which is exactly right for the single-process
+deployment this server is. Several replicas would need PostgreSQL
+`LISTEN`/`NOTIFY`, and that is the day to add it. Not Redis, and not
+today.
+
+## Consequences
+
+Reading gets live on every surface that has a feed, and only those.
+Statistics refresh because sessions commit, not because they are
+delivered.
+
+Structural changes stay outside the guarantee. Merging two works
+rewrites `ops.work_id` in place without minting a new `seq`, so a
+delta pull cannot recover it however promptly a client is told to look.
+The catalog has no feed at all. Both remain what a full sync is for,
+and the documentation says so rather than implying that live means
+converged.
+
+A closed app is still a closed app. Waking one needs FCM or Web Push
+and the infrastructure under them; the case that actually matters to a
+reader, opening Liseur after reading in a browser, is already covered
+by the sync on foreground.
+
+An older server has no `/v1/events`. A client treats that as "not
+available on this connection" and keeps its existing schedule, with no
+warning banner: nothing is degraded that was ever promised.
+
+## Acceptance criteria
+
+- A position or annotation committed by one client reaches another
+  connected client without a manual refresh, with no reading state on
+  the stream.
+- Subscribing and committing in either order loses no refresh; a burst
+  during a held refresh leaves at most one coalesced follow-up.
+- A token without `read-insights` never receives `insights`; a token
+  with no eligible topic is refused.
+- Expiry and revocation end a stream; shutdown releases subscriptions;
+  a slow reader cannot block a write path.
+- Duplicate-only and rolled-back writes notify nobody, on both storage
+  backends.
+- `docs/openapi.yaml`, `docs/integrating.md` and `docs/deployment.md`
+  describe the frame, the topic scopes, the heartbeat and idle-timeout
+  requirement, and the old-server fallback.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -58,6 +58,7 @@ loose ends that must come before any of it, are in
 | [0031](0031-web-reader-footer.md) | The web reader's footer mirrors the app | Later | Accepted; implemented | Percent, middle slot, page in the engine's bottom margin; pages are engine locations, never fabricated; click cycles the middle; a browser preference; amends [0012](0012-reader-engine-foliate.md) |
 | [0032](0032-reader-pages-are-readium-positions.md) | The reader's page is the app's page | Later | Accepted; implemented | Pages counted as Readium positions so the browser and the app name the same page; display only, no server or API change; three recorded patches to the vendored engine; amends [0031](0031-web-reader-footer.md) and [0012](0012-reader-engine-foliate.md) |
 | [0033](0033-a-device-outlives-its-token.md) | A device outlives its token | MVP | Accepted; implemented | `POST /v1/tokens` inherits a `device_id` the account already carried, `400 unknown_device` otherwise; `account_id` on `GET /v1/token`; the store keeps comparing devices; amends [0016](0016-token-self-introspection.md) |
+| [0034](0034-live-notifications-say-only-that-something-changed.md) | A live notification says only that something changed | Client | Accepted | `GET /v1/events` as topic-only SSE, published post-commit by the store, authorized per topic; correctness stays in the existing feeds; amends [0007](0007-web-reader.md) |
 
 ## Convention
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,6 +113,21 @@ becomes `content.insecure_http`. The server refuses to start on an
 unrecognized key rather than ignoring one, so a misplaced setting is
 reported instead of silently doing nothing.
 
+### Live event streams
+
+`GET /v1/events` holds an authenticated `text/event-stream` connection.
+Caddy flushes this content type without extra configuration. For nginx,
+the application sends `X-Accel-Buffering: no`; do not configure the proxy
+to ignore that header. Keep proxy idle timeouts above the 20-second
+heartbeat interval. Clients treat 60 seconds without bytes as a stalled
+connection.
+
+The server admits up to eight streams per account and returns `429` with
+`Retry-After` when that limit is reached. Each frame has a bounded write
+deadline, and shutdown closes streams before waiting for HTTP requests.
+Delivery is process-local: multiple replicas would need shared
+notification delivery before they could provide the same guarantee.
+
 ### Optional: extra auth at the proxy
 
 The API is fully authenticated by design, but you can put an extra

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -346,6 +346,71 @@ will be seen by Liseur as a device that keeps moving backwards. The
 behaviour is written out, against Kindle Whispersync as the yardstick,
 in [Liseur's ADR-0023](https://github.com/chmouel/liseur/blob/main/docs/adr/0023-position-sync-versus-whispersync.md).
 
+## Live notifications
+
+`GET /v1/events` opens a bearer-authenticated SSE stream under the same
+transport, origin and path-prefix rules as other native endpoints. Keep
+the credential in the `Authorization` header, never in the URL.
+
+```text
+event: invalidate
+data: {"topics":["positions","annotations"]}
+
+```
+
+The `sync` scope permits `positions` and `annotations`; `read-insights`
+permits `insights`. A token with no permitted topic gets `403`. Web reader
+tokens keep their existing scopes and receive no insights.
+
+The server registers the subscriber before sending an opening
+invalidation for its permitted topics. A write before registration is
+covered by the opening refresh; a write during that refresh can leave
+another notification pending. There is no `since` parameter, event ID or
+replay store. Notifications contain no sequence number: the position and
+annotation feeds have independent cursors, and sessions have no feed.
+
+Refresh only the affected topics. For `positions`, read the existing
+changes feed and preserve its transactional cursor and `410` recovery.
+A browser reading one book can use that work's position snapshot instead.
+For `annotations`, use the annotation feed and reconciliation rules, or
+replace the current book's live set when using snapshots. Remove deleted
+or changed overlays before drawing the replacement. For `insights`,
+re-fetch the queries currently displayed; do not upload sessions or run
+position sync. A remote position should not turn an open book's page.
+Present a catch-up choice on resume and bind acceptance to the position
+actually offered.
+
+Coalesce repeated events by union of topics. An event received while a
+refresh runs still requires a follow-up unless that refresh demonstrably
+covered it. Retain failed refreshes for retry without waiting for another
+event. Ignore unknown topic names. Avoid full library sync per event:
+hashing files and uploading sessions adds unrelated work.
+
+The server sends comment heartbeats every 20 seconds. Treat 60 seconds
+without bytes as a stalled stream. Respect SSE retry advice (milliseconds)
+and `429 Retry-After` (seconds), with bounded backoff and jitter; a brief
+`200` followed by a disconnect should not reset the backoff. The current
+limit is eight streams per account. Expiry or revoked authority closes an
+open stream; the next connection receives the normal authentication
+error. Only clients that retain a credential-minting mechanism can renew
+automatically.
+
+Connect while the client is in use, and cancel old subscriptions and
+queued work when its account changes. A short background grace period on
+Android avoids reopening the stream on every app switch. An older server
+may return `404` or `501`: keep ordinary sync working and re-probe at a
+later foreground boundary. `403` requires an eligible credential rather
+than a tight reconnect loop. `503` and transport failures can be retried.
+Missing live support is not evidence that ordinary sync failed or that a
+refresh succeeded.
+
+Notifications come from committed store writes, including legacy adapter
+writes. Duplicate-only batches and rejected writes produce no event;
+clients can receive notifications caused by their own successful writes.
+This process-local stream does not cover live catalog updates or recovery
+from structural work merge/split/delete operations, and cannot wake a
+closed app. See [ADR-0034](adr/0034-live-notifications-say-only-that-something-changed.md).
+
 ## Annotations
 
 Highlights, notes and bookmarks sync too (ADR-0028), and they are the

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -48,6 +48,60 @@ tags:
   - name: opds
 
 paths:
+  /v1/events:
+    get:
+      tags: [sync]
+      security: [{ deviceToken: [] }]
+      summary: Subscribe to live reading-state invalidations
+      description: |
+        Opens an authenticated Server-Sent Events stream for this account.
+        The `sync` scope permits `positions` and `annotations`;
+        `read-insights` permits `insights`. A credential with no eligible
+        topic is refused. Reader tokens do not need insight authority.
+
+        Registration precedes an opening invalidation of all permitted
+        topics. Later invalidations coalesce topics by union. There is no
+        event ID, sequence number, `since` parameter or replay history.
+        Unknown topics should be ignored. Read the affected topic through
+        its existing feed or snapshot endpoint; keep durable cursors there.
+
+        Comment heartbeats arrive every 20 seconds; clients should reconnect
+        after 60 seconds without bytes, using bounded backoff and jitter.
+        The stream ends at token expiry or when revalidation finds revoked
+        authority. After headers have been sent, these conditions close
+        the connection rather than returning a new HTTP status.
+        The current limit is eight concurrent streams per account.
+      responses:
+        "200":
+          description: |
+            SSE frames containing topic invalidations, comment heartbeats
+            and retry advice in milliseconds. Each event ends with a blank
+            line. The stream carries no book, device or reading position.
+          headers:
+            Cache-Control:
+              schema: { type: string, const: no-store }
+            X-Accel-Buffering:
+              schema: { type: string, const: "no" }
+          content:
+            text/event-stream:
+              schema: { type: string }
+              example: "retry: 5000\n\nevent: invalidate\ndata: {\"topics\":[\"positions\",\"annotations\"]}\n\n: ping\n\n"
+        "401": { $ref: "#/components/responses/Error", description: "Missing, invalid, revoked or expired token" }
+        "403": { $ref: "#/components/responses/Error", description: "No eligible topic, or HTTPS required" }
+        "429":
+          description: Too many concurrent streams for this account
+          headers:
+            Retry-After:
+              description: Reconnect delay in seconds
+              schema: { type: integer, example: 5 }
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error: { type: string }
+        "503": { $ref: "#/components/responses/Error", description: "Live events are not enabled" }
+
   /healthz:
     get:
       summary: Liveness probe (unauthenticated)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/chmouel/liseur-sync/internal/auth"
 	"github.com/chmouel/liseur-sync/internal/config"
+	"github.com/chmouel/liseur-sync/internal/live"
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
@@ -67,6 +68,13 @@ type Server struct {
 	WebUI interface {
 		Mount(mux *http.ServeMux, secure func(http.Handler) http.Handler)
 	}
+	// Live fans committed changes out to connected clients (ADR-0034).
+	// Nil disables GET /v1/events, which then reports 503: a client
+	// treats that as "no live events here" and keeps its own schedule.
+	Live *live.Hub
+	// Events bounds a live stream. The zero value takes
+	// DefaultEventsPolicy.
+	Events EventsPolicy
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
@@ -241,6 +249,12 @@ func (w *statusWriter) WriteHeader(status int) {
 	w.status = status
 	w.ResponseWriter.WriteHeader(status)
 }
+
+// Unwrap lets http.ResponseController reach the real writer through
+// this one. Without it a streaming handler cannot flush, and
+// GET /v1/events would hold every frame until the connection closed
+// while a direct handler test passed happily.
+func (w *statusWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
 
 // opJSON is the wire shape of an op (design §5.1).
 type opJSON struct {

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -1,0 +1,234 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/live"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// EventsPolicy bounds a live stream (ADR-0034). The defaults are the
+// contract: a heartbeat every 20 seconds, a client that gives up after
+// 60 seconds of silence, and both comfortably under the idle timeout of
+// any reverse proxy in front of this server.
+type EventsPolicy struct {
+	// Heartbeat is how often a comment frame goes out on an otherwise
+	// idle stream.
+	Heartbeat time.Duration
+	// Revalidate is how often the credential is checked again, so a
+	// revoked token does not keep receiving because it once connected.
+	Revalidate time.Duration
+	// WriteTimeout bounds a single frame. A client that stops reading
+	// is disconnected rather than buffered.
+	WriteTimeout time.Duration
+	// RetryAdvice is the reconnect delay suggested to the client.
+	RetryAdvice time.Duration
+}
+
+// DefaultEventsPolicy is used when Server.Events is left zero.
+var DefaultEventsPolicy = EventsPolicy{
+	Heartbeat:    20 * time.Second,
+	Revalidate:   time.Minute,
+	WriteTimeout: 10 * time.Second,
+	RetryAdvice:  5 * time.Second,
+}
+
+func (p EventsPolicy) orDefault() EventsPolicy {
+	d := DefaultEventsPolicy
+	if p.Heartbeat <= 0 {
+		p.Heartbeat = d.Heartbeat
+	}
+	if p.Revalidate <= 0 {
+		p.Revalidate = d.Revalidate
+	}
+	if p.WriteTimeout <= 0 {
+		p.WriteTimeout = d.WriteTimeout
+	}
+	if p.RetryAdvice <= 0 {
+		p.RetryAdvice = d.RetryAdvice
+	}
+	return p
+}
+
+// liveTopicsFor is the authorization rule for the stream: the endpoint
+// authenticates once and then filters. Demanding every scope would shut
+// out the web reader, whose token carries sync and library-read and has
+// no business holding insight authority.
+func liveTopicsFor(scopes store.ScopeSet) []store.Topic {
+	var out []store.Topic
+	if scopes.Allows(store.ScopeSync) {
+		out = append(out, store.TopicPositions, store.TopicAnnotations)
+	}
+	if scopes.Allows(store.ScopeReadInsights) {
+		out = append(out, store.TopicInsights)
+	}
+	return out
+}
+
+// HandleEvents streams change notifications for as long as the client
+// keeps listening. It carries no reading state: a frame names topics,
+// and the client answers by reading the feeds it already knows.
+func (s *Server) HandleEvents(w http.ResponseWriter, r *http.Request) {
+	tok, ok := auth.TokenFrom(r)
+	if !ok {
+		writeError(w, http.StatusUnauthorized, "invalid token")
+		return
+	}
+	// Authorization is decided before availability: whether this
+	// credential could ever receive anything does not depend on whether
+	// this build happens to have a hub.
+	allowed := liveTopicsFor(tok.Scopes)
+	if len(allowed) == 0 {
+		writeError(w, http.StatusForbidden, "insufficient scope")
+		return
+	}
+	if s.Live == nil {
+		writeError(w, http.StatusServiceUnavailable, "live events are not enabled")
+		return
+	}
+	policy := s.Events.orDefault()
+
+	// Registered before anything is written, so a change committed
+	// while this connection is being set up is still owed afterwards.
+	sub, err := s.Live.Subscribe(tok.UserID, allowed)
+	if err != nil {
+		if errors.Is(err, live.ErrTooManyStreams) {
+			w.Header().Set("Retry-After", strconv.Itoa(int(policy.RetryAdvice.Seconds())))
+			writeError(w, http.StatusTooManyRequests, "too many live streams for this account")
+			return
+		}
+		writeError(w, http.StatusForbidden, "insufficient scope")
+		return
+	}
+	defer sub.Close()
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-store")
+	h.Set("Connection", "keep-alive")
+	// Nginx buffers text/event-stream by default and would hold every
+	// frame until the stream ended, which is the whole point missed.
+	h.Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+
+	rc := http.NewResponseController(w)
+	send := func(b []byte) bool {
+		_ = rc.SetWriteDeadline(time.Now().Add(policy.WriteTimeout))
+		if _, err := w.Write(b); err != nil {
+			return false
+		}
+		return rc.Flush() == nil
+	}
+
+	if !send([]byte("retry: " + strconv.Itoa(int(policy.RetryAdvice.Milliseconds())) + "\n\n")) {
+		return
+	}
+
+	// The invalidation every connection opens with. A client that has
+	// been offline, or that has just been told its cursor is stale,
+	// needs no special case and sends no `since`.
+	sub.Raise(allowed...)
+
+	secret, _ := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	heartbeat := time.NewTicker(policy.Heartbeat)
+	defer heartbeat.Stop()
+	revalidate := time.NewTicker(policy.Revalidate)
+	defer revalidate.Stop()
+
+	// A stream is not a longer-lived credential: it ends when the token
+	// does, whatever it was authorized to do an hour ago.
+	var expiry <-chan time.Time
+	if tok.ExpiresAt != nil {
+		t := time.NewTimer(time.Until(*tok.ExpiresAt))
+		defer t.Stop()
+		expiry = t.C
+	}
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case <-sub.Done():
+			return
+		case <-expiry:
+			return
+		case <-revalidate.C:
+			// Once a 200 has been written this cannot become a 401.
+			// End the stream and let the reconnect be refused in the
+			// ordinary way.
+			if !s.liveStillAuthorized(r.Context(), secret, allowed) {
+				return
+			}
+			if !send([]byte(": ok\n\n")) {
+				return
+			}
+		case <-heartbeat.C:
+			if !s.liveStillAuthorized(r.Context(), secret, allowed) {
+				return
+			}
+			if !send([]byte(": ping\n\n")) {
+				return
+			}
+		case <-sub.Wake():
+			owed := sub.Take()
+			if len(owed) == 0 {
+				continue // spurious wake-up; an empty frame says nothing
+			}
+			if !s.liveStillAuthorized(r.Context(), secret, allowed) {
+				return
+			}
+			frame, err := invalidateFrame(owed)
+			if err != nil || !send(frame) {
+				return
+			}
+		}
+	}
+}
+
+// liveStillAuthorized re-reads the credential through the ordinary auth
+// path, so revocation, expiry and a demoted admin all end a stream the
+// same way they refuse a request.
+func (s *Server) liveStillAuthorized(ctx context.Context, secret string, allowed []store.Topic) bool {
+	if secret == "" {
+		return false
+	}
+	tok, err := s.Auth.AuthenticateToken(ctx, secret)
+	if err != nil {
+		return false
+	}
+	still := liveTopicsFor(tok.Scopes)
+	for _, want := range allowed {
+		found := false
+		for _, have := range still {
+			if have == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+func invalidateFrame(owed []store.Topic) ([]byte, error) {
+	payload, err := json.Marshal(struct {
+		Topics []store.Topic `json:"topics"`
+	}{owed})
+	if err != nil {
+		return nil, err
+	}
+	var b strings.Builder
+	b.WriteString("event: invalidate\ndata: ")
+	b.Write(payload)
+	b.WriteString("\n\n")
+	return []byte(b.String()), nil
+}

--- a/internal/api/events_test.go
+++ b/internal/api/events_test.go
@@ -1,0 +1,530 @@
+package api
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"net/url"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/config"
+	"github.com/chmouel/liseur-sync/internal/live"
+	"github.com/chmouel/liseur-sync/internal/store"
+	"github.com/chmouel/liseur-sync/internal/store/sqlite"
+)
+
+// eventsFixture is a server with live notifications on. It is served
+// through LogServerErrors, the wrapper production uses: a stream that
+// cannot flush through that middleware is the failure a handler-only
+// test would miss.
+type eventsFixture struct {
+	ts  *httptest.Server
+	st  store.Store
+	hub *live.Hub
+}
+
+func newEventsFixture(t *testing.T, maxStreams int, policy EventsPolicy) *eventsFixture {
+	t.Helper()
+	st, err := sqlite.Open(filepath.Join(t.TempDir(), "t.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.Default()
+	cfg.InsecureHTTP = true
+	hub := live.NewHub(maxStreams)
+	st.SetChangeNotifier(hub)
+	srv := &Server{
+		St:           st,
+		Auth:         auth.NewService(st),
+		Cfg:          cfg,
+		LoginLimiter: auth.NewRateLimiter(1000, time.Minute),
+		OPDSLimiter:  auth.NewRateLimiter(1000, time.Minute),
+		Live:         hub,
+		Events:       policy,
+	}
+	ts := httptest.NewServer(LogServerErrors(srv.Routes()))
+	t.Cleanup(ts.Close)
+	t.Cleanup(hub.Close)
+	return &eventsFixture{ts: ts, st: st, hub: hub}
+}
+
+func (f *eventsFixture) user(t *testing.T, name string, scopes ...store.Scope) string {
+	t.Helper()
+	hash, err := auth.HashPassword("hunter2hunter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := store.User{ID: name, Name: name, Argon2Hash: hash, CreatedAt: time.Now()}
+	if err := f.st.CreateUser(t.Context(), u); err != nil {
+		t.Fatal(err)
+	}
+	return f.mint(t, name, scopes...)
+}
+
+func (f *eventsFixture) mint(t *testing.T, userID string, scopes ...store.Scope) string {
+	t.Helper()
+	secret, err := auth.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tok := store.Token{
+		ID: store.NewID(), UserID: userID, DeviceID: store.NewID(),
+		Name: "test", Scopes: store.ScopeSet(scopes), SHA256: auth.HashSecret(secret),
+		CreatedAt: time.Now(),
+	}
+	if err := f.st.CreateToken(t.Context(), tok); err != nil {
+		t.Fatal(err)
+	}
+	return secret
+}
+
+// work makes a work directly, so a test about notifications does not
+// depend on the resolve endpoint's shape.
+func (f *eventsFixture) work(t *testing.T, userID string) string {
+	t.Helper()
+	id, _, err := f.st.CreatePendingWork(t.Context(), userID, store.NewID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return id
+}
+
+// stream is an open /v1/events connection.
+type stream struct {
+	resp *http.Response
+	br   *bufio.Reader
+	stop context.CancelFunc
+}
+
+func (f *eventsFixture) open(t *testing.T, token string) (*stream, int) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, f.ts.URL+"/v1/events", nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cancel()
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		cancel()
+		return &stream{resp: resp}, resp.StatusCode
+	}
+	s := &stream{resp: resp, br: bufio.NewReader(resp.Body), stop: cancel}
+	t.Cleanup(func() { cancel(); resp.Body.Close() })
+	return s, resp.StatusCode
+}
+
+// next reads frames until one is an invalidation, ignoring comments and
+// the retry advice, and reports the topics it named.
+func (s *stream) next(t *testing.T, within time.Duration) []string {
+	t.Helper()
+	type result struct {
+		topics []string
+		err    error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		var event, data string
+		for {
+			line, err := s.br.ReadString('\n')
+			if err != nil {
+				ch <- result{err: err}
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			switch {
+			case line == "":
+				if event == "invalidate" {
+					var payload struct {
+						Topics []string `json:"topics"`
+					}
+					if err := json.Unmarshal([]byte(data), &payload); err != nil {
+						ch <- result{err: err}
+						return
+					}
+					ch <- result{topics: payload.Topics}
+					return
+				}
+				event, data = "", ""
+			case strings.HasPrefix(line, "event: "):
+				event = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+	}()
+	select {
+	case r := <-ch:
+		if r.err != nil {
+			t.Fatalf("reading the stream: %v", r.err)
+		}
+		return r.topics
+	case <-time.After(within):
+		t.Fatal("no invalidation arrived")
+		return nil
+	}
+}
+
+// silent asserts nothing arrives, which is what a duplicate write and
+// another account's write must both look like.
+func (s *stream) silent(t *testing.T, within time.Duration) {
+	t.Helper()
+	done := make(chan []string, 1)
+	go func() {
+		var event, data string
+		for {
+			line, err := s.br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			switch {
+			case line == "":
+				if event == "invalidate" {
+					var payload struct {
+						Topics []string `json:"topics"`
+					}
+					_ = json.Unmarshal([]byte(data), &payload)
+					done <- payload.Topics
+					return
+				}
+				event, data = "", ""
+			case strings.HasPrefix(line, "event: "):
+				event = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				data = strings.TrimPrefix(line, "data: ")
+			}
+		}
+	}()
+	select {
+	case topics := <-done:
+		t.Fatalf("unexpected invalidation naming %v", topics)
+	case <-time.After(within):
+	}
+}
+
+func op(workID, opID string, prog float64) store.Op {
+	return store.Op{
+		OpID: opID, WorkID: workID, ClientTS: time.Now().UTC().Truncate(time.Millisecond),
+		Progression: prog, Origin: store.OriginNative,
+	}
+}
+
+func TestEventsOpensWithAnInvalidationAndFollowsCommits(t *testing.T) {
+	f := newEventsFixture(t, 4, EventsPolicy{})
+	token := f.user(t, "u1", store.ScopeSync)
+	workID := f.work(t, "u1")
+
+	s, code := f.open(t, token)
+	if code != http.StatusOK {
+		t.Fatalf("connect: %d", code)
+	}
+	if ct := s.resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("content type %q", ct)
+	}
+	// Every connection opens with one, so a client that was offline
+	// needs no cursor and no special case.
+	if got := s.next(t, 5*time.Second); len(got) != 2 ||
+		got[0] != "positions" || got[1] != "annotations" {
+		t.Fatalf("initial invalidation named %v", got)
+	}
+
+	if _, err := f.st.AppendOps(t.Context(), "u1", "dev", []store.Op{op(workID, "op-1", 0.25)}); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.next(t, 5*time.Second); len(got) != 1 || got[0] != "positions" {
+		t.Fatalf("after a commit: %v", got)
+	}
+
+	// The identical push again changes no row, and a client that
+	// re-read on every retry would never settle.
+	if _, err := f.st.AppendOps(t.Context(), "u1", "dev", []store.Op{op(workID, "op-1", 0.25)}); err != nil {
+		t.Fatal(err)
+	}
+	s.silent(t, 300*time.Millisecond)
+}
+
+func TestEventsNeverCrossAccounts(t *testing.T) {
+	f := newEventsFixture(t, 4, EventsPolicy{})
+	mine := f.user(t, "u1", store.ScopeSync)
+	f.user(t, "u2", store.ScopeSync)
+	theirWork := f.work(t, "u2")
+
+	s, code := f.open(t, mine)
+	if code != http.StatusOK {
+		t.Fatalf("connect: %d", code)
+	}
+	s.next(t, 5*time.Second) // the opening invalidation
+
+	if _, err := f.st.AppendOps(t.Context(), "u2", "dev", []store.Op{op(theirWork, "op-1", 0.5)}); err != nil {
+		t.Fatal(err)
+	}
+	s.silent(t, 300*time.Millisecond)
+}
+
+func TestEventsTopicsFollowScopes(t *testing.T) {
+	f := newEventsFixture(t, 4, EventsPolicy{})
+
+	// An insights credential hears about sessions and nothing else.
+	insights := f.user(t, "u1", store.ScopeReadInsights)
+	s, code := f.open(t, insights)
+	if code != http.StatusOK {
+		t.Fatalf("connect: %d", code)
+	}
+	if got := s.next(t, 5*time.Second); len(got) != 1 || got[0] != "insights" {
+		t.Fatalf("insights token was offered %v", got)
+	}
+
+	// A catalog-only credential could receive nothing, so it is
+	// refused rather than parked on a silent stream.
+	catalog := f.user(t, "u2", store.ScopeLibraryRead)
+	if _, code := f.open(t, catalog); code != http.StatusForbidden {
+		t.Fatalf("library-read token got %d", code)
+	}
+
+	if _, code := f.open(t, ""); code != http.StatusUnauthorized {
+		t.Fatalf("anonymous got %d", code)
+	}
+}
+
+func TestEventsSessionsRefreshInsights(t *testing.T) {
+	f := newEventsFixture(t, 4, EventsPolicy{})
+	token := f.user(t, "u1", store.ScopeSync, store.ScopeReadInsights)
+	workID := f.work(t, "u1")
+
+	s, code := f.open(t, token)
+	if code != http.StatusOK {
+		t.Fatalf("connect: %d", code)
+	}
+	s.next(t, 5*time.Second)
+
+	ses := store.Session{
+		SessionID: store.NewID(), WorkID: workID, DeviceID: "dev",
+		StartedAt: time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond),
+		EndedAt:   time.Now().UTC().Truncate(time.Millisecond),
+		StartProg: 0.1, EndProg: 0.2, Origin: store.OriginNative,
+	}
+	if err := f.st.AppendSessions(t.Context(), "u1", []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.next(t, 5*time.Second); len(got) != 1 || got[0] != "insights" {
+		t.Fatalf("after a session: %v", got)
+	}
+	// The same batch again stores nothing, so it says nothing.
+	if err := f.st.AppendSessions(t.Context(), "u1", []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	s.silent(t, 300*time.Millisecond)
+}
+
+func TestEventsHeartbeatsThroughTheProductionMiddleware(t *testing.T) {
+	// A short heartbeat proves the frames are flushed rather than
+	// buffered until the response ends.
+	f := newEventsFixture(t, 4, EventsPolicy{Heartbeat: 50 * time.Millisecond})
+	token := f.user(t, "u1", store.ScopeSync)
+	s, code := f.open(t, token)
+	if code != http.StatusOK {
+		t.Fatalf("connect: %d", code)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	pings := 0
+	for time.Now().Before(deadline) && pings < 2 {
+		line, err := s.br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("reading the stream: %v", err)
+		}
+		if strings.HasPrefix(line, ": ping") {
+			pings++
+		}
+	}
+	if pings < 2 {
+		t.Fatal("no heartbeats arrived")
+	}
+}
+
+func TestEventsRefusesTooManyStreams(t *testing.T) {
+	f := newEventsFixture(t, 1, EventsPolicy{})
+	token := f.user(t, "u1", store.ScopeSync)
+	if _, code := f.open(t, token); code != http.StatusOK {
+		t.Fatalf("first stream: %d", code)
+	}
+	s, code := f.open(t, token)
+	if code != http.StatusTooManyRequests {
+		t.Fatalf("second stream: %d", code)
+	}
+	if s.resp.Header.Get("Retry-After") == "" {
+		t.Fatal("a refusal with no Retry-After leaves the client guessing")
+	}
+}
+
+func TestEventsEndAtTokenExpiry(t *testing.T) {
+	f := newEventsFixture(t, 4, EventsPolicy{Revalidate: 50 * time.Millisecond})
+	hash, err := auth.HashPassword("hunter2hunter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := f.st.CreateUser(t.Context(), store.User{
+		ID: "u1", Name: "u1", Argon2Hash: hash, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	secret, err := auth.NewSecret()
+	if err != nil {
+		t.Fatal(err)
+	}
+	expires := time.Now().Add(400 * time.Millisecond)
+	tok := store.Token{
+		ID: store.NewID(), UserID: "u1", DeviceID: store.NewID(), Name: "short",
+		Scopes: store.ScopeSet{store.ScopeSync}, SHA256: auth.HashSecret(secret),
+		CreatedAt: time.Now(), ExpiresAt: &expires,
+	}
+	if err := f.st.CreateToken(t.Context(), tok); err != nil {
+		t.Fatal(err)
+	}
+	s, code := f.open(t, secret)
+	if code != http.StatusOK {
+		t.Fatalf("connect: %d", code)
+	}
+	// A stream authenticated now must not still be authorized after the
+	// credential behind it has lapsed.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			if _, err := s.br.ReadString('\n'); err != nil {
+				return
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("an expired token kept its stream")
+	}
+}
+
+func TestEventsRevocationEndsStreamBeforeNextFrame(t *testing.T) {
+	for _, trigger := range []string{"heartbeat", "invalidation"} {
+		t.Run(trigger, func(t *testing.T) {
+			heartbeat := time.Hour
+			if trigger == "heartbeat" {
+				heartbeat = 50 * time.Millisecond
+			}
+			f := newEventsFixture(t, 4, EventsPolicy{
+				Heartbeat: heartbeat, Revalidate: time.Hour,
+			})
+			token := f.user(t, "u1", store.ScopeSync)
+			s, code := f.open(t, token)
+			if code != http.StatusOK {
+				t.Fatalf("connect: %d", code)
+			}
+			s.next(t, 5*time.Second)
+			tokens, err := f.st.ListTokens(t.Context(), "u1")
+			if err != nil || len(tokens) != 1 {
+				t.Fatalf("tokens: %v, %v", tokens, err)
+			}
+			if err := f.st.RevokeToken(t.Context(), "u1", tokens[0].ID); err != nil {
+				t.Fatal(err)
+			}
+			if trigger == "invalidation" {
+				f.hub.Notify("u1", store.TopicPositions)
+			}
+			done := make(chan string, 1)
+			go func() {
+				data, _ := io.ReadAll(s.br)
+				done <- string(data)
+			}()
+			select {
+			case data := <-done:
+				if strings.Contains(data, "event: invalidate") {
+					t.Fatalf("revoked credential received an invalidation: %q", data)
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("revoked credential kept its stream")
+			}
+			if _, code := f.open(t, token); code != http.StatusUnauthorized {
+				t.Fatalf("reconnect after revocation: %d", code)
+			}
+		})
+	}
+}
+
+func TestEventsFlushThroughSubpathProxy(t *testing.T) {
+	f := newEventsFixture(t, 4, EventsPolicy{Heartbeat: 25 * time.Millisecond})
+	token := f.user(t, "u1", store.ScopeSync)
+	upstream, err := url.Parse(f.ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	proxy := httptest.NewServer(http.StripPrefix("/sync", httputil.NewSingleHostReverseProxy(upstream)))
+	defer proxy.Close()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, proxy.URL+"/sync/v1/events", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("proxied connect: %d", resp.StatusCode)
+	}
+	s := &stream{resp: resp, br: bufio.NewReader(resp.Body)}
+	if topics := s.next(t, time.Second); len(topics) != 2 {
+		t.Fatalf("proxied opening topics: %v", topics)
+	}
+	for {
+		line, err := s.br.ReadString('\n')
+		if err != nil {
+			t.Fatalf("proxied heartbeat: %v", err)
+		}
+		if strings.HasPrefix(line, ": ping") {
+			break
+		}
+	}
+	f.hub.Notify("u1", store.TopicAnnotations)
+	if topics := s.next(t, time.Second); len(topics) != 1 || topics[0] != "annotations" {
+		t.Fatalf("proxied change after idle heartbeat: %v", topics)
+	}
+}
+
+func TestEventsHubShutdownEndsStreams(t *testing.T) {
+	f := newEventsFixture(t, 4, EventsPolicy{})
+	token := f.user(t, "u1", store.ScopeSync)
+	s, code := f.open(t, token)
+	if code != http.StatusOK {
+		t.Fatalf("connect: %d", code)
+	}
+	s.next(t, 5*time.Second)
+	f.hub.Close()
+	done := make(chan struct{})
+	go func() {
+		_, _ = io.Copy(io.Discard, s.br)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("hub shutdown left a stream open")
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -354,6 +354,14 @@ func (s *Server) Routes() *http.ServeMux {
 	mux.Handle("DELETE /v1/annotations/{id}", syncH(s.HandleDeleteAnnotation))
 	mux.Handle("GET /v1/works/{id}/annotations", syncH(s.HandleWorkAnnotations))
 
+	// Live notifications (ADR-0034). Authenticated like every other
+	// route, then filtered by topic rather than gated on one scope: the
+	// reader token carries sync, an insights dashboard carries
+	// read-insights, and each gets what it can already read.
+	mux.Handle("GET /v1/events",
+		auth.RequireSecureTransport(s.Cfg,
+			auth.RequireToken(s.Auth, http.HandlerFunc(s.HandleEvents))))
+
 	// read-insights scope.
 	insH := func(h http.HandlerFunc) http.Handler {
 		return auth.RequireSecureTransport(s.Cfg,

--- a/internal/api/token_scope_test.go
+++ b/internal/api/token_scope_test.go
@@ -140,6 +140,7 @@ const (
 	gateResolveBoth                    // bearer, library-read AND sync
 	gateOPDS                           // HTTP Basic, scope library-read
 	gateTokenSelf                      // bearer, no scope beyond authenticating
+	gateLiveEvents                     // bearer, authenticated then filtered per topic
 	gateLoginCred                      // the short-lived login credential, not a device token
 )
 
@@ -222,6 +223,8 @@ var registeredRouteGates = map[string]routeGate{
 	"HEAD /opds/v1.2/books/{id}/cover":           gateOPDS,
 
 	"GET /v1/token": gateTokenSelf,
+
+	"GET /v1/events": gateLiveEvents,
 
 	"POST /v1/tokens":        gateLoginCred,
 	"GET /v1/tokens":         gateLoginCred,
@@ -476,6 +479,27 @@ func TestScopeMatrixCoversEveryRegisteredRoute(t *testing.T) {
 				// what it is — that is the entire point of the route.
 				if got := bearer(method, path, syncOnly); got != http.StatusOK {
 					t.Errorf("a scoped token describing itself: %d, want 200", got)
+				}
+			case gateLiveEvents:
+				if got := bearer(method, path, ""); got != http.StatusUnauthorized {
+					t.Errorf("no token: %d, want 401", got)
+				}
+				// ADR-0034: one authentication, then a per-topic
+				// filter. A credential that could receive nothing is
+				// refused rather than parked on a silent stream.
+				if got := bearer(method, path, libraryReadOnly); got != http.StatusForbidden {
+					t.Errorf("a catalog-only token on the event stream: %d, want 403", got)
+				}
+				// This server has no hub, so a credential that passes
+				// the gate meets a 503 instead of an open stream. That
+				// is what keeps this matrix from hanging on a route
+				// designed never to answer.
+				for name, secret := range map[string]string{
+					"sync": syncOnly, "read-insights": insightsOnly,
+				} {
+					if got := bearer(method, path, secret); got == http.StatusUnauthorized || got == http.StatusForbidden {
+						t.Errorf("a %s token on the event stream: %d, should have passed the gate", name, got)
+					}
 				}
 			case gateLoginCred:
 				if got := bearer(method, path, ""); got != http.StatusUnauthorized {

--- a/internal/live/hub.go
+++ b/internal/live/hub.go
@@ -1,0 +1,235 @@
+// Package live carries transient change notifications from a write
+// that committed to the clients currently connected (ADR-0034).
+//
+// Nothing here is durable, and nothing here says what changed. A
+// subscriber learns which topics to re-read and answers by reading the
+// feeds it already knows. Losing every notification in this package
+// costs latency and nothing else, which is why one process's memory is
+// the right place for it.
+package live
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// ErrTooManyStreams is returned when an account already holds as many
+// subscriptions as it is allowed. The caller answers 429.
+var ErrTooManyStreams = errors.New("too many live streams for this account")
+
+// ErrNoTopics is returned for a credential that could never receive
+// anything. It is refused rather than parked on a silent stream.
+var ErrNoTopics = errors.New("no live topics for this credential")
+
+// topics is a set held as a bitmask so that coalescing is a union and
+// draining allocates once. The canonical order below is what every
+// subscriber sees, so two clients told the same thing read the same
+// frame.
+type topics uint8
+
+var known = []store.Topic{
+	store.TopicPositions,
+	store.TopicAnnotations,
+	store.TopicInsights,
+}
+
+func bit(t store.Topic) topics {
+	for i, k := range known {
+		if k == t {
+			return 1 << i
+		}
+	}
+	return 0
+}
+
+func setOf(list []store.Topic) topics {
+	var s topics
+	for _, t := range list {
+		s |= bit(t)
+	}
+	return s
+}
+
+func (s topics) list() []store.Topic {
+	if s == 0 {
+		return nil
+	}
+	out := make([]store.Topic, 0, len(known))
+	for i, k := range known {
+		if s&(1<<i) != 0 {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+// Hub fans committed changes out to the subscriptions of one account.
+// It is safe for concurrent use and never blocks its caller: a write
+// path notifies while a request is still open.
+type Hub struct {
+	maxPerUser int
+
+	mu     sync.Mutex
+	subs   map[string]map[*Subscription]struct{}
+	closed bool
+}
+
+// NewHub returns a hub allowing maxPerUser concurrent subscriptions per
+// account. A non-positive limit means one: a reader with several tabs
+// is still a reader, but an unbounded count is a way to hold file
+// descriptors.
+func NewHub(maxPerUser int) *Hub {
+	if maxPerUser < 1 {
+		maxPerUser = 1
+	}
+	return &Hub{maxPerUser: maxPerUser, subs: map[string]map[*Subscription]struct{}{}}
+}
+
+// Subscribe registers a subscription for the topics this credential may
+// receive. Register before reading anything the first invalidation
+// provokes: a change committed between that read and the registration
+// is the one a client would otherwise never hear about.
+func (h *Hub) Subscribe(userID string, allowed []store.Topic) (*Subscription, error) {
+	set := setOf(allowed)
+	if userID == "" || set == 0 {
+		return nil, ErrNoTopics
+	}
+	sub := &Subscription{
+		hub:     h,
+		userID:  userID,
+		allowed: set,
+		wake:    make(chan struct{}, 1),
+		done:    make(chan struct{}),
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.closed {
+		// Shutting down. Hand back a subscription that is already over
+		// rather than a nil and a special case at the call site.
+		sub.finish()
+		return sub, nil
+	}
+	if len(h.subs[userID]) >= h.maxPerUser {
+		return nil, ErrTooManyStreams
+	}
+	if h.subs[userID] == nil {
+		h.subs[userID] = map[*Subscription]struct{}{}
+	}
+	h.subs[userID][sub] = struct{}{}
+	return sub, nil
+}
+
+// Notify implements store.ChangeNotifier. It takes no socket and does
+// no I/O: it marks each interested subscription and pokes it awake.
+func (h *Hub) Notify(userID string, list ...store.Topic) {
+	set := setOf(list)
+	if set == 0 {
+		return
+	}
+	h.mu.Lock()
+	subs := make([]*Subscription, 0, len(h.subs[userID]))
+	for sub := range h.subs[userID] {
+		subs = append(subs, sub)
+	}
+	h.mu.Unlock()
+	// Outside the lock: a subscription's own mutex is taken here, and a
+	// slow client must never be able to stall a commit.
+	for _, sub := range subs {
+		sub.raise(set)
+	}
+}
+
+// Close ends every subscription, for shutdown. Handlers see Done close
+// and finish their responses.
+func (h *Hub) Close() {
+	h.mu.Lock()
+	subs := h.subs
+	h.subs = map[string]map[*Subscription]struct{}{}
+	h.closed = true
+	h.mu.Unlock()
+	for _, byUser := range subs {
+		for sub := range byUser {
+			sub.finish()
+		}
+	}
+}
+
+// Subscription is one connected client. It holds the set of topics it
+// owes and a single wake-up slot: notifications arriving during one
+// slow write collapse into one frame naming everything they mentioned,
+// which is as much as the client needs to know.
+type Subscription struct {
+	hub     *Hub
+	userID  string
+	allowed topics
+	wake    chan struct{}
+
+	mu      sync.Mutex
+	pending topics
+
+	doneOnce sync.Once
+	done     chan struct{}
+}
+
+func (s *Subscription) raise(set topics) {
+	set &= s.allowed
+	if set == 0 {
+		return
+	}
+	s.mu.Lock()
+	before := s.pending
+	s.pending |= set
+	changed := s.pending != before
+	s.mu.Unlock()
+	if !changed {
+		// Already owed, and the client has not read the last frame:
+		// another one would say the same thing.
+		return
+	}
+	select {
+	case s.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Raise queues topics without going through the hub. The handler uses
+// it for the invalidation every connection opens with.
+func (s *Subscription) Raise(list ...store.Topic) { s.raise(setOf(list)) }
+
+// Wake fires when something is owed.
+func (s *Subscription) Wake() <-chan struct{} { return s.wake }
+
+// Done fires when the hub shuts the subscription down.
+func (s *Subscription) Done() <-chan struct{} { return s.done }
+
+// Allowed lists the topics this subscription may ever receive, in
+// canonical order.
+func (s *Subscription) Allowed() []store.Topic { return s.allowed.list() }
+
+// Take drains what is owed. An empty result is a spurious wake-up, not
+// an empty frame: the caller sends nothing.
+func (s *Subscription) Take() []store.Topic {
+	s.mu.Lock()
+	set := s.pending
+	s.pending = 0
+	s.mu.Unlock()
+	return set.list()
+}
+
+// Close unregisters the subscription. Calling it twice is safe.
+func (s *Subscription) Close() {
+	h := s.hub
+	h.mu.Lock()
+	if byUser, ok := h.subs[s.userID]; ok {
+		delete(byUser, s)
+		if len(byUser) == 0 {
+			delete(h.subs, s.userID)
+		}
+	}
+	h.mu.Unlock()
+	s.finish()
+}
+
+func (s *Subscription) finish() { s.doneOnce.Do(func() { close(s.done) }) }

--- a/internal/live/hub_test.go
+++ b/internal/live/hub_test.go
@@ -1,0 +1,174 @@
+package live
+
+import (
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func waited(t *testing.T, sub *Subscription) []store.Topic {
+	t.Helper()
+	select {
+	case <-sub.Wake():
+		return sub.Take()
+	case <-time.After(2 * time.Second):
+		t.Fatal("no wake-up")
+		return nil
+	}
+}
+
+func quiet(t *testing.T, sub *Subscription) {
+	t.Helper()
+	select {
+	case <-sub.Wake():
+		t.Fatalf("unexpected wake-up carrying %v", sub.Take())
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestNotifyReachesOnlyItsOwnAccount(t *testing.T) {
+	h := NewHub(4)
+	mine, err := h.Subscribe("u1", []store.Topic{store.TopicPositions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	theirs, err := h.Subscribe("u2", []store.Topic{store.TopicPositions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.Notify("u1", store.TopicPositions)
+	if got := waited(t, mine); len(got) != 1 || got[0] != store.TopicPositions {
+		t.Fatalf("own account got %v", got)
+	}
+	quiet(t, theirs)
+}
+
+func TestTopicsCoalesceByUnion(t *testing.T) {
+	h := NewHub(4)
+	sub, err := h.Subscribe("u1", known)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A burst while nobody is reading must not lose the earlier topics
+	// by being replaced with the later one.
+	h.Notify("u1", store.TopicPositions)
+	h.Notify("u1", store.TopicAnnotations)
+	h.Notify("u1", store.TopicInsights)
+	got := waited(t, sub)
+	if len(got) != 3 || got[0] != store.TopicPositions ||
+		got[1] != store.TopicAnnotations || got[2] != store.TopicInsights {
+		t.Fatalf("coalesced to %v", got)
+	}
+	// Drained: nothing further is owed.
+	if rest := sub.Take(); rest != nil {
+		t.Fatalf("still owed %v", rest)
+	}
+}
+
+func TestUnpermittedTopicIsNeverDelivered(t *testing.T) {
+	h := NewHub(4)
+	sub, err := h.Subscribe("u1", []store.Topic{store.TopicPositions})
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.Notify("u1", store.TopicInsights)
+	quiet(t, sub)
+
+	h.Notify("u1", store.TopicInsights, store.TopicPositions)
+	if got := waited(t, sub); len(got) != 1 || got[0] != store.TopicPositions {
+		t.Fatalf("filtered set was %v", got)
+	}
+}
+
+func TestSubscribeRefusals(t *testing.T) {
+	h := NewHub(1)
+	if _, err := h.Subscribe("u1", nil); err != ErrNoTopics {
+		t.Fatalf("no topics: %v", err)
+	}
+	if _, err := h.Subscribe("", known); err != ErrNoTopics {
+		t.Fatalf("no user: %v", err)
+	}
+	first, err := h.Subscribe("u1", known)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := h.Subscribe("u1", known); err != ErrTooManyStreams {
+		t.Fatalf("over the limit: %v", err)
+	}
+	// Closing one makes room again, so a reconnecting client is not
+	// locked out by its own previous stream.
+	first.Close()
+	if _, err := h.Subscribe("u1", known); err != nil {
+		t.Fatalf("after close: %v", err)
+	}
+}
+
+func TestCloseEndsEverySubscription(t *testing.T) {
+	h := NewHub(4)
+	sub, err := h.Subscribe("u1", known)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.Close()
+	select {
+	case <-sub.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("shutdown did not end the subscription")
+	}
+	// Subscribing during shutdown yields something already over rather
+	// than a nil to special-case.
+	late, err := h.Subscribe("u1", known)
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-late.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("late subscription was not already over")
+	}
+	sub.Close() // idempotent
+}
+
+func TestNotifyDoesNotBlockOnAnIdleSubscriber(t *testing.T) {
+	h := NewHub(4)
+	if _, err := h.Subscribe("u1", known); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 1000 {
+			h.Notify("u1", store.TopicPositions, store.TopicAnnotations)
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a client that never reads stalled the write path")
+	}
+}
+
+func TestConcurrentNotifyAndSubscribe(t *testing.T) {
+	h := NewHub(64)
+	stop := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				h.Notify("u1", store.TopicPositions)
+			}
+		}
+	}()
+	for range 50 {
+		sub, err := h.Subscribe("u1", known)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sub.Take()
+		sub.Close()
+	}
+	close(stop)
+}

--- a/internal/store/notify.go
+++ b/internal/store/notify.go
@@ -1,0 +1,88 @@
+package store
+
+import "sync/atomic"
+
+// Topic names a family of reading state a client already knows how to
+// read for itself (ADR-0034). It is the entire content of a live
+// notification: no work, no locator, no sequence number, nothing a
+// client could mistake for the change itself.
+type Topic string
+
+const (
+	// TopicPositions covers everything on the op log: native pushes,
+	// the web reader's reading status, and the kosync adapter.
+	TopicPositions Topic = "positions"
+	// TopicAnnotations covers the annotation feed, tombstones included.
+	TopicAnnotations Topic = "annotations"
+	// TopicInsights covers reading sessions, which have no feed of
+	// their own: a client answers by asking for the statistics again.
+	TopicInsights Topic = "insights"
+)
+
+// ChangeNotifier is told, after a commit, that a user's reading state
+// moved. It must not block: a write path calls it while a request is
+// still in flight.
+type ChangeNotifier interface {
+	Notify(userID string, topics ...Topic)
+}
+
+// ChangeNotifying is the optional interface a backend implements to
+// accept one. The Store interface deliberately does not carry it:
+// nothing reads state through it, and a wrapper that hid it would be a
+// bug rather than a layer.
+type ChangeNotifying interface {
+	SetChangeNotifier(ChangeNotifier)
+}
+
+// Notifications is embedded by a backend to carry the hook. The zero
+// value notifies nobody, which is what every test and the admin CLI
+// want.
+type Notifications struct {
+	notifier atomic.Pointer[ChangeNotifier]
+}
+
+// SetChangeNotifier installs the hook. Passing nil removes it.
+func (n *Notifications) SetChangeNotifier(cn ChangeNotifier) {
+	if cn == nil {
+		n.notifier.Store(nil)
+		return
+	}
+	n.notifier.Store(&cn)
+}
+
+// Notify raises the topics for one user. Callers must only reach here
+// after a successful commit, and only when the commit changed
+// something a client could read: a duplicate that changed no row is
+// exactly the write that must not start another round of pulls.
+func (n *Notifications) Notify(userID string, topics ...Topic) {
+	if userID == "" || len(topics) == 0 {
+		return
+	}
+	cn := n.notifier.Load()
+	if cn == nil {
+		return
+	}
+	(*cn).Notify(userID, topics...)
+}
+
+// AnyOpApplied reports whether a batch of op results contains a write
+// that landed. Duplicates and conflicts changed no row.
+func AnyOpApplied(results []OpResult) bool {
+	for _, r := range results {
+		if r.Status == "applied" {
+			return true
+		}
+	}
+	return false
+}
+
+// AnyAnnotationApplied is the same question for annotation results,
+// which share the vocabulary but not the type.
+func AnyAnnotationApplied(results []AnnotationResult) bool {
+	for _, r := range results {
+		if r.Status == "applied" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/postgres/annotations.go
+++ b/internal/store/postgres/annotations.go
@@ -86,6 +86,9 @@ func (s *Store) PushAnnotations(ctx context.Context, userID, deviceID string, it
 	if err != nil {
 		return nil, err
 	}
+	if store.AnyAnnotationApplied(results) {
+		s.Notify(userID, store.TopicAnnotations)
+	}
 	return results, nil
 }
 
@@ -266,6 +269,9 @@ func (s *Store) DeleteAnnotation(ctx context.Context, userID, id string, rev int
 	})
 	if err != nil {
 		return store.AnnotationResult{}, err
+	}
+	if r.Status == "applied" {
+		s.Notify(userID, store.TopicAnnotations)
 	}
 	return r, nil
 }

--- a/internal/store/postgres/koplugin.go
+++ b/internal/store/postgres/koplugin.go
@@ -48,7 +48,7 @@ func (s *Store) UpsertKopluginSession(ctx context.Context, userID string, ses st
 	if err != nil {
 		return "", err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := s.commitSessions(tx, userID, status != "duplicate"); err != nil {
 		return "", err
 	}
 	return status, nil
@@ -72,7 +72,7 @@ func (s *Store) UpsertKopluginSessionByAlias(ctx context.Context, userID, partia
 	if err != nil {
 		return "", err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := s.commitSessions(tx, userID, status != "duplicate"); err != nil {
 		return "", err
 	}
 	return status, nil

--- a/internal/store/postgres/ops.go
+++ b/internal/store/postgres/ops.go
@@ -28,6 +28,9 @@ func (s *Store) AppendOps(ctx context.Context, userID, deviceID string, ops []st
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
+	if store.AnyOpApplied(results) {
+		s.Notify(userID, store.TopicPositions)
+	}
 	return results, nil
 }
 
@@ -115,6 +118,9 @@ func (s *Store) AppendKosyncOp(ctx context.Context, userID, partialMD5, deviceID
 	}
 	if err := tx.Commit(); err != nil {
 		return store.OpResult{}, err
+	}
+	if store.AnyOpApplied(results) {
+		s.Notify(userID, store.TopicPositions)
 	}
 	return results[0], nil
 }

--- a/internal/store/postgres/postgres.go
+++ b/internal/store/postgres/postgres.go
@@ -16,6 +16,7 @@ import (
 
 // Store is the Postgres backend.
 type Store struct {
+	store.Notifications
 	db *sql.DB
 }
 

--- a/internal/store/postgres/sessions.go
+++ b/internal/store/postgres/sessions.go
@@ -18,13 +18,28 @@ func (s *Store) AppendSessions(ctx context.Context, userID string, ss []store.Se
 	if err := lockWorkGraph(ctx, tx, userID); err != nil {
 		return err
 	}
-	if err := appendSessionsTx(ctx, tx, userID, ss, time.Now().UTC()); err != nil {
+	inserted, err := appendSessionsTx(ctx, tx, userID, ss, time.Now().UTC())
+	if err != nil {
 		return err
 	}
-	return tx.Commit()
+	return s.commitSessions(tx, userID, inserted > 0)
 }
 
-func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store.Session, now time.Time) error {
+// commitSessions: see the SQLite implementation's doc comment.
+func (s *Store) commitSessions(tx *sql.Tx, userID string, changed bool) error {
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if changed {
+		s.Notify(userID, store.TopicInsights)
+	}
+	return nil
+}
+
+// appendSessionsTx returns how many sessions it stored; the rest were
+// idempotent replays.
+func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store.Session, now time.Time) (int, error) {
+	inserted := 0
 	for i, ses := range ss {
 		var archivedFingerprint string
 		err := tx.QueryRowContext(ctx, q(
@@ -32,33 +47,33 @@ func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store
 			userID, ses.SessionID).Scan(&archivedFingerprint)
 		if err == nil {
 			if archivedFingerprint != store.SessionFingerprint(ses) {
-				return store.IDMismatch("session", ses.SessionID, i)
+				return inserted, store.IDMismatch("session", ses.SessionID, i)
 			}
 			continue
 		}
 		if !errors.Is(err, sql.ErrNoRows) {
-			return err
+			return inserted, err
 		}
 		var found int
 		if err = tx.QueryRowContext(ctx, q(
 			`SELECT COUNT(1) FROM sessions WHERE user_id = ? AND session_id = ?`),
 			userID, ses.SessionID).Scan(&found); err != nil {
-			return err
+			return inserted, err
 		}
 		if found > 0 {
 			same, err := sameSession(ctx, tx, userID, ses)
 			if err != nil {
-				return err
+				return inserted, err
 			}
 			if !same {
-				return store.IDMismatch("session", ses.SessionID, i)
+				return inserted, store.IDMismatch("session", ses.SessionID, i)
 			}
 			continue
 		}
 		if ok, err := workExistsTx(ctx, tx, userID, ses.WorkID); err != nil {
-			return err
+			return inserted, err
 		} else if !ok {
-			return store.UnknownWork("session", ses.SessionID, i, ses.WorkID)
+			return inserted, store.UnknownWork("session", ses.SessionID, i, ses.WorkID)
 		}
 		_, err = tx.ExecContext(ctx, q(
 			`INSERT INTO sessions (user_id, session_id, work_id, edition_sha, device_id,
@@ -70,10 +85,11 @@ func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store
 			ses.StartProg, ses.EndProg, ses.IdleMs,
 			string(ses.Origin), ses.OriginAlias, ses.SourceKey, now)
 		if err != nil {
-			return err
+			return inserted, err
 		}
+		inserted++
 	}
-	return nil
+	return inserted, nil
 }
 
 func (s *Store) AppendInferredSession(ctx context.Context, userID string, group store.InferredSessionGroup) error {
@@ -103,8 +119,9 @@ func (s *Store) AppendInferredSession(ctx context.Context, userID string, group 
 			return store.ErrConflict
 		}
 	}
-	if err := appendSessionsTx(ctx, tx, userID,
-		[]store.Session{group.Session}, time.Now().UTC()); err != nil {
+	inserted, err := appendSessionsTx(ctx, tx, userID,
+		[]store.Session{group.Session}, time.Now().UTC())
+	if err != nil {
 		return err
 	}
 	for _, op := range group.Ops {
@@ -123,7 +140,8 @@ func (s *Store) AppendInferredSession(ctx context.Context, userID string, group 
 			return store.ErrConflict
 		}
 	}
-	return tx.Commit()
+	// Stamping ops for a session already stored changes no statistics.
+	return s.commitSessions(tx, userID, inserted > 0)
 }
 
 func sameSession(ctx context.Context, tx *sql.Tx, userID string, ses store.Session) (bool, error) {

--- a/internal/store/sqlite/annotations.go
+++ b/internal/store/sqlite/annotations.go
@@ -101,6 +101,9 @@ func (s *Store) PushAnnotations(ctx context.Context, userID, deviceID string, it
 	if err != nil {
 		return nil, err
 	}
+	if store.AnyAnnotationApplied(results) {
+		s.Notify(userID, store.TopicAnnotations)
+	}
 	return results, nil
 }
 
@@ -281,6 +284,9 @@ func (s *Store) DeleteAnnotation(ctx context.Context, userID, id string, rev int
 	})
 	if err != nil {
 		return store.AnnotationResult{}, err
+	}
+	if r.Status == "applied" {
+		s.Notify(userID, store.TopicAnnotations)
 	}
 	return r, nil
 }

--- a/internal/store/sqlite/koplugin.go
+++ b/internal/store/sqlite/koplugin.go
@@ -68,7 +68,7 @@ func (s *Store) UpsertKopluginSession(ctx context.Context, userID string, ses st
 	if err != nil {
 		return "", err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := s.commitSessions(tx, userID, status != "duplicate"); err != nil {
 		return "", err
 	}
 	return status, nil
@@ -92,7 +92,7 @@ func (s *Store) UpsertKopluginSessionByAlias(ctx context.Context, userID, partia
 	if err != nil {
 		return "", err
 	}
-	if err := tx.Commit(); err != nil {
+	if err := s.commitSessions(tx, userID, status != "duplicate"); err != nil {
 		return "", err
 	}
 	return status, nil

--- a/internal/store/sqlite/ops.go
+++ b/internal/store/sqlite/ops.go
@@ -30,6 +30,9 @@ func (s *Store) AppendOps(ctx context.Context, userID, deviceID string, ops []st
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
+	if store.AnyOpApplied(results) {
+		s.Notify(userID, store.TopicPositions)
+	}
 	return results, nil
 }
 
@@ -125,6 +128,9 @@ func (s *Store) AppendKosyncOp(ctx context.Context, userID, partialMD5, deviceID
 	}
 	if err := tx.Commit(); err != nil {
 		return store.OpResult{}, err
+	}
+	if store.AnyOpApplied(results) {
+		s.Notify(userID, store.TopicPositions)
 	}
 	return results[0], nil
 }

--- a/internal/store/sqlite/sessions.go
+++ b/internal/store/sqlite/sessions.go
@@ -25,13 +25,32 @@ func (s *Store) AppendSessions(ctx context.Context, userID string, ss []store.Se
 	if err := lockWorkGraph(ctx, tx, userID); err != nil {
 		return err
 	}
-	if err := appendSessionsTx(ctx, tx, userID, ss, formatTime(time.Now())); err != nil {
+	inserted, err := appendSessionsTx(ctx, tx, userID, ss, formatTime(time.Now()))
+	if err != nil {
 		return err
 	}
-	return tx.Commit()
+	return s.commitSessions(tx, userID, inserted > 0)
 }
 
-func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store.Session, now string) error {
+// commitSessions commits a session write and, when it actually stored
+// something, tells whoever is listening that this user's statistics
+// moved. Sessions have no delta feed, so a client answers by asking for
+// the numbers again. A batch that was entirely duplicates changed
+// nothing and must stay silent.
+func (s *Store) commitSessions(tx *sql.Tx, userID string, changed bool) error {
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	if changed {
+		s.Notify(userID, store.TopicInsights)
+	}
+	return nil
+}
+
+// appendSessionsTx returns how many sessions it stored; the rest were
+// idempotent replays.
+func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store.Session, now string) (int, error) {
+	inserted := 0
 	for i, ses := range ss {
 		var archivedFingerprint string
 		err := tx.QueryRowContext(ctx,
@@ -39,34 +58,34 @@ func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store
 			userID, ses.SessionID).Scan(&archivedFingerprint)
 		if err == nil {
 			if archivedFingerprint != store.SessionFingerprint(ses) {
-				return store.IDMismatch("session", ses.SessionID, i)
+				return inserted, store.IDMismatch("session", ses.SessionID, i)
 			}
 			continue
 		}
 		if !errors.Is(err, sql.ErrNoRows) {
-			return err
+			return inserted, err
 		}
 		var found int
 		err = tx.QueryRowContext(ctx,
 			`SELECT COUNT(1) FROM sessions WHERE user_id = ? AND session_id = ?`,
 			userID, ses.SessionID).Scan(&found)
 		if err != nil {
-			return err
+			return inserted, err
 		}
 		if found > 0 {
 			same, err := sameSession(ctx, tx, userID, ses)
 			if err != nil {
-				return err
+				return inserted, err
 			}
 			if !same {
-				return store.IDMismatch("session", ses.SessionID, i)
+				return inserted, store.IDMismatch("session", ses.SessionID, i)
 			}
 			continue // idempotent duplicate
 		}
 		if ok, err := workExistsTx(ctx, tx, userID, ses.WorkID); err != nil {
-			return err
+			return inserted, err
 		} else if !ok {
-			return store.UnknownWork("session", ses.SessionID, i, ses.WorkID)
+			return inserted, store.UnknownWork("session", ses.SessionID, i, ses.WorkID)
 		}
 		_, err = tx.ExecContext(ctx,
 			`INSERT INTO sessions (user_id, session_id, work_id, edition_sha, device_id,
@@ -78,10 +97,11 @@ func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store
 			ses.StartProg, ses.EndProg, ses.IdleMs,
 			string(ses.Origin), nullStr(ses.OriginAlias), nullStr(ses.SourceKey), now)
 		if err != nil {
-			return err
+			return inserted, err
 		}
+		inserted++
 	}
-	return nil
+	return inserted, nil
 }
 
 func (s *Store) AppendInferredSession(ctx context.Context, userID string, group store.InferredSessionGroup) error {
@@ -111,8 +131,9 @@ func (s *Store) AppendInferredSession(ctx context.Context, userID string, group 
 			return store.ErrConflict
 		}
 	}
-	if err := appendSessionsTx(ctx, tx, userID,
-		[]store.Session{group.Session}, formatTime(time.Now())); err != nil {
+	inserted, err := appendSessionsTx(ctx, tx, userID,
+		[]store.Session{group.Session}, formatTime(time.Now()))
+	if err != nil {
 		return err
 	}
 	for _, op := range group.Ops {
@@ -131,7 +152,8 @@ func (s *Store) AppendInferredSession(ctx context.Context, userID string, group 
 			return store.ErrConflict
 		}
 	}
-	return tx.Commit()
+	// Stamping ops for a session already stored changes no statistics.
+	return s.commitSessions(tx, userID, inserted > 0)
 }
 
 func sameSession(ctx context.Context, tx *sql.Tx, userID string, ses store.Session) (bool, error) {

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -14,6 +14,7 @@ import (
 
 // Store is the SQLite backend.
 type Store struct {
+	store.Notifications
 	db *sql.DB
 }
 

--- a/internal/store/storetest/notifications.go
+++ b/internal/store/storetest/notifications.go
@@ -1,0 +1,446 @@
+package storetest
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/infer"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+type changeNotice struct {
+	userID string
+	topics []store.Topic
+}
+
+type notificationProbe struct {
+	notices []changeNotice
+	read    func(context.Context)
+}
+
+func (p *notificationProbe) Notify(userID string, topics ...store.Topic) {
+	p.notices = append(p.notices, changeNotice{userID, slices.Clone(topics)})
+	if p.read != nil {
+		// Read through the store, not the write transaction: an early
+		// notification sees stale data (Postgres) or times out (SQLite).
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		p.read(ctx)
+	}
+}
+
+func (p *notificationProbe) check(t *testing.T, userID string, topic store.Topic) {
+	t.Helper()
+	defer func() { p.notices = nil }()
+	if topic == "" {
+		if len(p.notices) != 0 {
+			t.Fatalf("no-op write notified: %+v", p.notices)
+		}
+		return
+	}
+	if len(p.notices) != 1 || p.notices[0].userID != userID ||
+		!slices.Equal(p.notices[0].topics, []store.Topic{topic}) {
+		t.Fatalf("want one %s notice for %s, got %+v", topic, userID, p.notices)
+	}
+}
+
+func notificationFixture(t *testing.T, open OpenFunc) (store.Store, store.User, store.Work, *notificationProbe) {
+	t.Helper()
+	s := open(t)
+	other := MkUser(t, s, "alice")
+	MkWork(t, s, other, "w1", "sha1")
+	user := MkUser(t, s, "bob")
+	work := MkWork(t, s, user, "w1", "sha1")
+	hook, ok := s.(store.ChangeNotifying)
+	if !ok {
+		t.Fatal("backend does not implement ChangeNotifying")
+	}
+	probe := &notificationProbe{}
+	hook.SetChangeNotifier(probe)
+	t.Cleanup(func() { hook.SetChangeNotifier(nil) })
+	return s, user, work, probe
+}
+
+func testNotifications(t *testing.T, open OpenFunc) {
+	for _, kosync := range []bool{false, true} {
+		name := "NativeOps"
+		if kosync {
+			name = "KosyncOps"
+		}
+		t.Run(name, func(t *testing.T) { testOpNotifications(t, open, kosync) })
+	}
+	t.Run("Annotations", func(t *testing.T) { testAnnotationNotifications(t, open) })
+	t.Run("NativeSessions", func(t *testing.T) { testSessionNotifications(t, open) })
+	t.Run("InferredSessions", func(t *testing.T) { testInferredNotifications(t, open, false) })
+	t.Run("ExistingInferredSession", func(t *testing.T) { testInferredNotifications(t, open, true) })
+	for _, alias := range []bool{false, true} {
+		name := "Koplugin"
+		if alias {
+			name = "KopluginByAlias"
+		}
+		t.Run(name, func(t *testing.T) { testKopluginNotifications(t, open, alias) })
+	}
+}
+
+func testOpNotifications(t *testing.T, open OpenFunc, kosync bool) {
+	s, user, work, probe := notificationFixture(t, open)
+	ctx := context.Background()
+	op := store.Op{
+		OpID: "op1", WorkID: work.ID, ClientTS: time.Now(),
+		Progression: 0.2, Origin: store.OriginNative,
+	}
+	if kosync {
+		op.Origin = store.OriginKosync
+	}
+	appendOp := func(op store.Op) (store.OpResult, error) {
+		if kosync {
+			return s.AppendKosyncOp(ctx, user.ID, "md5-w1", "device", op)
+		}
+		results, err := s.AppendOps(ctx, user.ID, "device", []store.Op{op})
+		if err != nil {
+			return store.OpResult{}, err
+		}
+		return results[0], nil
+	}
+	probe.read = func(ctx context.Context) {
+		page, err := s.Changes(ctx, user.ID, 0, 10)
+		if err != nil || len(page.Ops) != 1 || page.Ops[0].OpID != op.OpID ||
+			page.Ops[0].Progression != 0.2 {
+			t.Errorf("notification preceded op commit: %+v, %v", page, err)
+		}
+	}
+	for _, status := range []string{"applied", "duplicate", "conflict"} {
+		if status == "conflict" {
+			op.Progression = 0.7
+		}
+		result, err := appendOp(op)
+		if err != nil || result.Status != status {
+			t.Fatalf("want %s, got %+v, %v", status, result, err)
+		}
+		topic := store.Topic("")
+		if status == "applied" {
+			topic = store.TopicPositions
+		}
+		probe.check(t, user.ID, topic)
+	}
+	probe.read = nil
+	if kosync {
+		bad := op
+		bad.OpID, bad.EditionSHA = "bad", Ptr("unknown-edition")
+		if _, err := s.AppendKosyncOp(ctx, user.ID, "new-alias", "device", bad); err == nil {
+			t.Fatal("expected foreign-key failure")
+		}
+		if _, err := s.WorkIDByAlias(ctx, user.ID, "partial-md5", "new-alias"); !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("failed kosync write left its alias: %v", err)
+		}
+	} else {
+		valid, invalid := op, op
+		valid.OpID, invalid.OpID, invalid.WorkID = "rolled-back", "unknown", "no-work"
+		if _, err := s.AppendOps(ctx, user.ID, "device", []store.Op{valid, invalid}); !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("expected unknown work: %v", err)
+		}
+	}
+	probe.check(t, user.ID, "")
+	page, err := s.Changes(ctx, user.ID, 0, 10)
+	if err != nil || len(page.Ops) != 1 {
+		t.Fatalf("failed write was not rolled back: %+v, %v", page, err)
+	}
+	if !kosync {
+		badEdition := op
+		badEdition.OpID, badEdition.EditionSHA = "bad-edition", Ptr("unknown-edition")
+		if _, err := s.AppendOps(ctx, user.ID, "device", []store.Op{badEdition}); err == nil {
+			t.Fatal("expected deferred foreign-key failure at commit")
+		}
+		probe.check(t, user.ID, "")
+		fresh := op
+		fresh.OpID = "op2"
+		probe.read = func(ctx context.Context) {
+			page, err := s.Changes(ctx, user.ID, 0, 10)
+			if err != nil || len(page.Ops) != 2 {
+				t.Errorf("mixed batch not committed: %+v, %v", page, err)
+			}
+		}
+		original := op
+		original.Progression = 0.2
+		results, err := s.AppendOps(ctx, user.ID, "device", []store.Op{original, fresh})
+		if err != nil || len(results) != 2 || results[0].Status != "duplicate" || results[1].Status != "applied" {
+			t.Fatalf("mixed batch: %+v, %v", results, err)
+		}
+		probe.check(t, user.ID, store.TopicPositions)
+		if _, err := s.AppendOps(ctx, user.ID, "device", nil); err != nil {
+			t.Fatal(err)
+		}
+		probe.check(t, user.ID, "")
+	}
+	probe.read = nil
+	if _, err := s.AppendOps(ctx, "u-alice", "device", []store.Op{op}); err != nil {
+		t.Fatal(err)
+	}
+	probe.check(t, "u-alice", store.TopicPositions)
+}
+
+func testAnnotationNotifications(t *testing.T, open OpenFunc) {
+	s, user, work, probe := notificationFixture(t, open)
+	ctx := context.Background()
+	item := annWrite("a1", work.ID, 0)
+	wantRev := int64(1)
+	wantDeleted := false
+	probe.read = func(ctx context.Context) {
+		page, err := s.AnnotationChanges(ctx, user.ID, 0, 10)
+		if err != nil || len(page.Annotations) != 1 || page.Annotations[0].Rev != wantRev ||
+			page.Annotations[0].Deleted() != wantDeleted {
+			t.Errorf("notification preceded annotation commit: %+v, %v", page, err)
+		}
+	}
+	for _, status := range []string{"applied", "duplicate"} {
+		if r := pushOne(t, s, user.ID, "device", item); r.Status != status {
+			t.Fatalf("create/replay: %+v", r)
+		}
+		topic := store.Topic("")
+		if status == "applied" {
+			topic = store.TopicAnnotations
+		}
+		probe.check(t, user.ID, topic)
+	}
+	item.BaseRev, item.Body, wantRev = 1, "edited", 2
+	if r := pushOne(t, s, user.ID, "device", item); r.Status != "applied" {
+		t.Fatalf("edit: %+v", r)
+	}
+	probe.check(t, user.ID, store.TopicAnnotations)
+	if r := pushOne(t, s, user.ID, "device", item); r.Status != "duplicate" {
+		t.Fatalf("edit replay: %+v", r)
+	}
+	probe.check(t, user.ID, "")
+	item.Body = "stale edit"
+	if r := pushOne(t, s, user.ID, "device", item); r.Status != "conflict" {
+		t.Fatalf("stale edit: %+v", r)
+	}
+	probe.check(t, user.ID, "")
+	if r := pushOne(t, s, user.ID, "device", annWrite("unknown", "no-work", 0)); r.Status != "invalid" {
+		t.Fatalf("unknown work: %+v", r)
+	}
+	probe.check(t, user.ID, "")
+	if r, err := s.DeleteAnnotation(ctx, user.ID, item.ID, 1); err != nil || r.Status != "conflict" {
+		t.Fatalf("stale delete: %+v, %v", r, err)
+	}
+	probe.check(t, user.ID, "")
+	wantRev, wantDeleted = 3, true
+	if r, err := s.DeleteAnnotation(ctx, user.ID, item.ID, 2); err != nil || r.Status != "applied" {
+		t.Fatalf("delete: %+v, %v", r, err)
+	}
+	probe.check(t, user.ID, store.TopicAnnotations)
+	if r, err := s.DeleteAnnotation(ctx, user.ID, item.ID, 2); err != nil || r.Status != "duplicate" {
+		t.Fatalf("delete replay: %+v, %v", r, err)
+	}
+	probe.check(t, user.ID, "")
+	if _, err := s.DeleteAnnotation(ctx, user.ID, "missing", 1); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("missing delete: %v", err)
+	}
+	probe.check(t, user.ID, "")
+	if _, err := s.PushAnnotations(ctx, user.ID, "device", nil, 2000); err != nil {
+		t.Fatal(err)
+	}
+	probe.check(t, user.ID, "")
+	probe.read = nil
+	fresh, invalid := annWrite("a2", work.ID, 0), annWrite("bad-kind", work.ID, 0)
+	// Bypass handler validation to fail SQL after an earlier item wrote.
+	invalid.Kind = "unsupported"
+	if _, err := s.PushAnnotations(ctx, user.ID, "device", []store.AnnotationWrite{fresh, invalid}, 2000); err == nil {
+		t.Fatal("expected annotation constraint failure")
+	}
+	probe.check(t, user.ID, "")
+	page, err := s.AnnotationChanges(ctx, user.ID, 0, 10)
+	if err != nil || len(page.Annotations) != 1 || page.HighWater != 3 {
+		t.Fatalf("failed annotation batch was not rolled back: %+v, %v", page, err)
+	}
+	probe.read = func(ctx context.Context) {
+		page, err := s.AnnotationChanges(ctx, user.ID, 3, 10)
+		if err != nil || len(page.Annotations) != 1 || page.Annotations[0].ID != fresh.ID {
+			t.Errorf("notification preceded mixed annotation commit: %+v, %v", page, err)
+		}
+	}
+	invalid = annWrite("unknown", "no-work", 0)
+	results, err := s.PushAnnotations(ctx, user.ID, "device", []store.AnnotationWrite{invalid, fresh, fresh}, 2000)
+	if err != nil || len(results) != 3 || results[0].Status != "invalid" ||
+		results[1].Status != "applied" || results[2].Status != "duplicate" {
+		t.Fatalf("mixed annotation batch: %+v, %v", results, err)
+	}
+	probe.check(t, user.ID, store.TopicAnnotations)
+}
+
+func notificationSession(workID string) store.Session {
+	start := time.Unix(1754800000, 0)
+	return store.Session{
+		SessionID: "session1", WorkID: workID, DeviceID: "device",
+		StartedAt: start, EndedAt: start.Add(time.Minute),
+		StartProg: 0.1, EndProg: 0.2, Origin: store.OriginNative,
+	}
+}
+
+func testSessionNotifications(t *testing.T, open OpenFunc) {
+	s, user, work, probe := notificationFixture(t, open)
+	ctx := context.Background()
+	session := notificationSession(work.ID)
+	wantCount := 1
+	probe.read = func(ctx context.Context) {
+		sessions, err := s.SessionsForWork(ctx, user.ID, work.ID, 10)
+		if err != nil || len(sessions) != wantCount {
+			t.Errorf("notification preceded session commit: %+v, %v", sessions, err)
+		}
+	}
+	for _, topic := range []store.Topic{store.TopicInsights, ""} {
+		if err := s.AppendSessions(ctx, user.ID, []store.Session{session}); err != nil {
+			t.Fatal(err)
+		}
+		probe.check(t, user.ID, topic)
+	}
+	fresh := session
+	fresh.SessionID = "session2"
+	for _, unknown := range []bool{false, true} {
+		bad := session
+		bad.EndProg = 0.9
+		wantErr := store.ErrIDMismatch
+		if unknown {
+			bad.SessionID, bad.WorkID = "unknown", "no-work"
+			wantErr = store.ErrNotFound
+		}
+		if err := s.AppendSessions(ctx, user.ID, []store.Session{fresh, bad}); !errors.Is(err, wantErr) {
+			t.Fatalf("rejected batch: %v", err)
+		}
+		probe.check(t, user.ID, "")
+		sessions, err := s.SessionsForWork(ctx, user.ID, work.ID, 10)
+		if err != nil || len(sessions) != 1 {
+			t.Fatalf("failed session batch was not rolled back: %+v, %v", sessions, err)
+		}
+	}
+	wantCount = 2
+	badEdition := fresh
+	badEdition.EditionSHA = Ptr("unknown-edition")
+	if err := s.AppendSessions(ctx, user.ID, []store.Session{badEdition}); err == nil {
+		t.Fatal("expected deferred foreign-key failure at commit")
+	}
+	probe.check(t, user.ID, "")
+	if err := s.AppendSessions(ctx, user.ID, []store.Session{session, fresh}); err != nil {
+		t.Fatal(err)
+	}
+	probe.check(t, user.ID, store.TopicInsights)
+	if err := s.AppendSessions(ctx, user.ID, nil); err != nil {
+		t.Fatal(err)
+	}
+	probe.check(t, user.ID, "")
+}
+
+func testInferredNotifications(t *testing.T, open OpenFunc, existing bool) {
+	s, user, work, probe := notificationFixture(t, open)
+	ctx := context.Background()
+	for i, id := range []string{"op1", "op2"} {
+		op := store.Op{
+			OpID: id, ClientTS: time.Now(), Progression: float64(i) / 10,
+			Origin: store.OriginKosync, OriginAlias: Ptr("partial-md5:md5-w1"),
+		}
+		if _, err := s.AppendKosyncOp(ctx, user.ID, "md5-w1", "device", op); err != nil {
+			t.Fatal(err)
+		}
+		probe.check(t, user.ID, store.TopicPositions)
+	}
+	ops, err := s.PendingInferenceOps(ctx, user.ID)
+	if err != nil || len(ops) != 2 {
+		t.Fatalf("pending ops: %+v, %v", ops, err)
+	}
+	group := store.InferredSessionGroup{Session: infer.Materialize(user.ID, ops), Ops: ops}
+	if existing {
+		if err := s.AppendSessions(ctx, user.ID, []store.Session{group.Session}); err != nil {
+			t.Fatal(err)
+		}
+		probe.check(t, user.ID, store.TopicInsights)
+	}
+	probe.read = func(ctx context.Context) {
+		sessions, err := s.SessionsForWork(ctx, user.ID, work.ID, 10)
+		if err != nil || len(sessions) != 1 || sessions[0].SessionID != group.Session.SessionID {
+			t.Errorf("notification preceded inferred session commit: %+v, %v", sessions, err)
+		}
+		pending, err := s.PendingInferenceOps(ctx, user.ID)
+		if err != nil || len(pending) != 0 {
+			t.Errorf("notification preceded inference stamps: %+v, %v", pending, err)
+		}
+	}
+	staleOps := slices.Clone(ops)
+	staleOps[0].Seq++
+	stale := store.InferredSessionGroup{Session: group.Session, Ops: staleOps}
+	if err := s.AppendInferredSession(ctx, user.ID, stale); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("stale inference: %v", err)
+	}
+	probe.check(t, user.ID, "")
+	if err := s.AppendInferredSession(ctx, user.ID, group); err != nil {
+		t.Fatal(err)
+	}
+	topic := store.TopicInsights
+	if existing {
+		topic = ""
+	}
+	probe.check(t, user.ID, topic)
+	probe.read(ctx)
+	if err := s.AppendInferredSession(ctx, user.ID, group); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("inference replay: %v", err)
+	}
+	probe.check(t, user.ID, "")
+}
+
+func testKopluginNotifications(t *testing.T, open OpenFunc, byAlias bool) {
+	s, user, work, probe := notificationFixture(t, open)
+	ctx := context.Background()
+	session := notificationSession(work.ID)
+	session.Origin, session.SourceKey = store.OriginKoplugin, Ptr("device|md5-w1|42|1754800000")
+	upsert := func(ses store.Session) (string, error) {
+		if byAlias {
+			return s.UpsertKopluginSessionByAlias(ctx, user.ID, "md5-w1", ses)
+		}
+		return s.UpsertKopluginSession(ctx, user.ID, ses)
+	}
+	wantCount := 1
+	probe.read = func(ctx context.Context) {
+		sessions, err := s.SessionsForWork(ctx, user.ID, work.ID, 10)
+		if err != nil || len(sessions) != wantCount {
+			t.Errorf("notification preceded koplugin commit: %+v, %v", sessions, err)
+		}
+		current, err := s.CurrentSessionsForWork(ctx, user.ID, work.ID, 10)
+		wantID := "session1"
+		if wantCount == 2 {
+			wantID = "session2"
+		}
+		if err != nil || len(current) != 1 || current[0].SessionID != wantID {
+			t.Errorf("notification preceded koplugin supersession commit: %+v, %v", current, err)
+		}
+	}
+	for _, status := range []string{"inserted", "duplicate", "superseded", "duplicate"} {
+		switch status {
+		case "superseded":
+			session.SessionID, session.EndProg, wantCount = "session2", 0.3, 2
+		case "duplicate":
+			// Replay the original revision, including after supersession.
+			session.SessionID, session.EndProg = "session1", 0.2
+		}
+		got, err := upsert(session)
+		if err != nil || got != status {
+			t.Fatalf("want %s, got %s, %v", status, got, err)
+		}
+		topic := store.TopicInsights
+		if status == "duplicate" {
+			topic = ""
+		}
+		probe.check(t, user.ID, topic)
+	}
+	bad := session
+	bad.SessionID, bad.EditionSHA = "bad-session", Ptr("unknown-edition")
+	if _, err := upsert(bad); err == nil {
+		t.Fatal("expected foreign-key failure")
+	}
+	probe.check(t, user.ID, "")
+	sessions, err := s.SessionsForWork(ctx, user.ID, work.ID, 10)
+	if err != nil || len(sessions) != 2 {
+		t.Fatalf("failed koplugin write changed sessions: %+v, %v", sessions, err)
+	}
+}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -24,6 +24,7 @@ const anyReader = ""
 
 // Run executes the full suite.
 func Run(t *testing.T, open OpenFunc) {
+	t.Run("Notifications", func(t *testing.T) { testNotifications(t, open) })
 	t.Run("Users", func(t *testing.T) { testUsers(t, open) })
 	t.Run("AdminRole", func(t *testing.T) { testAdminRole(t, open) })
 	t.Run("ConcurrentAdminDemotion", func(t *testing.T) {

--- a/internal/webui/reader.templ
+++ b/internal/webui/reader.templ
@@ -208,6 +208,13 @@ templ readerPage(v ReaderView, csrf string) {
 			</header>
 			<div class="reader-progress"><div id="reader-progress-bar"></div></div>
 			<p id="reader-status" class="reader-status">Loading…</p>
+			<aside id="reader-catchup" class="reader-catchup" aria-label="Reading position on another device" hidden>
+				<p id="reader-catchup-text" role="status" aria-live="polite"></p>
+				<div>
+					<button type="button" id="reader-catchup-accept">Continue there</button>
+					<button type="button" id="reader-catchup-dismiss">Stay here</button>
+				</div>
+			</aside>
 			// The table of contents, filled in from the publication's own
 			// navigation once the book is open. A drawer over the left
 			// edge, the way Komga does it: every entry is the book's, so

--- a/internal/webui/readerbrowser_ext_test.go
+++ b/internal/webui/readerbrowser_ext_test.go
@@ -375,11 +375,43 @@ func seedStalePosition(t *testing.T, base string, cookie *http.Cookie, bookID st
 // developer's check rather than a gate. That is the right trade: the
 // alternative is either a browser in CI for one test or shipping a
 // renderer nobody ever ran.
+func TestReaderLiveInARealBrowser(t *testing.T) {
+	chrome := findChrome()
+	if chrome == "" {
+		t.Skip("no chromium; set LISEUR_CHROME to run the browser check")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("no node to drive the browser with")
+	}
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "live-novel", browserTestEPUB(t))
+	ts := httptest.NewUnstartedServer(nil)
+	wholeServer(t, f, ts, "")
+	cookie := f.loginTo(t, ts, "alice")
+	seedStalePosition(t, ts.URL, cookie, bookID)
+	cmd := exec.Command(node, filepath.Join("testdata", "readerbrowser.mjs"))
+	cmd.Env = append(os.Environ(),
+		"SMOKE_CHROME="+chrome,
+		"SMOKE_URL="+ts.URL+"/ui/books/"+bookID+"/read",
+		"SMOKE_COOKIE="+cookie.Name+"="+cookie.Value,
+		"SMOKE_HOST="+strings.TrimPrefix(ts.URL, "http://"),
+		"SMOKE_LIVE=1",
+		"SMOKE_SHOT="+os.Getenv("LISEUR_READER_SCREENSHOT"),
+	)
+	out, err := cmd.CombinedOutput()
+	t.Logf("%s", out)
+	if err != nil {
+		t.Fatalf("live reader did not work in a browser: %v", err)
+	}
+}
+
 func TestReaderOpensInARealBrowser(t *testing.T) {
 	chrome := findChrome()
 	if chrome == "" {
 		t.Skip("no chromium; set LISEUR_CHROME to run the browser check")
 	}
+
 	node, err := exec.LookPath("node")
 	if err != nil {
 		t.Skip("no node to drive the browser with")

--- a/internal/webui/readerlive_ext_test.go
+++ b/internal/webui/readerlive_ext_test.go
@@ -1,0 +1,19 @@
+package webui_test
+
+import "testing"
+
+func TestReaderLiveTransport(t *testing.T) {
+	runNodeTests(t, "readerlive.test.mjs")
+}
+
+func TestReaderLiveState(t *testing.T) {
+	runNodeTests(t, "readersync.test.mjs")
+}
+
+func TestReaderCredentialLifecycle(t *testing.T) {
+	runNodeTests(t, "readerauth.test.mjs")
+}
+
+func TestReaderAnnotationReplacement(t *testing.T) {
+	runNodeTests(t, "readerannotations.test.mjs")
+}

--- a/internal/webui/readerorigin_ext_test.go
+++ b/internal/webui/readerorigin_ext_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/chmouel/liseur-sync/internal/auth"
 	"github.com/chmouel/liseur-sync/internal/config"
 	"github.com/chmouel/liseur-sync/internal/content"
+	"github.com/chmouel/liseur-sync/internal/live"
+	"github.com/chmouel/liseur-sync/internal/store"
 	"github.com/chmouel/liseur-sync/internal/webui"
 )
 
@@ -52,9 +54,14 @@ func wholeServer(t *testing.T, f *booksFixture, ts *httptest.Server, readerOrigi
 	cfg := f.cfg
 	cfg.ReaderOrigin = readerOrigin
 	cfg.InsecureHTTP = true
+	hub := live.NewHub(8)
+	if notifying, ok := f.st.(store.ChangeNotifying); ok {
+		notifying.SetChangeNotifier(hub)
+	}
 
 	apiSrv := &api.Server{
 		St: f.st, Auth: auth.NewService(f.st), Cfg: cfg,
+		Live:         hub,
 		LoginLimiter: auth.NewRateLimiter(100, time.Minute),
 		OPDSLimiter:  auth.NewRateLimiter(100, time.Minute),
 		Files:        content.NewFiles(f.st), Covers: f.cache,
@@ -66,7 +73,10 @@ func wholeServer(t *testing.T, f *booksFixture, ts *httptest.Server, readerOrigi
 	}
 	ts.Config = &http.Server{Handler: apiSrv.Handler(), ReadHeaderTimeout: time.Minute}
 	ts.Start()
-	t.Cleanup(ts.Close)
+	t.Cleanup(func() {
+		hub.Close()
+		ts.Close()
+	})
 }
 
 // ask sends a request to ts pretending it arrived at host, which is the

--- a/internal/webui/static/reader-annotations.js
+++ b/internal/webui/static/reader-annotations.js
@@ -1,0 +1,69 @@
+export function annotationCFI(a) {
+  const fragments = a?.locator?.locations?.fragments;
+  if (!Array.isArray(fragments)) return null;
+  return fragments.find((s) => typeof s === "string" && s.startsWith("epubcfi(")) || null;
+}
+
+// foliate's add/delete calls yield while resolving a CFI. One queue owns all
+// overlay mutations so an old add cannot land after a new set removed it.
+export function annotationRenderer({ getView, current, changed }) {
+  let annotations = [], colors = new Map(), failed = new Set();
+  let epoch = 0, identity = null, chain = Promise.resolve();
+  const drawn = new Map();
+  const valid = (run, stamp) => run === epoch && current(stamp);
+  const queue = (fn) => {
+    chain = chain.catch(() => {}).then(fn);
+    return chain;
+  };
+  const removeAll = async () => {
+    for (const [view, cfis] of drawn) {
+      for (const cfi of cfis) {
+        try { await view.deleteAnnotation({ value: cfi }); } catch { /* stale CFI */ }
+      }
+    }
+    drawn.clear();
+  };
+  const draw = async (run, stamp) => {
+    if (!valid(run, stamp)) return;
+    const view = getView();
+    if (!view) return;
+    for (const a of annotations) {
+      if (!valid(run, stamp) || view !== getView()) return;
+      const cfi = annotationCFI(a);
+      if (a.kind !== "highlight" || !cfi || failed.has(a.id)) continue;
+      colors.set(cfi, a.color);
+      if (!drawn.has(view)) drawn.set(view, new Set());
+      drawn.get(view).add(cfi);
+      try { await view.addAnnotation({ value: cfi }); }
+      catch { if (valid(run, stamp)) failed.add(a.id); }
+    }
+    if (valid(run, stamp)) changed();
+  };
+  return {
+    annotations: () => annotations,
+    failed: (id) => failed.has(id),
+    color: (cfi) => colors.get(cfi),
+    replace(next, stamp) {
+      const run = ++epoch;
+      identity = stamp;
+      return queue(async () => {
+        await removeAll();
+        colors.clear(); failed.clear();
+        if (!valid(run, stamp)) return;
+        annotations = next;
+        changed();
+        await draw(run, stamp);
+      });
+    },
+    clear() {
+      ++epoch;
+      annotations = []; colors.clear(); failed.clear();
+      changed();
+      return queue(removeAll);
+    },
+    draw() {
+      const run = epoch, stamp = identity;
+      return queue(() => draw(run, stamp));
+    },
+  };
+}

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -534,6 +534,7 @@ async function push() {
       keepalive: true,
       body: JSON.stringify({ ops: [op] }),
     });
+    stamp.identity = auth.responseIdentity(resp) || stamp.identity;
     if (!resp.ok || !current(stamp) || !auth.responseCurrent(resp)) return;
     const out = await resp.json().catch(() => null);
     if (!current(stamp) || !auth.responseCurrent(resp)) return;
@@ -669,6 +670,7 @@ async function pushSession(closing) {
       keepalive: true,
       body: JSON.stringify({ sessions: batch }),
     });
+    stamp.identity = auth.responseIdentity(resp) || stamp.identity;
     // 2xx: filed (re-posting the same payload is idempotently a 2xx too).
     // 409: this session_id was already used with a *different* payload —
     // a collision, not a repeat of this sitting — and replaying the same

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -102,7 +102,6 @@ const auth = readerAuth({
   ...cfg,
   handed: cfg.handed,
   onChange(identity, previous) {
-    lifecycle++;
     catchup.bind(identity.account, workID, identity.device);
     hideCatchup();
     if (!previous) return;
@@ -110,6 +109,11 @@ const auth = readerAuth({
     live.stop();
     annotationDrawing.clear().catch(() => {});
     if (previous.account !== identity.account) {
+      // A same-account renewal already invalidates old-credential
+      // responses through auth.current(); only an actual account
+      // switch needs the page lifecycle to advance, or a write settled
+      // under the fresh token would be requeued as if it never landed.
+      lifecycle++;
       auth.stop(); // A page opened for one account never writes under another.
       return;
     }
@@ -242,6 +246,10 @@ catchupAccept?.addEventListener("click", async () => {
   if (!shown || !view) return;
   cancelScheduledPush();
   await settlePosition();
+  // A failed flush leaves the local page dirty on purpose, so adopting
+  // the remote offer now would lose it for good the moment retryOp and
+  // readingDirty are cleared below.
+  if (readingDirty) return;
   const stamp = snapshot();
   const op = current(stamp) ? catchup.accept(shown) : null;
   if (!op || !view) return;
@@ -1906,6 +1914,15 @@ function handleKeys(e) {
       e.preventDefault();
       toggleTOC(false);
     }
+    return;
+  }
+  // The catch-up offer never takes focus, so Escape typed in the
+  // publication (a separate document) or on the page must still reach
+  // it, the same as the drawer above.
+  if (catchupPanel && !catchupPanel.hidden && e.key === "Escape") {
+    e.preventDefault();
+    catchup.dismiss();
+    hideCatchup();
     return;
   }
   // "?" summons the help from anywhere, including from inside a

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -16,6 +16,10 @@ import "./vendor/foliate/view.js";
 import { Overlayer } from "./vendor/foliate/overlayer.js";
 import { openSession } from "./reader-session.js";
 import { positionTable, pageAt, pageLocation } from "./reader-positions.js";
+import { readerAuth } from "./reader-auth.js";
+import { liveStream } from "./reader-live.js";
+import { catchupState, topicRefresh } from "./reader-sync.js";
+import { annotationCFI, annotationRenderer } from "./reader-annotations.js";
 
 const el = document.getElementById("reader-config");
 // Every URL is relative, computed server-side, so the reader keeps
@@ -66,11 +70,21 @@ const fullscreenBtn = document.getElementById("reader-fullscreen");
 
 let view = null;
 let workID = null;
-let token = null;
-let tokenExpiry = 0;
 let pending = null;
 let here = null;
 let faviconObjectURL = null;
+let ready = false;
+let readingDirty = false;
+let interactionPending = false;
+let restoring = true;
+let lifecycle = 0;
+let activityGeneration = 0;
+let syncExpired = false;
+const catchup = catchupState();
+const catchupPanel = document.getElementById("reader-catchup");
+const catchupText = document.getElementById("reader-catchup-text");
+const catchupAccept = document.getElementById("reader-catchup-accept");
+const catchupDismiss = document.getElementById("reader-catchup-dismiss");
 // The book's positions, counted once when it opens. Null for a book
 // this recipe cannot measure, which leaves the engine's own locations
 // to say what page it is.
@@ -84,55 +98,50 @@ function say(message, isError) {
 
 // ------------------------------------------------------------ auth
 
-// credential keeps a live reader token. It re-mints rather than
-// refreshes, because there is no refresh token to steal: the session
-// cookie is the thing that proves the browser may ask.
-async function credential() {
-  if (token && Date.now() < tokenExpiry - 60000) return token;
-  if (cfg.detached) {
-    // Nothing on this origin can prove who the reader is, so there is
-    // no re-minting here: the token was handed over once and when it
-    // is gone the reader has to be opened from the library again. That
-    // is the price of a hostname with no session on it.
-    if (!cfg.handed)
-      throw new Error(
-        "this reading session has expired; open the book from your library again",
-      );
-    token = cfg.handed;
-    // Once it has been refused there is no second one to ask for, so
-    // the next attempt reports that plainly instead of looping.
-    cfg.handed = null;
-    tokenExpiry = Date.now() + 86400000;
-    return token;
-  }
-  const resp = await fetch(cfg.tokenURL, {
-    method: "POST",
-    headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    body: new URLSearchParams({ csrf: cfg.csrf }),
-  });
-  if (!resp.ok) throw new Error("could not obtain a reading credential");
-  const got = await resp.json();
-  token = got.token;
-  tokenExpiry = Date.parse(got.expires_at) || Date.now() + 3600000;
-  return token;
-}
+const auth = readerAuth({
+  ...cfg,
+  handed: cfg.handed,
+  onChange(identity, previous) {
+    lifecycle++;
+    catchup.bind(identity.account, workID, identity.device);
+    hideCatchup();
+    if (!previous) return;
+    refreshes.reset();
+    live.stop();
+    annotationDrawing.clear().catch(() => {});
+    if (previous.account !== identity.account) {
+      auth.stop(); // A page opened for one account never writes under another.
+      return;
+    }
+    if (ready && !document.hidden) startLive();
+  },
+  onExhausted(err) {
+    syncExpired = true;
+    ready = false;
+    lifecycle++;
+    workID = null;
+    session = null;
+    unsent = [];
+    retryOp = null;
+    readingDirty = false;
+    cancelScheduledPush();
+    refreshes.stop();
+    live.stop();
+    catchup.bind(null, null, null);
+    hideCatchup();
+    annotationDrawing.clear().catch(() => {});
+    say(err.message, true);
+  },
+});
+cfg.handed = null;
+const api = (path, options) => auth.request(path, options);
 
-// api retries once on 401, which is the whole of the token lifecycle a
-// client has to implement: expired means ask again, not sign in again.
-async function api(path, options = {}, retry = true) {
-  const secret = await credential();
-  const resp = await fetch(cfg.apiBase + path, {
-    ...options,
-    headers: {
-      ...(options.headers || {}),
-      Authorization: "Bearer " + secret,
-    },
-  });
-  if (resp.status === 401 && retry) {
-    token = null;
-    return api(path, options, false);
-  }
-  return resp;
+function snapshot() {
+  return { identity: auth.identity(), work: workID, view, lifecycle };
+}
+function current(stamp) {
+  return stamp && auth.current(stamp.identity) && stamp.work === workID &&
+    stamp.view === view && stamp.lifecycle === lifecycle;
 }
 
 // ------------------------------------------------------------ sync
@@ -147,18 +156,116 @@ async function resolveWork() {
     },
   );
   if (!resp.ok) return null;
-  return (await resp.json()).work_id || null;
+  const data = await resp.json();
+  return auth.responseCurrent(resp) ? data.work_id || null : null;
 }
 
 async function lastPosition() {
-  if (!workID) return null;
+  if (!workID) return { ok: false };
+  const work = workID;
+  const stamp = snapshot();
   const resp = await api(
-    "v1/works/" + encodeURIComponent(workID) + "/positions?limit=1",
+    "v1/works/" + encodeURIComponent(work) + "/positions?limit=1",
   );
-  if (!resp.ok) return null;
+  if (!resp.ok) return { ok: false };
+  stamp.identity = auth.responseIdentity(resp);
   const ops = (await resp.json()).ops || [];
-  return ops.length ? ops[0] : null;
+  if (work !== workID || !current(stamp)) return { ok: false };
+  return { ok: true, op: ops.length ? ops[0] : null };
 }
+
+// ------------------------------------------------------------- live
+
+function hideCatchup() {
+  if (!catchupPanel) return;
+  const focused = catchupPanel.contains(document.activeElement);
+  catchupPanel.hidden = true;
+  if (focused) {
+    stage.tabIndex = -1;
+    stage.focus({ preventScroll: true });
+  }
+}
+
+function showCatchup() {
+  const offer = catchup.offer();
+  if (!offer || !catchupPanel) return;
+  const fraction = offer.op.progression;
+  catchupText.textContent = finite(fraction)
+    ? `Continue from ${Math.round(fraction * 100)}% read on another device?`
+    : "Continue from the position read on another device?";
+  catchupPanel.hidden = false;
+}
+
+const refreshes = topicRefresh({
+  async refresh(topic) {
+    if (!ready || document.hidden || !workID) return false;
+    const run = lifecycle;
+    const activity = activityGeneration;
+    if (topic === "annotations") return loadAnnotations();
+    const result = await lastPosition();
+    if (!result.ok || document.hidden || run !== lifecycle ||
+        activity !== activityGeneration) return false;
+    catchup.observe(result.op);
+    showCatchup(); // The state allows this only after hidden -> visible.
+    return true;
+  },
+});
+const live = liveStream({
+  request: api,
+  current: (resp) => ready && !document.hidden && auth.responseCurrent(resp),
+  onTopics: (topics) => refreshes.owe(topics),
+});
+
+function startLive() {
+  if (!workID) return;
+  refreshes.start();
+  // This also refreshes on resume against a server without /v1/events.
+  refreshes.owe(["positions", "annotations"]);
+  live.start();
+}
+
+catchupDismiss?.addEventListener("click", () => {
+  catchup.dismiss();
+  hideCatchup();
+});
+catchupPanel?.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    catchup.dismiss();
+    hideCatchup();
+  }
+});
+catchupAccept?.addEventListener("click", async () => {
+  const shown = catchup.shown();
+  const stamp = snapshot();
+  const op = current(stamp) ? catchup.accept(shown) : null;
+  const activity = activityGeneration;
+  hideCatchup();
+  if (!op || !view) return;
+  cancelScheduledPush();
+  retryOp = null;
+  readingDirty = false;
+  interactionPending = false;
+  // Close the old sitting at its actual page, not at the remote destination.
+  endSession();
+  restoring = true;
+  try {
+    for (const target of startCandidates(op)) {
+      if (!current(stamp) || document.hidden || activity !== activityGeneration) break;
+      try {
+        const resolved = await view.resolveNavigation(target);
+        if (!current(stamp) || document.hidden || activity !== activityGeneration) break;
+        // goTo catches anchor failures internally; use the renderer so a stale
+        // CFI actually descends to the existing fraction/href fallback.
+        await view.renderer.goTo(resolved);
+        break;
+      } catch { /* try the coarser locator */ }
+    }
+  } finally {
+    restoring = false;
+    // A restored page starts accounting only when the reader next interacts.
+  }
+});
 
 // ------------------------------------------------------ annotations
 
@@ -183,53 +290,20 @@ const ANNOTATION_COLORS = {
   orange: "#ffb74d",
 };
 
-let annotations = []; // the live set, in the server's progression order
-const annColorByCFI = new Map(); // overlayer key -> validated palette token
-const annFailed = new Set(); // annotation ids whose CFI did not anchor
-
-function annotationCFI(a) {
-  const fragments =
-    (a && a.locator && a.locator.locations && a.locator.locations.fragments) ||
-    [];
-  for (const fragment of fragments) {
-    if (typeof fragment === "string" && fragment.indexOf("epubcfi(") === 0) {
-      return fragment;
-    }
-  }
-  return null;
-}
-
-// drawAnnotations (re)offers every drawable highlight to the engine.
-// addAnnotation draws into any chapter that is on screen and is a
-// no-op for the ones that are not, so this runs once after the fetch
-// and again on every create-overlay as chapters arrive. A CFI that
-// fails to anchor moves its annotation to the sidebar instead.
-async function drawAnnotations() {
-  if (!view) return;
-  let degraded = false;
-  for (const a of annotations) {
-    if (a.kind !== "highlight" || annFailed.has(a.id)) continue;
-    const cfi = annotationCFI(a);
-    if (!cfi) continue;
-    annColorByCFI.set(cfi, a.color);
-    try {
-      await view.addAnnotation({ value: cfi });
-    } catch (err) {
-      annFailed.add(a.id);
-      degraded = true;
-    }
-  }
-  if (degraded) buildAnnotationList();
-}
+const annotationDrawing = annotationRenderer({
+  getView: () => view,
+  current,
+  changed: buildAnnotationList,
+});
 
 // buildAnnotationList fills the sidebar with the entries that do not
 // draw over the text. Excerpts and bodies are set as text nodes only.
 function buildAnnotationList() {
   if (!annPanel || !annList) return;
   annList.textContent = "";
-  const listed = annotations.filter(
+  const listed = annotationDrawing.annotations().filter(
     (a) =>
-      a.kind !== "highlight" || !annotationCFI(a) || annFailed.has(a.id),
+      a.kind !== "highlight" || !annotationCFI(a) || annotationDrawing.failed(a.id),
   );
   annPanel.hidden = !listed.length;
   if (!listed.length) return;
@@ -244,7 +318,7 @@ function buildAnnotationList() {
       entry.href = "#";
       entry.addEventListener("click", (e) => {
         e.preventDefault();
-        noteActivity();
+        if (!noteNavigation()) return;
         toggleTOC(false);
         if (!view) return;
         const fall = () => {
@@ -278,18 +352,19 @@ function buildAnnotationList() {
 // loadAnnotations is best-effort like every other sync call: a reader
 // on a server without the routes, or offline, still reads the book.
 async function loadAnnotations() {
-  if (!workID || !view) return;
-  try {
-    const resp = await api(
-      "v1/works/" + encodeURIComponent(workID) + "/annotations",
-    );
-    if (!resp.ok) return;
-    annotations = (await resp.json()).annotations || [];
-  } catch (err) {
-    return; /* offline: the book reads without its annotations */
-  }
-  buildAnnotationList();
-  await drawAnnotations();
+  if (!workID || !view) return false;
+  const work = workID;
+  const stamp = snapshot();
+  const resp = await api("v1/works/" + encodeURIComponent(work) + "/annotations");
+  // An old server without annotation support is not a failing refresh.
+  if ([404, 501].includes(resp.status)) return true;
+  if (!resp.ok) return false;
+  stamp.identity = auth.responseIdentity(resp);
+  const data = await resp.json();
+  if (!current(stamp) || work !== workID || document.hidden) return false;
+  if (!Array.isArray(data.annotations)) return false;
+  await annotationDrawing.replace(data.annotations, stamp);
+  return current(stamp);
 }
 
 // bookTitle is read from the package document rather than from the
@@ -423,7 +498,8 @@ function scheduleFractionRetry() {
 }
 
 async function push() {
-  if (!workID || !here) return;
+  if (!workID || !here || !readingDirty || restoring) return;
+  const stamp = snapshot();
   const locator = locatorFor(here);
   // A non-finite fraction has no position to record. Return without
   // touching retryOp; the layout retry below will prod the engine for
@@ -448,6 +524,7 @@ async function push() {
           locator: locator,
         };
   retryOp = { key, op };
+  catchup.wrote(op);
   try {
     const resp = await api("v1/ops", {
       method: "POST",
@@ -457,8 +534,9 @@ async function push() {
       keepalive: true,
       body: JSON.stringify({ ops: [op] }),
     });
-    if (!resp.ok) return;
+    if (!resp.ok || !current(stamp) || !auth.responseCurrent(resp)) return;
     const out = await resp.json().catch(() => null);
+    if (!current(stamp) || !auth.responseCurrent(resp)) return;
     const status =
       out && out.results && out.results[0] && out.results[0].status;
     if (
@@ -471,7 +549,12 @@ async function push() {
     // Only this op's own outcome may clear it: a slower response
     // arriving after the reader has moved on must not discard the op
     // a newer push is still responsible for.
-    if (retryOp && retryOp.op === op) retryOp = null;
+    if (retryOp && retryOp.op === op) {
+      retryOp = null;
+      // A newer local page still needs its own push.
+      if (locatorFor(here)?.locations.fragments[0] === locator.locations.fragments[0] &&
+          here.fraction === locator.locations.totalProgression) readingDirty = false;
+    }
   } catch (err) {
     /* offline: the next page turn replays this exact op */
   }
@@ -497,6 +580,7 @@ function opID() {
 }
 
 function schedulePush() {
+  if (!readingDirty || restoring) return;
   cancelScheduledPush();
   pending = setTimeout(push, 1500);
 }
@@ -529,6 +613,9 @@ function beginSession() {
 }
 
 function noteActivity() {
+  activityGeneration++;
+  if (document.hidden || restoring) return;
+  interactionPending = true;
   if (session) {
     session.activity(performance.now(), here && here.fraction);
   } else {
@@ -537,12 +624,19 @@ function noteActivity() {
   if (unsent.length) pushSession();
 }
 
+function noteNavigation() {
+  if (!view || restoring || document.hidden) return false;
+  noteActivity();
+  catchup.moved();
+  hideCatchup();
+  return true;
+}
+
 // noteProgress follows a relocate. It is not activity: the engine
 // relocates on a resize or a font change too, and only a key, a tap or
 // a scroll says somebody was there.
 function noteProgress() {
   if (session) session.progress(here && here.fraction);
-  else beginSession();
 }
 
 function endSession() {
@@ -566,6 +660,7 @@ let sessionInFlight = false;
 async function pushSession(closing) {
   if (!unsent.length || (sessionInFlight && !closing)) return;
   const batch = unsent.slice();
+  const stamp = snapshot();
   sessionInFlight = true;
   try {
     const resp = await api("v1/sessions", {
@@ -580,7 +675,8 @@ async function pushSession(closing) {
     // batch cannot fix that. Any other 4xx is a payload the server will
     // refuse however often it is sent — an unknown work, say. Only a
     // server error or no answer at all leaves the batch to try again.
-    if (resp.ok || (resp.status >= 400 && resp.status < 500)) {
+    if (current(stamp) && auth.responseCurrent(resp) &&
+        (resp.ok || (resp.status >= 400 && resp.status < 500))) {
       unsent = unsent.filter((p) => !batch.includes(p));
     }
   } catch (err) {
@@ -591,17 +687,33 @@ async function pushSession(closing) {
 }
 
 document.addEventListener("visibilitychange", () => {
+  lifecycle++;
   if (document.hidden) {
+    live.stop();
+    refreshes.stop();
+    catchup.hide();
+    hideCatchup();
+    cancelScheduledPush();
+    push();
     endSession();
     return;
   }
+  catchup.resume();
+  if (ready) startLive();
   beginSession();
   if (here && !finite(here.fraction)) {
     fractionRetryAttempt = 0;
     scheduleFractionRetry();
   }
 });
-window.addEventListener("pagehide", endSession);
+window.addEventListener("pagehide", () => {
+  lifecycle++;
+  live.stop();
+  refreshes.stop();
+  catchup.hide();
+  hideCatchup();
+  endSession();
+});
 
 function cfiOf(op) {
   const fragments =
@@ -651,7 +763,7 @@ function startCandidates(op) {
     typeof locations.totalProgression === "number"
       ? locations.totalProgression
       : op.progression;
-  if (typeof fraction === "number" && fraction > 0) {
+  if (finite(fraction) && fraction >= 0) {
     out.push({ fraction: Math.min(0.999, fraction) });
   }
   const href = op.locator && op.locator.href;
@@ -1189,7 +1301,7 @@ function wireChapterPointer(doc) {
   );
   // A scroll is the one way to move through a book that is neither a
   // key nor a tap, so it counts as activity for the sitting.
-  doc.addEventListener("wheel", noteActivity, { passive: true });
+  doc.addEventListener("wheel", () => noteNavigation(), { passive: true });
   doc.addEventListener(
     "pointerdown",
     (e) => {
@@ -1483,6 +1595,7 @@ if (gotoForm) {
     e.preventDefault();
     const val = parseFloat(gotoInput.value);
     if (!Number.isFinite(val)) return;
+    if (!noteNavigation()) return;
     if (gotoKind === "percent") {
       const pct = Math.min(Math.max(val, 0), 100);
       if (view) await view.goToFraction(pct / 100).catch(() => {});
@@ -1587,7 +1700,7 @@ tocList.addEventListener("click", (e) => {
   const a = e.target && e.target.closest && e.target.closest("a[data-href]");
   if (!a) return;
   e.preventDefault();
-  noteActivity();
+  if (!noteNavigation()) return;
   toggleTOC(false);
   if (view) view.goTo(a.dataset.href).catch(() => {});
 });
@@ -1646,7 +1759,7 @@ function stripScripts(book) {
 }
 
 function turn(direction) {
-  if (!view) return undefined;
+  if (!noteNavigation()) return undefined;
   return direction > 0 ? view.goRight() : view.goLeft();
 }
 
@@ -1755,6 +1868,9 @@ stageArea.addEventListener("click", (e) => {
 // alone goes deaf — the engine re-emits its load event per chapter, so
 // each document gets wired as it arrives.
 function handleKeys(e) {
+  // Native buttons own Space/Enter; the reading shortcuts must not turn the
+  // publication or invalidate the offer while its controls have keyboard focus.
+  if (catchupPanel?.contains(e.target)) return;
   noteActivity();
   if (gotoDialog && gotoDialog.open) return;
   const helpDialog = document.getElementById("reader-help");
@@ -1836,10 +1952,10 @@ function handleKeys(e) {
       toggleChrome();
       break;
     case "Home":
-      if (view) view.goToFraction(0);
+      if (noteNavigation()) view.goToFraction(0);
       break;
     case "End":
-      if (view) view.goToFraction(1);
+      if (noteNavigation()) view.goToFraction(1);
       break;
   }
 }
@@ -1871,8 +1987,16 @@ window.addEventListener("beforeunload", () => {
       paint(e.detail);
       if (finite(e.detail.fraction)) {
         clearFractionRetry();
-        schedulePush();
-        noteProgress();
+        if (!restoring) {
+          if (interactionPending) {
+            interactionPending = false;
+            readingDirty = true;
+            catchup.moved();
+            hideCatchup();
+          }
+          schedulePush();
+          noteProgress();
+        }
       } else {
         cancelScheduledPush();
         scheduleFractionRetry();
@@ -1887,6 +2011,9 @@ window.addEventListener("beforeunload", () => {
       e.detail.doc.addEventListener("keydown", handleKeys);
       wireChapterPointer(e.detail.doc);
     });
+    view.addEventListener("link", (e) => {
+      if (!noteNavigation()) e.preventDefault();
+    });
     // Highlight drawing (ADR-0028): the engine asks how to draw each
     // annotation it anchors, and asks again for every chapter it
     // creates an overlay for. The color is resolved from the palette
@@ -1894,12 +2021,12 @@ window.addEventListener("beforeunload", () => {
     view.addEventListener("draw-annotation", (e) => {
       const { draw, annotation } = e.detail;
       const color =
-        ANNOTATION_COLORS[annColorByCFI.get(annotation.value)] ||
+        ANNOTATION_COLORS[annotationDrawing.color(annotation.value)] ||
         ANNOTATION_COLORS.yellow;
       draw(Overlayer.highlight, { color });
     });
     view.addEventListener("create-overlay", () => {
-      drawAnnotations().catch(() => {});
+      annotationDrawing.draw().catch(() => {});
     });
     await view.open(
       new File([blob], "book.epub", { type: "application/epub+zip" }),
@@ -1928,7 +2055,9 @@ window.addEventListener("beforeunload", () => {
       api("v1/books/" + encodeURIComponent(cfg.bookID) + "/cover?size=icon")
         .then(async (resp) => {
           if (!resp.ok) return;
-          const nextFaviconObjectURL = URL.createObjectURL(await resp.blob());
+          const cover = await resp.blob();
+          if (!auth.responseCurrent(resp)) return;
+          const nextFaviconObjectURL = URL.createObjectURL(cover);
           const link = document.querySelector("link[rel=icon]");
           if (!link) {
             URL.revokeObjectURL(nextFaviconObjectURL);
@@ -1946,7 +2075,11 @@ window.addEventListener("beforeunload", () => {
     let op = null;
     try {
       workID = await resolveWork();
-      op = await lastPosition();
+      const identity = auth.identity();
+      catchup.bind(identity?.account, workID, identity?.device);
+      const result = await lastPosition();
+      if (result.ok) op = result.op;
+      catchup.baseline(op);
     } catch (err) {
       /* read on without sync */
     }
@@ -1969,10 +2102,14 @@ window.addEventListener("beforeunload", () => {
       }
     }
     if (!opened) await view.init({ lastLocation: null });
+    restoring = false;
+    ready = !syncExpired;
+    beginSession();
     // The annotations arrive after the book is on screen: they are
     // decoration on the text, never the reason the text waits.
-    loadAnnotations().catch(() => {});
-    say("");
+    if (ready && !document.hidden) startLive();
+    if (document.hidden) catchup.hide();
+    if (!syncExpired) say("");
   } catch (err) {
     say((err && err.message) || "this book could not be opened", true);
   }

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -237,12 +237,14 @@ catchupPanel?.addEventListener("keydown", (event) => {
 });
 catchupAccept?.addEventListener("click", async () => {
   const shown = catchup.shown();
-  const stamp = snapshot();
-  const op = current(stamp) ? catchup.accept(shown) : null;
   const activity = activityGeneration;
   hideCatchup();
-  if (!op || !view) return;
+  if (!shown || !view) return;
   cancelScheduledPush();
+  await settlePosition();
+  const stamp = snapshot();
+  const op = current(stamp) ? catchup.accept(shown) : null;
+  if (!op || !view) return;
   retryOp = null;
   readingDirty = false;
   interactionPending = false;
@@ -451,6 +453,7 @@ function sectionProgression(location) {
 // has it, and "conflict" means this id already belongs to another
 // payload, where replaying is the one thing that cannot help.
 let retryOp = null;
+let positionInFlight = null;
 let fractionRetryTimer = null;
 let fractionRetryAttempt = 0;
 const FRACTION_RETRY_DELAYS = [250, 750, 1500, 3000, 6000];
@@ -525,8 +528,7 @@ async function push() {
         };
   retryOp = { key, op };
   catchup.wrote(op);
-  try {
-    const resp = await api("v1/ops", {
+  const request = api("v1/ops", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       // keepalive lets the final flush outlive the page: without it a
@@ -534,6 +536,9 @@ async function push() {
       keepalive: true,
       body: JSON.stringify({ ops: [op] }),
     });
+  positionInFlight = request;
+  try {
+    const resp = await request;
     stamp.identity = auth.responseIdentity(resp) || stamp.identity;
     if (!resp.ok || !current(stamp) || !auth.responseCurrent(resp)) return;
     const out = await resp.json().catch(() => null);
@@ -558,7 +563,14 @@ async function push() {
     }
   } catch (err) {
     /* offline: the next page turn replays this exact op */
+  } finally {
+    if (positionInFlight === request) positionInFlight = null;
   }
+}
+
+async function settlePosition() {
+  if (readingDirty && !restoring && !positionInFlight) await push();
+  if (positionInFlight) await positionInFlight;
 }
 
 // opID is a v4 UUID. crypto.randomUUID exists only in a secure

--- a/internal/webui/static/reader-auth.js
+++ b/internal/webui/static/reader-auth.js
@@ -1,0 +1,111 @@
+export const REOPEN_MESSAGE =
+  "this reading session has expired; open the book from your library again";
+
+export function readerAuth({
+  apiBase, tokenURL, csrf, handed, detached, fetcher = (...args) => fetch(...args),
+  now = Date.now, onChange = () => {}, onExhausted = () => {},
+}) {
+  let credential = null, previous = null, flight = null, generation = 0, stopped = false;
+  const responses = new WeakMap();
+  const exhausted = () => {
+    stopped = true;
+    credential = null;
+    generation++;
+    const err = new Error(REOPEN_MESSAGE);
+    err.terminal = true;
+    onExhausted(err);
+    return err;
+  };
+  const current = (identity) => !!identity && !stopped && identity === credential;
+  const acquire = async () => {
+    if (stopped) {
+      const err = new Error(REOPEN_MESSAGE);
+      err.terminal = true;
+      throw err;
+    }
+    if (credential && now() < credential.expires - 60000) return credential;
+    if (flight) return flight;
+    const started = generation;
+    flight = (async () => {
+      let got;
+      if (detached) {
+        if (!handed) throw exhausted();
+        got = { token: handed };
+      } else {
+        const resp = await fetcher(tokenURL, {
+          method: "POST", credentials: "same-origin",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({ csrf }),
+          signal: AbortSignal.timeout(30000),
+        });
+        if ([401, 403].includes(resp.status) || resp.redirected) throw exhausted();
+        if (!resp.ok) throw new Error("could not obtain a reading credential");
+        got = await resp.json();
+      }
+      if (!got.token) throw new Error("missing reading credential");
+      if (stopped || started !== generation) throw new Error("stale reading credential");
+      const resp = await fetcher(apiBase + "v1/token", {
+        headers: { Authorization: "Bearer " + got.token },
+        credentials: "omit", signal: AbortSignal.timeout(30000),
+      });
+      if (resp.status === 401) throw exhausted();
+      // Older servers may lack introspection. A credential-local identity is
+      // conservative: replacement invalidates all state rather than mixing users.
+      if (!resp.ok && ![404, 501].includes(resp.status))
+        throw new Error("could not identify reading credential");
+      const info = resp.ok ? await resp.json() : {};
+      if (stopped || started !== generation) throw new Error("stale reading credential");
+      const old = previous;
+      credential = {
+        secret: got.token,
+        expires: Date.parse(got.expires_at) || (detached ? Infinity : now() + 3600000),
+        account: info.account_id || "credential:" + (generation + 1),
+        device: info.device_id || got.device_id || null,
+        generation: ++generation,
+      };
+      handed = null;
+      previous = credential;
+      onChange(credential, old);
+      if (stopped) {
+        const err = new Error(REOPEN_MESSAGE);
+        err.terminal = true;
+        throw err;
+      }
+      return credential;
+    })().finally(() => { flight = null; });
+    return flight;
+  };
+  return {
+    acquire,
+    stop: () => { if (!stopped) exhausted(); },
+    identity: () => credential,
+    current,
+    responseIdentity: (resp) => responses.get(resp),
+    responseCurrent: (resp) => current(responses.get(resp)),
+    async request(path, options = {}) {
+      let refreshed = false;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const identity = await acquire();
+        options.signal?.throwIfAborted();
+        const resp = await fetcher(apiBase + path, {
+          ...options, credentials: "omit",
+          signal: options.signal || AbortSignal.timeout(30000),
+          headers: { ...options.headers, Authorization: "Bearer " + identity.secret },
+        });
+        if (resp.status !== 401) {
+          responses.set(resp, identity);
+          return resp;
+        }
+        await resp.body?.cancel();
+        // A late refusal for a replaced token must not evict its successor.
+        if (current(identity)) {
+          if (detached || refreshed) throw exhausted();
+          credential = null;
+          refreshed = true;
+        }
+      }
+      // A late refusal of an obsolete token is not a refusal of its successor.
+      throw new Error("reading credential changed during the request");
+    },
+  };
+}

--- a/internal/webui/static/reader-live.js
+++ b/internal/webui/static/reader-live.js
@@ -1,7 +1,7 @@
 // Live events are hints. Neither this parser nor the reconnect loop keeps a cursor.
 export const MAX_FRAME_BYTES = 64 * 1024;
 
-export function eventParser(onTopics, limit = MAX_FRAME_BYTES) {
+export function eventParser(onTopics, limit = MAX_FRAME_BYTES, onRetry = () => {}) {
   const decoder = new TextDecoder("utf-8", { fatal: true });
   let line = "", event = "", data = [], bytes = 0, cr = false;
   const finishLine = () => {
@@ -22,6 +22,9 @@ export function eventParser(onTopics, limit = MAX_FRAME_BYTES) {
       if (value.startsWith(" ")) value = value.slice(1);
       if (field === "event") event = value;
       if (field === "data") data.push(value);
+      // The retry directive takes effect on its own, independent of any
+      // frame it happens to share a blank-line boundary with.
+      if (field === "retry" && /^\d+$/.test(value)) onRetry(Number(value));
     }
     line = "";
   };
@@ -52,13 +55,17 @@ export function eventParser(onTopics, limit = MAX_FRAME_BYTES) {
   };
 }
 
-export function retryDelay(attempt, retryAfter, now = Date.now(), random = Math.random) {
+export function retryDelay(attempt, retryAfter, now = Date.now(), random = Math.random, retryAdviceMS = null) {
   const cap = Math.min(60000, 1000 * 2 ** Math.min(attempt, 6));
   const jitter = cap * (0.5 + random() * 0.5);
-  if (!retryAfter) return jitter;
-  const seconds = /^\d+$/.test(retryAfter.trim()) ? Number(retryAfter) : NaN;
-  const wait = Number.isFinite(seconds) ? seconds * 1000 : Date.parse(retryAfter) - now;
-  return Math.max(jitter, Number.isFinite(wait) ? Math.max(0, wait) : 0);
+  let floor = 0;
+  if (retryAfter) {
+    const seconds = /^\d+$/.test(retryAfter.trim()) ? Number(retryAfter) : NaN;
+    const wait = Number.isFinite(seconds) ? seconds * 1000 : Date.parse(retryAfter) - now;
+    floor = Math.max(floor, Number.isFinite(wait) ? Math.max(0, wait) : 0);
+  }
+  if (Number.isFinite(retryAdviceMS) && retryAdviceMS >= 0) floor = Math.max(floor, retryAdviceMS);
+  return floor ? Math.max(jitter, floor) : jitter;
 }
 
 export function liveStream({
@@ -70,7 +77,7 @@ export function liveStream({
   const connect = async (run) => {
     const abort = new AbortController();
     controller = abort;
-    let watchdog = null, reader = null, retryAfter = null;
+    let watchdog = null, reader = null, retryAfter = null, retryAdviceMS = null;
     const valid = () => active && generation === run && !abort.signal.aborted;
     const touch = () => {
       clearTimer(watchdog);
@@ -98,7 +105,7 @@ export function liveStream({
       }
       const parser = eventParser((topics) => {
         if (valid() && current(resp)) onTopics(topics);
-      });
+      }, undefined, (ms) => { retryAdviceMS = ms; });
       reader = resp.body.getReader();
       for (;;) {
         const { value, done } = await reader.read();
@@ -124,7 +131,7 @@ export function liveStream({
       if (active && generation === run && supported) {
         // A quick 200 followed by EOF is still a failure, not a recovery.
         if (healthy) attempts = 0;
-        const delay = retryDelay(attempts++, retryAfter, now(), random);
+        const delay = retryDelay(attempts++, retryAfter, now(), random, retryAdviceMS);
         // Long Retry-After values must not overflow the platform's timer.
         const deadline = now() + delay;
         const wait = () => {

--- a/internal/webui/static/reader-live.js
+++ b/internal/webui/static/reader-live.js
@@ -1,0 +1,155 @@
+// Live events are hints. Neither this parser nor the reconnect loop keeps a cursor.
+export const MAX_FRAME_BYTES = 64 * 1024;
+
+export function eventParser(onTopics, limit = MAX_FRAME_BYTES) {
+  const decoder = new TextDecoder("utf-8", { fatal: true });
+  let line = "", event = "", data = [], bytes = 0, cr = false;
+  const finishLine = () => {
+    if (!line) {
+      if (event === "invalidate" && data.length) {
+        const value = JSON.parse(data.join("\n"));
+        if (!Array.isArray(value?.topics)) throw new Error("invalid live topics");
+        const topics = [...new Set(value.topics.filter(
+          (t) => t === "positions" || t === "annotations",
+        ))];
+        if (topics.length) onTopics(topics);
+      }
+      event = ""; data = []; bytes = 0;
+    } else if (!line.startsWith(":")) {
+      const colon = line.indexOf(":");
+      const field = colon < 0 ? line : line.slice(0, colon);
+      let value = colon < 0 ? "" : line.slice(colon + 1);
+      if (value.startsWith(" ")) value = value.slice(1);
+      if (field === "event") event = value;
+      if (field === "data") data.push(value);
+    }
+    line = "";
+  };
+  return {
+    feed(chunk) {
+      // Inspect bytes before decoding: even an unterminated line is bounded.
+      for (const byte of chunk) {
+        if (cr && byte === 10) {
+          cr = false;
+          if (bytes && ++bytes > limit) throw new Error("live frame too large");
+          continue;
+        }
+        cr = false;
+        if (++bytes > limit) throw new Error("live frame too large");
+        if (byte === 10 || byte === 13) {
+          line += decoder.decode();
+          finishLine();
+          cr = byte === 13;
+        } else {
+          line += decoder.decode(Uint8Array.of(byte), { stream: true });
+        }
+      }
+    },
+    end() {
+      decoder.decode(); // Refuse a truncated UTF-8 code point.
+      // SSE requires a blank line; EOF does not dispatch a partial frame.
+    },
+  };
+}
+
+export function retryDelay(attempt, retryAfter, now = Date.now(), random = Math.random) {
+  const cap = Math.min(60000, 1000 * 2 ** Math.min(attempt, 6));
+  const jitter = cap * (0.5 + random() * 0.5);
+  if (!retryAfter) return jitter;
+  const seconds = /^\d+$/.test(retryAfter.trim()) ? Number(retryAfter) : NaN;
+  const wait = Number.isFinite(seconds) ? seconds * 1000 : Date.parse(retryAfter) - now;
+  return Math.max(jitter, Number.isFinite(wait) ? Math.max(0, wait) : 0);
+}
+
+export function liveStream({
+  request, current, onTopics, onError = () => {}, now = Date.now,
+  random = Math.random, setTimer = setTimeout, clearTimer = clearTimeout,
+  idleMS = 60000,
+}) {
+  let active = false, controller = null, timer = null, generation = 0, attempts = 0;
+  const connect = async (run) => {
+    const abort = new AbortController();
+    controller = abort;
+    let watchdog = null, reader = null, retryAfter = null;
+    const valid = () => active && generation === run && !abort.signal.aborted;
+    const touch = () => {
+      clearTimer(watchdog);
+      watchdog = setTimer(() => abort.abort(), idleMS);
+    };
+    const began = now();
+    let supported = true, healthy = false;
+    try {
+      touch(); // Also bounds credential acquisition / waiting for response headers.
+      const resp = await request("v1/events", {
+        signal: abort.signal,
+        headers: { Accept: "text/event-stream" },
+        cache: "no-store",
+      });
+      if (!valid()) { await resp.body?.cancel(); return; }
+      retryAfter = resp.headers.get("Retry-After");
+      if ([401, 403, 404, 501].includes(resp.status)) {
+        supported = false; // Probe again only at the next visibility boundary.
+        await resp.body?.cancel();
+        return;
+      }
+      if (!resp.ok || !resp.headers.get("Content-Type")?.toLowerCase().startsWith("text/event-stream")) {
+        await resp.body?.cancel();
+        throw new Error("live stream unavailable");
+      }
+      const parser = eventParser((topics) => {
+        if (valid() && current(resp)) onTopics(topics);
+      });
+      reader = resp.body.getReader();
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (!valid() || !current(resp)) break;
+        if (done) { parser.end(); break; }
+        if (value.length) {
+          touch();
+          parser.feed(value);
+          if (now() - began >= idleMS) healthy = true;
+        }
+      }
+    } catch (err) {
+      if (active && generation === run) onError(err);
+      if (err?.terminal) supported = false;
+    } finally {
+      clearTimer(watchdog);
+      abort.abort();
+      if (reader) {
+        await reader.cancel().catch(() => {});
+        reader.releaseLock();
+      }
+      if (controller === abort) controller = null;
+      if (active && generation === run && supported) {
+        // A quick 200 followed by EOF is still a failure, not a recovery.
+        if (healthy) attempts = 0;
+        const delay = retryDelay(attempts++, retryAfter, now(), random);
+        // Long Retry-After values must not overflow the platform's timer.
+        const deadline = now() + delay;
+        const wait = () => {
+          if (!active || generation !== run) return;
+          const left = deadline - now();
+          if (left > 0) timer = setTimer(wait, Math.min(left, 2147483647));
+          else { timer = null; void connect(run); }
+        };
+        wait();
+      }
+    }
+  };
+  return {
+    start() {
+      if (active) return;
+      active = true;
+      attempts = 0;
+      void connect(++generation);
+    },
+    stop() {
+      active = false;
+      generation++;
+      clearTimer(timer);
+      timer = null;
+      controller?.abort();
+    },
+  };
+}

--- a/internal/webui/static/reader-sync.js
+++ b/internal/webui/static/reader-sync.js
@@ -1,0 +1,122 @@
+// Coalescing is per topic. An event during a read owes one more read; failure
+// keeps that obligation even if no later event arrives.
+export function topicRefresh({
+  refresh, setTimer = setTimeout, clearTimer = clearTimeout, delay = 1500,
+}) {
+  let active = false, running = false, timer = null, epoch = 0;
+  let batchInFlight = [];
+  const owed = new Set();
+  const drain = async () => {
+    timer = null;
+    if (!active || running || !owed.size) return;
+    running = true;
+    const run = epoch;
+    const batch = [...owed];
+    batchInFlight = batch;
+    batch.forEach((topic) => owed.delete(topic));
+    try {
+      for (const topic of batch) {
+        if (!active || epoch !== run) break;
+        try {
+          if (await refresh(topic) === false && epoch === run) owed.add(topic);
+        } catch {
+          if (epoch === run) owed.add(topic);
+        }
+      }
+    } finally {
+      running = false;
+      batchInFlight = [];
+      schedule();
+    }
+  };
+  const schedule = () => {
+    if (active && !running && !timer && owed.size) timer = setTimer(drain, delay);
+  };
+  return {
+    owe(topics) {
+      for (const topic of topics)
+        if (topic === "positions" || topic === "annotations") owed.add(topic);
+      schedule();
+    },
+    start() { active = true; schedule(); },
+    stop() {
+      active = false; epoch++;
+      batchInFlight.forEach((topic) => owed.add(topic));
+      clearTimer(timer); timer = null;
+    },
+    reset() {
+      epoch++; owed.clear(); batchInFlight = [];
+      clearTimer(timer); timer = null;
+    },
+  };
+}
+
+export function candidateID(account, work, op) {
+  if (!op?.op_id || !op.device_id) return null;
+  return JSON.stringify([account, work, op.op_id, op.device_id]);
+}
+
+export function catchupState() {
+  let account = null, work = null, device = null, generation = 0;
+  let candidate = null, offer = null, hidden = false, resume = false, baseline = null;
+  const authored = new Map();
+  const ignored = new Set();
+  const identify = (op) => candidateID(account, work, op);
+  return {
+    bind(nextAccount, nextWork, nextDevice) {
+      const sameBook = account === nextAccount && work === nextWork;
+      account = nextAccount; work = nextWork; device = nextDevice;
+      generation++; candidate = null; offer = null;
+      if (!sameBook) resume = false;
+      if (!sameBook) {
+        baseline = null;
+        authored.clear(); ignored.clear();
+      }
+    },
+    baseline(op) { baseline = identify(op); },
+    wrote(op) {
+      authored.set(op.op_id, device);
+      if (authored.size > 256) authored.delete(authored.keys().next().value);
+    },
+    observe(op) {
+      const id = identify(op);
+      if (!id || id === baseline || ignored.has(id) ||
+          (authored.has(op.op_id) && authored.get(op.op_id) === op.device_id)) {
+        candidate = null;
+        return;
+      }
+      candidate = { id, op: structuredClone(op), generation };
+    },
+    hide() { hidden = true; resume = false; offer = null; },
+    resume() {
+      if (!hidden) return;
+      hidden = false; resume = true;
+    },
+    offer() {
+      if (hidden || !resume || offer) return offer;
+      resume = false;
+      if (candidate?.generation === generation) offer = structuredClone(candidate);
+      return offer;
+    },
+    shown: () => offer,
+    moved() {
+      baseline = candidate?.id || offer?.id || baseline;
+      generation++; candidate = null; offer = null; resume = false;
+    },
+    dismiss() {
+      if (offer) ignored.add(offer.id);
+      if (ignored.size > 256) ignored.delete(ignored.values().next().value);
+      offer = null; resume = false;
+    },
+    accept(shown) {
+      if (!shown || hidden || offer !== shown || shown.generation !== generation ||
+          shown.id !== identify(shown.op) || candidate?.id !== shown.id) {
+        offer = null;
+        return null;
+      }
+      baseline = shown.id;
+      candidate = null; offer = null; resume = false;
+      return structuredClone(shown.op);
+    },
+  };
+}

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -1298,3 +1298,22 @@ button.linkish:hover, button.linkish:focus-visible {
   padding: .3rem 0; border-bottom: 1px solid var(--line);
 }
 .bindings li form { margin: 0 0 0 auto; }
+.reader-catchup {
+  position: fixed;
+  z-index: 40;
+  bottom: 4rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(30rem, calc(100vw - 2rem));
+  padding: 1rem;
+  border: 1px solid currentColor;
+  border-radius: 0.6rem;
+  background: Canvas;
+  color: CanvasText;
+  box-shadow: 0 0.25rem 1rem #0003;
+}
+.reader-catchup[hidden] { display: none; }
+.reader-catchup p { margin: 0 0 0.75rem; }
+.reader-catchup > div { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.reader-catchup button { min-height: 2.75rem; }
+.reader-catchup button:focus-visible { outline: 3px solid currentColor; outline-offset: 3px; }

--- a/internal/webui/testdata/readerannotations.test.mjs
+++ b/internal/webui/testdata/readerannotations.test.mjs
@@ -1,0 +1,114 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { annotationCFI, annotationRenderer } from "../static/reader-annotations.js";
+
+const mark = (id, color = "yellow", cfi = "epubcfi(/6/2)") => ({
+  id, kind: "highlight", color,
+  locator: { locations: { fragments: [cfi] } },
+});
+const flush = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
+
+function fixture() {
+  const overlays = new Map(), calls = [];
+  let identity = 1, renderer;
+  const view = {
+    async addAnnotation({ value }) {
+      calls.push(["add", value]);
+      overlays.set(value, renderer.color(value));
+    },
+    async deleteAnnotation({ value }) {
+      calls.push(["delete", value]);
+      overlays.delete(value);
+    },
+  };
+  renderer = annotationRenderer({ getView: () => view, current: (id) => id === identity, changed() {} });
+  return { renderer, view, overlays, calls, changeIdentity() { identity++; } };
+}
+
+test("replacement removes deletions and recolors existing overlays", async () => {
+  const { renderer, overlays, calls } = fixture();
+  await renderer.replace([mark("one"), mark("two", "blue", "epubcfi(/6/4)")], 1);
+  assert.equal(overlays.size, 2);
+  await renderer.replace([mark("one", "pink")], 1);
+  assert.deepEqual([...overlays], [["epubcfi(/6/2)", "pink"]]);
+  assert.equal(renderer.color("epubcfi(/6/4)"), undefined);
+  assert.deepEqual(calls.map(([method]) => method), ["add", "add", "delete", "delete", "add"]);
+  await renderer.replace([], 1);
+  assert.equal(overlays.size, 0);
+  assert.deepEqual(renderer.annotations(), []);
+});
+
+test("CFI failure cache is cleared when the server replaces the live set", async () => {
+  const { renderer, view } = fixture();
+  const add = view.addAnnotation;
+  view.addAnnotation = async () => { throw new Error("stale CFI"); };
+  await renderer.replace([mark("one")], 1);
+  assert.equal(renderer.failed("one"), true);
+  view.addAnnotation = add;
+  await renderer.replace([mark("one", "green")], 1);
+  assert.equal(renderer.failed("one"), false);
+});
+
+test("an in-flight old draw cannot recreate an overlay removed by a newer set", async () => {
+  const { renderer, view, overlays } = fixture();
+  const add = view.addAnnotation;
+  let release;
+  view.addAnnotation = async (annotation) => {
+    await new Promise((r) => { release = r; });
+    await add(annotation);
+  };
+  const first = renderer.replace([mark("old")], 1);
+  await flush();
+  const removed = renderer.replace([], 1);
+  release();
+  await Promise.all([first, removed]);
+  assert.equal(overlays.size, 0);
+  assert.equal(renderer.color("epubcfi(/6/2)"), undefined);
+});
+
+test("superseded token/work rendering is discarded and clear removes in-flight overlays", async () => {
+  const { renderer, view, overlays, changeIdentity } = fixture();
+  const add = view.addAnnotation;
+  let release;
+  view.addAnnotation = async (annotation) => {
+    await new Promise((r) => { release = r; });
+    await add(annotation);
+  };
+  const old = renderer.replace([mark("old"), mark("later", "blue", "epubcfi(/6/4)")], 1);
+  await flush();
+  changeIdentity();
+  const cleared = renderer.clear();
+  release();
+  await Promise.all([old, cleared]);
+  assert.equal(overlays.size, 0);
+  await renderer.replace([mark("stale")], 1);
+  assert.equal(overlays.size, 0);
+  assert.deepEqual(renderer.annotations(), []);
+});
+
+test("overlapping chapter draw requests are serialized", async () => {
+  const { renderer, view } = fixture();
+  let active = 0, maximum = 0;
+  view.addAnnotation = async () => {
+    active++;
+    maximum = Math.max(maximum, active);
+    await Promise.resolve();
+    active--;
+  };
+  await renderer.replace([mark("one")], 1);
+  await Promise.all([renderer.draw(), renderer.draw(), renderer.draw()]);
+  assert.equal(maximum, 1);
+});
+
+test("non-drawable notes/bookmarks stay in the replacement set without overlays", async () => {
+  const { renderer, overlays } = fixture();
+  const rows = [
+    { id: "note", kind: "note", body: "A standalone note" },
+    { ...mark("bookmark"), kind: "bookmark" },
+    { ...mark("unknown"), locator: {} },
+  ];
+  await renderer.replace(rows, 1);
+  assert.equal(overlays.size, 0);
+  assert.deepEqual(renderer.annotations(), rows);
+  assert.equal(annotationCFI({ locator: { locations: { fragments: "not an array" } } }), null);
+});

--- a/internal/webui/testdata/readerauth.test.mjs
+++ b/internal/webui/testdata/readerauth.test.mjs
@@ -1,0 +1,216 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readerAuth, REOPEN_MESSAGE } from "../static/reader-auth.js";
+
+const json = (data, status = 200) => new Response(JSON.stringify(data), { status });
+const flush = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
+const deferred = () => {
+  let resolve;
+  const promise = new Promise((r) => { resolve = r; });
+  return { promise, resolve };
+};
+const options = { apiBase: "/proxy/", tokenURL: "/proxy/ui/reader/token", csrf: "csrf" };
+const metadata = (account = "a", device = "browser") => json({ account_id: account, device_id: device });
+
+test("concurrent streaming and API calls mint a single credential with Bearer headers", async () => {
+  const mint = deferred();
+  let mints = 0, inspections = 0;
+  const calls = [];
+  const auth = readerAuth({
+    ...options,
+    fetcher: async (url, opts) => {
+      calls.push([url, opts]);
+      if (url === options.tokenURL) { mints++; return mint.promise; }
+      if (url.endsWith("v1/token")) { inspections++; return metadata(); }
+      return json({ ok: true });
+    },
+  });
+  const requests = [auth.request("v1/events"), auth.request("v1/works/w/positions")];
+  mint.resolve(json({ token: "one", expires_at: "2099-01-01T00:00:00Z" }));
+  const responses = await Promise.all(requests);
+  assert.equal(mints, 1);
+  assert.equal(inspections, 1);
+  assert.equal(calls[0][1].credentials, "same-origin");
+  assert.equal(String(calls[0][1].body), "csrf=csrf");
+  for (const [url, opts] of calls.slice(1)) {
+    assert.equal(opts.headers.Authorization, "Bearer one", url);
+    assert.equal(opts.credentials, "omit", url);
+  }
+  responses.forEach((resp) => assert.equal(auth.responseCurrent(resp), true));
+  assert.equal(auth.identity().account, "a");
+  assert.equal(auth.identity().device, "browser");
+});
+
+test("concurrent 401 responses refresh once and late refusal cannot evict the new token", async () => {
+  const late = deferred();
+  let mints = 0, oldCalls = 0;
+  const auth = readerAuth({
+    ...options,
+    fetcher: async (url, opts) => {
+      if (url === options.tokenURL) return json({ token: "t" + ++mints });
+      if (url.endsWith("v1/token")) return metadata();
+      if (opts.headers.Authorization === "Bearer t1") {
+        oldCalls++;
+        return oldCalls === 1 ? json({}, 401) : late.promise;
+      }
+      return json({ ok: true });
+    },
+  });
+  await auth.acquire();
+  const first = auth.request("v1/events");
+  const second = auth.request("v1/works/w/positions");
+  await first;
+  late.resolve(json({}, 401));
+  const response = await second;
+  assert.equal(mints, 2);
+  assert.equal(auth.identity().secret, "t2");
+  assert.equal(auth.responseCurrent(response), true);
+});
+
+test("second 401 after one refresh terminates rather than looping", async () => {
+  let mints = 0, exhausted = 0;
+  const auth = readerAuth({
+    ...options, onExhausted() { exhausted++; },
+    fetcher: async (url) => {
+      if (url === options.tokenURL) return json({ token: "t" + ++mints });
+      if (url.endsWith("v1/token")) return metadata();
+      return json({}, 401);
+    },
+  });
+  await assert.rejects(auth.request("v1/events"), (err) => err.terminal && err.message === REOPEN_MESSAGE);
+  await assert.rejects(auth.request("v1/events"), (err) => err.terminal);
+  assert.equal(mints, 2);
+  assert.equal(exhausted, 1);
+});
+
+test("detached refusal stops all attempts and retains the reopen message", async () => {
+  let calls = 0, exhausted = 0;
+  const auth = readerAuth({
+    ...options, detached: true, handed: "handed", onExhausted() { exhausted++; },
+    fetcher: async (url) => {
+      calls++;
+      assert.notEqual(url, options.tokenURL);
+      return url.endsWith("v1/token") ? metadata() : json({}, 401);
+    },
+  });
+  await assert.rejects(auth.request("v1/events"), (err) => err.terminal && err.message === REOPEN_MESSAGE);
+  await assert.rejects(auth.request("v1/events"), (err) => err.terminal);
+  assert.equal(calls, 2);
+  assert.equal(exhausted, 1);
+});
+
+test("expired handed token fails identity lookup without trying the session-cookie endpoint", async () => {
+  const calls = [];
+  const auth = readerAuth({
+    ...options, detached: true, handed: "expired",
+    fetcher: async (url) => { calls.push(url); return json({}, 401); },
+  });
+  await assert.rejects(auth.acquire(), (err) => err.terminal);
+  assert.deepEqual(calls, ["/proxy/v1/token"]);
+});
+
+test("response generation remains attached through delayed body decoding", async () => {
+  let time = 0, mints = 0;
+  const changed = [];
+  const auth = readerAuth({
+    ...options, now: () => time, onChange: (next, old) => changed.push([next, old]),
+    fetcher: async (url) => {
+      if (url === options.tokenURL)
+        return json({ token: "t" + ++mints, expires_at: new Date(time + 3600000).toISOString() });
+      if (url.endsWith("v1/token")) return metadata(mints === 1 ? "a" : "b");
+      return json({ value: "old" });
+    },
+  });
+  const old = await auth.request("v1/works/w/positions");
+  const stamp = auth.responseIdentity(old);
+  time = 3600000;
+  await auth.acquire();
+  await old.json();
+  assert.equal(auth.current(stamp), false);
+  assert.equal(auth.responseCurrent(old), false);
+  assert.equal(changed[1][1].account, "a");
+  assert.equal(changed[1][0].account, "b");
+});
+
+test("account change can stop before any mutation under the replacement account", async () => {
+  let time = 0, mints = 0, writes = 0, auth;
+  auth = readerAuth({
+    ...options, now: () => time,
+    onChange(next, old) { if (old && old.account !== next.account) auth.stop(); },
+    fetcher: async (url) => {
+      if (url === options.tokenURL) return json({ token: "t" + ++mints, expires_at: new Date(time + 3600000).toISOString() });
+      if (url.endsWith("v1/token")) return metadata(mints === 1 ? "a" : "b");
+      writes++;
+      return json({});
+    },
+  });
+  await auth.acquire();
+  time = 3600000;
+  await assert.rejects(auth.request("v1/ops", { method: "POST" }), (err) => err.terminal);
+  assert.equal(writes, 0);
+});
+
+test("stopped generation rejects an in-flight mint without installing it", async () => {
+  const held = deferred();
+  let changed = 0;
+  const auth = readerAuth({
+    ...options, onChange() { changed++; },
+    fetcher: async (url) => url === options.tokenURL ? held.promise : metadata(),
+  });
+  const request = auth.acquire();
+  auth.stop();
+  held.resolve(json({ token: "late" }));
+  await assert.rejects(request);
+  assert.equal(changed, 0);
+  assert.equal(auth.identity(), null);
+});
+
+test("an aborted stream waiting for the shared mint makes no event request", async () => {
+  const held = deferred();
+  let requests = 0;
+  const auth = readerAuth({
+    ...options,
+    fetcher: async (url) => {
+      if (url === options.tokenURL) return held.promise;
+      if (url.endsWith("v1/token")) return metadata();
+      requests++;
+      return json({});
+    },
+  });
+  const controller = new AbortController();
+  const promise = auth.request("v1/events", { signal: controller.signal });
+  controller.abort();
+  held.resolve(json({ token: "one" }));
+  await assert.rejects(promise, { name: "AbortError" });
+  assert.equal(requests, 0);
+});
+
+test("cookie auth refusal is terminal, transient mint failure remains retryable", async () => {
+  const denied = readerAuth({ ...options, fetcher: async () => json({}, 403) });
+  await assert.rejects(denied.acquire(), (err) => err.terminal);
+  let calls = 0;
+  const auth = readerAuth({
+    ...options,
+    fetcher: async (url) => {
+      if (url.endsWith("v1/token")) return metadata();
+      if (++calls === 1) return json({}, 503);
+      return json({ token: "one" });
+    },
+  });
+  await assert.rejects(auth.acquire(), /could not obtain/);
+  await auth.acquire();
+  assert.equal(calls, 2);
+});
+
+test("old servers without introspection still allow ordinary requests", async () => {
+  const auth = readerAuth({
+    ...options,
+    fetcher: async (url) => {
+      if (url === options.tokenURL) return json({ token: "one", device_id: "browser" });
+      if (url.endsWith("v1/token")) return json({}, 404);
+      return json({});
+    },
+  });
+  assert.equal((await auth.request("v1/works/w/positions")).ok, true);
+  assert.equal(auth.identity().device, "browser");
+});

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -20,6 +20,7 @@ const nan = process.env.SMOKE_NAN === '1';
 // Session mode (ADR-0030): hides and shows the tab with a skewed clock,
 // watching what the reader posts to /v1/sessions.
 const sessions = process.env.SMOKE_SESSIONS === '1';
+const liveMode = process.env.SMOKE_LIVE === '1';
 // How many pages the fixture has, counted from the archive by the Go
 // side with Readium's recipe (ADR-0032). The footer has to agree, or the
 // browser and the app are naming different pages again.
@@ -92,6 +93,32 @@ await S('Network.enable');
 const [name, value] = cookie.split('=');
 await S('Network.setCookie', { name, value, domain: host.split(':')[0], path: '/' });
 
+if (liveMode) {
+  await S('Page.addScriptToEvaluateOnNewDocument', { source: `(() => {
+    const original = window.fetch;
+    window.__liveReads = 0;
+    window.__liveStreams = [];
+    window.__liveOwnOps = [];
+    window.fetch = async function(input, init = {}) {
+      const url = typeof input === 'string' ? input : input.url;
+      if (init.headers?.Authorization) window.__liveBearer = init.headers.Authorization;
+      if (url.endsWith('v1/events')) window.__liveStreams.push(init.signal);
+      if (url.endsWith('v1/ops') && init.body) {
+        const ops = JSON.parse(init.body).ops || [];
+        window.__liveOwnOps.push(...ops.filter((op) => !op.op_id.startsWith('live-test-')));
+      }
+      const resp = await original.call(this, input, init);
+      if (url.includes('/positions?') && resp.ok) {
+        await resp.clone().json();
+        window.__liveReads++;
+      }
+      if (url.endsWith('/resolve') && resp.ok) {
+        window.__liveWork = (await resp.clone().json()).work_id;
+      }
+      return resp;
+    };
+  })()` });
+}
 await S('Page.navigate', { url });
 await new Promise((r) => setTimeout(r, 8000));
 
@@ -126,6 +153,12 @@ if (nan) {
 }
 if (sessions) {
   await sessionGuard(evalIn, check);
+  ws.close();
+  proc.kill();
+  process.exit(fail.length ? 1 : 0);
+}
+if (liveMode) {
+  await liveGuard(evalIn, check, S);
   ws.close();
   proc.kill();
   process.exit(fail.length ? 1 : 0);
@@ -1261,6 +1294,123 @@ ws.close();
 proc.kill();
 process.exit(fail.length ? 1 : 0);
 
+async function liveGuard(evalIn, check, S) {
+  const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const wait = async (expression) => {
+    for (let i = 0; i < 50; i++) {
+      if (await evalIn(expression)) return true;
+      await pause(200);
+    }
+    return false;
+  };
+  const position = () => evalIn("document.querySelector('foliate-view').lastLocation.fraction");
+  const overlay = `(() => {
+    const content = document.querySelector('foliate-view').renderer.getContents()[0];
+    const group = content?.overlayer?.element?.querySelector('g');
+    return group?.getAttribute('fill') || null;
+  })()`;
+  const original = await position();
+  check('opening restore creates no position op', await evalIn('window.__liveOwnOps.length === 0'));
+  check('one live stream is open', await evalIn('window.__liveStreams.length === 1 && !window.__liveStreams[0].aborted'));
+  await evalIn(`(() => {
+    window.__liveCall = async (path, method = 'GET', body) => {
+      const base = document.getElementById('reader-config').dataset.apiBase;
+      const resp = await fetch(base + path, {
+        method, headers: { Authorization: window.__liveBearer, 'Content-Type': 'application/json' },
+        ...(body ? { body: JSON.stringify(body) } : {}),
+      });
+      if (!resp.ok) throw new Error(path + ': ' + resp.status);
+      return resp.status === 204 ? null : resp.json();
+    };
+    return true;
+  })()`);
+  // Recolour and delete the seeded range while remaining on its chapter.
+  const recoloured = await evalIn(`(async () => {
+    const page = await window.__liveCall('v1/works/' + window.__liveWork + '/annotations');
+    const a = page.annotations.find((a) => a.id.endsWith('a1'));
+    const out = await window.__liveCall('v1/annotations', 'POST', { annotations: [{
+      id: a.id, base_rev: a.rev, work_id: window.__liveWork, kind: a.kind,
+      color: 'pink', excerpt: a.excerpt, progression: a.progression,
+      locator: a.locator, client_ts: new Date().toISOString(),
+    }] });
+    return out.results[0].status;
+  })()`);
+  check('remote recolour commits', recoloured === 'applied', recoloured);
+  check('recolour reaches the open chapter without a page turn', await wait(`(${overlay}) === '#f06292'`));
+  await evalIn(`(async () => {
+    const page = await window.__liveCall('v1/works/' + window.__liveWork + '/annotations');
+    const a = page.annotations.find((a) => a.id.endsWith('a1'));
+    await window.__liveCall('v1/annotations/' + a.id + '?rev=' + a.rev, 'DELETE');
+    return true;
+  })()`);
+  check('remote deletion removes its overlay without a page turn', await wait(`(${overlay}) === null`));
+  check('annotation refresh does not move the book', await position() === original);
+
+  const remote = (id, fraction) => evalIn(`(async () => {
+    const out = await window.__liveCall('v1/ops', 'POST', { ops: [{
+      op_id: ${JSON.stringify('live-test-' + id)}, work_id: window.__liveWork,
+      client_ts: new Date().toISOString(), progression: ${fraction},
+      locator: { locations: { totalProgression: ${fraction}, fragments: ['epubcfi(/6/9998!/4/2)'] } },
+    }] });
+    return out.results[0].status;
+  })()`);
+  let before = await evalIn('window.__liveReads');
+  check('remote position commits', await remote('first', 0.7) === 'applied');
+  check('a live position triggers the work snapshot', await wait(`window.__liveReads > ${before}`));
+  await pause(300);
+  check('live position does not move the visible book', await position() === original);
+  check('live position does not show an offer while reading', await evalIn("document.getElementById('reader-catchup').hidden"));
+  await evalIn(`(() => {
+    window.__liveHidden = false;
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => window.__liveHidden });
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => window.__liveHidden ? 'hidden' : 'visible' });
+    return true;
+  })()`);
+  const visibility = (hidden) => evalIn(`(() => {
+    window.__liveHidden = ${hidden};
+    document.dispatchEvent(new Event('visibilitychange'));
+    return true;
+  })()`);
+  await visibility(true);
+  check('hidden closes the stream', await evalIn('window.__liveStreams.at(-1).aborted'));
+  await visibility(false);
+  check('resume offers the remote page', await wait("!document.getElementById('reader-catchup').hidden"));
+  const offered = await evalIn("document.getElementById('reader-catchup-text').textContent");
+  check('offer names the held position', offered.includes('70%'), offered);
+  before = await evalIn('window.__liveReads');
+  await remote('second', 0.8);
+  await wait(`window.__liveReads > ${before}`);
+  await pause(300);
+  check('new remote position does not retarget the shown offer',
+    await evalIn("document.getElementById('reader-catchup-text').textContent") === offered);
+  await evalIn("document.getElementById('reader-catchup-accept').click()");
+  await pause(300);
+  check('stale offer acceptance cannot navigate', await position() === original);
+
+  await visibility(true); await visibility(false);
+  check('next resume offers the newer snapshot', await wait("!document.getElementById('reader-catchup').hidden && document.getElementById('reader-catchup-text').textContent.includes('80%')"));
+  if (process.env.SMOKE_SHOT) {
+    const shot = await S('Page.captureScreenshot', { format: 'png' });
+    (await import('node:fs')).writeFileSync(process.env.SMOKE_SHOT, Buffer.from(shot.data, 'base64'));
+  }
+  await evalIn("document.getElementById('reader-catchup-accept').focus()");
+  check('the offer button can receive keyboard focus',
+    await evalIn("document.activeElement.id === 'reader-catchup-accept'"));
+  await S('Input.dispatchKeyEvent', {
+    type: 'keyDown', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13,
+    text: '\r', unmodifiedText: '\r',
+  });
+  await S('Input.dispatchKeyEvent', { type: 'keyUp', key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13 });
+  check('keyboard acceptance uses fraction fallback from a stale CFI',
+    await wait("document.querySelector('foliate-view').lastLocation.fraction > 0.75"),
+    JSON.stringify(await evalIn("({ fraction: document.querySelector('foliate-view').lastLocation.fraction, offerHidden: document.getElementById('reader-catchup').hidden, status: document.getElementById('reader-status').textContent })")));
+  await pause(2000);
+  check('accepted restore does not echo a position op', await evalIn('window.__liveOwnOps.length === 0'));
+  await evalIn("document.getElementById('reader-next').click()");
+  check('a genuine page turn still syncs', await wait('window.__liveOwnOps.length > 0'));
+  await visibility(true);
+}
+
 // nanGuard proves the position-jumps fix from the page's own side. The
 // server now rejects a null progression whatever the client does, so a
 // test that only inspected the op log would be vacuous: the observable
@@ -1313,6 +1463,9 @@ async function nanGuard(evalIn, check) {
   const settle = () => new Promise((r) => setTimeout(r, 2500));
 
   await evalIn('(() => { window.__pushedOps = []; return true; })()');
+  // A layout correction should sync a page the reader actually reached,
+  // not manufacture activity merely because a relocate was emitted.
+  await evalIn("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }))");
   await evalIn(relocate('NaN'));
   await settle();
   const afterNaN = await pushed();
@@ -1321,6 +1474,7 @@ async function nanGuard(evalIn, check) {
   check('a skipped NaN schedules a layout retry',
     afterNaN.length >= 1, JSON.stringify(afterNaN));
 
+  await evalIn("document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Shift' }))");
   await evalIn(relocate('0.47'));
   await settle();
   const afterFinite = await pushed();

--- a/internal/webui/testdata/readerlive.test.mjs
+++ b/internal/webui/testdata/readerlive.test.mjs
@@ -92,6 +92,25 @@ test("jitter is bounded, capped and Retry-After is a minimum", () => {
   assert.equal(retryDelay(0, "nonsense", 0, () => 0), 500);
 });
 
+test("SSE retry advice is also a minimum, alongside Retry-After", () => {
+  assert.equal(retryDelay(0, null, 0, () => 0, 5000), 5000);
+  // Retry-After (seconds) and the stream's own retry advice (ms) both
+  // floor the delay; the larger of the two wins.
+  assert.equal(retryDelay(0, "1", 0, () => 0, 5000), 5000);
+  assert.equal(retryDelay(0, "10", 0, () => 0, 5000), 10000);
+  // A brief backoff cap can still exceed a small retry advice.
+  assert.equal(retryDelay(100, "0", 0, () => 1, 1), 60000);
+});
+
+test("the retry field is parsed independently of any invalidate frame", () => {
+  const got = [];
+  let retryMS = null;
+  const parser = eventParser((topics) => got.push(topics), undefined, (ms) => { retryMS = ms; });
+  parser.feed(encode("retry: 5000\n\n" + frame));
+  assert.equal(retryMS, 5000);
+  assert.deepEqual(got, [["positions", "annotations"]]);
+});
+
 function socket(signal) {
   let controller;
   const body = new ReadableStream({

--- a/internal/webui/testdata/readerlive.test.mjs
+++ b/internal/webui/testdata/readerlive.test.mjs
@@ -1,0 +1,241 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { eventParser, liveStream, retryDelay } from "../static/reader-live.js";
+
+const encode = (s) => new TextEncoder().encode(s);
+const flush = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
+const frame = 'event: invalidate\r\ndata: {"topics":["positions","annotations","insights","positions"]}\r\n\r\n';
+
+function clock() {
+  let now = 0, id = 0;
+  const tasks = new Map();
+  return {
+    now: () => now,
+    setTimer(fn, ms) { const key = ++id; tasks.set(key, { at: now + ms, fn }); return key; },
+    clearTimer(key) { tasks.delete(key); },
+    async tick(ms) {
+      const end = now + ms;
+      for (;;) {
+        const next = [...tasks.entries()].filter(([, v]) => v.at <= end)
+          .sort((a, b) => a[1].at - b[1].at)[0];
+        if (!next) break;
+        now = next[1].at;
+        tasks.delete(next[0]);
+        next[1].fn();
+        await flush();
+      }
+      now = end;
+      await flush();
+    },
+    pending: () => tasks.size,
+  };
+}
+
+test("split CRLF, one-byte UTF-8, comments and known topics", () => {
+  const got = [];
+  const parser = eventParser((topics) => got.push(topics));
+  for (const byte of encode(": café 📚\r\n\r\n" + frame + "event: other\ndata: bad\n\n")) {
+    parser.feed(Uint8Array.of(byte));
+  }
+  parser.end();
+  assert.deepEqual(got, [["positions", "annotations"]]);
+});
+
+test("all chunk boundaries produce the same event; EOF never dispatches", () => {
+  const bytes = encode(frame);
+  for (let cut = 0; cut <= bytes.length; cut++) {
+    const got = [];
+    const parser = eventParser((topics) => got.push(topics));
+    parser.feed(bytes.slice(0, cut));
+    parser.feed(bytes.slice(cut));
+    parser.end();
+    assert.deepEqual(got, [["positions", "annotations"]]);
+  }
+  const got = [];
+  const parser = eventParser((topics) => got.push(topics));
+  parser.feed(encode('event: invalidate\ndata: {"topics":["positions"]}\n'));
+  parser.end();
+  assert.deepEqual(got, []);
+});
+
+test("multi-line data, bare CR and unknown fields", () => {
+  const got = [];
+  const parser = eventParser((topics) => got.push(topics));
+  parser.feed(encode('id: ignored\rretry: 0\revent: invalidate\rdata: {"topics":\rdata: ["annotations"]}\r\r'));
+  assert.deepEqual(got, [["annotations"]]);
+});
+
+test("oversized lines and frames are refused before unbounded accumulation", () => {
+  const parser = eventParser(() => {}, 64);
+  assert.throws(() => parser.feed(encode(":" + "a".repeat(64))), /large/);
+  const multiline = eventParser(() => {}, 64);
+  assert.throws(() => multiline.feed(encode("data: a\n".repeat(10))), /large/);
+  const separate = eventParser(() => {}, 64);
+  separate.feed(encode(": heartbeat\n\n".repeat(1000)));
+});
+
+test("malformed payloads and truncated/invalid UTF-8 terminate a connection", () => {
+  assert.throws(() => eventParser(() => {}).feed(encode("event: invalidate\ndata: nope\n\n")));
+  assert.throws(() => eventParser(() => {}).feed(encode('event: invalidate\ndata: {"topics":1}\n\n')));
+  const parser = eventParser(() => {});
+  parser.feed(Uint8Array.of(0xc3));
+  assert.throws(() => parser.end());
+  assert.throws(() => eventParser(() => {}).feed(Uint8Array.of(0xff)));
+});
+
+test("jitter is bounded, capped and Retry-After is a minimum", () => {
+  assert.equal(retryDelay(0, null, 0, () => 0), 500);
+  assert.equal(retryDelay(1, null, 0, () => 1), 2000);
+  assert.equal(retryDelay(100, null, 0, () => 1), 60000);
+  assert.equal(retryDelay(0, "120", 0, () => 0), 120000);
+  assert.equal(retryDelay(0, "Thu, 01 Jan 1970 00:01:00 GMT", 0, () => 0), 60000);
+  assert.equal(retryDelay(0, "nonsense", 0, () => 0), 500);
+});
+
+function socket(signal) {
+  let controller;
+  const body = new ReadableStream({
+    start(c) {
+      controller = c;
+      signal.addEventListener("abort", () => {
+        try { c.error(new DOMException("aborted", "AbortError")); } catch {}
+      }, { once: true });
+    },
+  });
+  return {
+    response: new Response(body, { headers: { "Content-Type": "text/event-stream" } }),
+    send: (s) => controller.enqueue(encode(s)),
+    close: () => controller.close(),
+  };
+}
+
+test("one visible stream, opening hints, heartbeats and 60-second silence watchdog", async () => {
+  const time = clock(), got = [], signals = [];
+  let connection;
+  const live = liveStream({
+    ...time, random: () => 0, current: () => true,
+    request: async (path, options) => {
+      assert.equal(path, "v1/events");
+      assert.equal(options.headers.Accept, "text/event-stream");
+      signals.push(options.signal);
+      connection = socket(options.signal);
+      return connection.response;
+    },
+    onTopics: (topics) => got.push(topics),
+  });
+  live.start(); live.start();
+  await flush();
+  assert.equal(signals.length, 1);
+  connection.send(frame);
+  await flush();
+  assert.deepEqual(got, [["positions", "annotations"]]);
+  await time.tick(40000);
+  connection.send(": heartbeat\n\n");
+  await flush();
+  await time.tick(40000);
+  assert.equal(signals[0].aborted, false);
+  await time.tick(20000);
+  assert.equal(signals[0].aborted, true);
+  await time.tick(500);
+  assert.equal(signals.length, 2);
+  live.stop();
+  await flush();
+  assert.equal(signals[1].aborted, true);
+  assert.equal(time.pending(), 0);
+});
+
+test("quick 200/EOF failures increase delay instead of resetting it", async () => {
+  const time = clock();
+  let calls = 0;
+  const live = liveStream({
+    ...time, random: () => 0, current: () => true, onTopics() {},
+    request: async () => {
+      calls++;
+      return new Response("", { headers: { "Content-Type": "text/event-stream" } });
+    },
+  });
+  live.start(); await flush();
+  assert.equal(calls, 1);
+  await time.tick(500);
+  assert.equal(calls, 2);
+  await time.tick(999);
+  assert.equal(calls, 2);
+  await time.tick(1);
+  assert.equal(calls, 3);
+  live.stop(); await flush();
+});
+
+test("unsupported and forbidden streams wait for the next visible boundary", async () => {
+  for (const status of [401, 403, 404, 501]) {
+    const time = clock();
+    let calls = 0;
+    const live = liveStream({
+      ...time, current: () => true, onTopics() {},
+      request: async () => { calls++; return new Response(null, { status }); },
+    });
+    live.start(); await flush();
+    await time.tick(300000);
+    assert.equal(calls, 1);
+    live.stop(); live.start(); await flush();
+    assert.equal(calls, 2);
+    live.stop();
+  }
+});
+
+test("429 respects Retry-After and hidden state cancels retry", async () => {
+  const time = clock();
+  let calls = 0;
+  const live = liveStream({
+    ...time, random: () => 0, current: () => true, onTopics() {},
+    request: async () => {
+      calls++;
+      return new Response(null, { status: 429, headers: { "Retry-After": "120" } });
+    },
+  });
+  live.start(); await flush();
+  await time.tick(119999);
+  assert.equal(calls, 1);
+  await time.tick(1);
+  assert.equal(calls, 2);
+  live.stop();
+  await time.tick(300000);
+  assert.equal(calls, 2);
+});
+
+test("late headers and obsolete credentials cannot deliver queued topics", async () => {
+  const time = clock(), got = [];
+  let resolve, connection, valid = true;
+  const live = liveStream({
+    ...time, current: () => valid, onTopics: (t) => got.push(t),
+    request: (_, options) => {
+      connection = socket(options.signal);
+      return new Promise((r) => { resolve = r; });
+    },
+  });
+  live.start();
+  live.stop();
+  resolve(connection.response);
+  await flush();
+  assert.deepEqual(got, []);
+  live.start();
+  resolve(connection.response);
+  await flush();
+  valid = false;
+  connection.send(frame);
+  await flush();
+  assert.deepEqual(got, []);
+  live.stop();
+});
+
+test("terminal credential exhaustion does not retry", async () => {
+  const time = clock();
+  let calls = 0;
+  const live = liveStream({
+    ...time, current: () => true, onTopics() {},
+    request: async () => { calls++; throw Object.assign(new Error("expired"), { terminal: true }); },
+  });
+  live.start(); await flush();
+  await time.tick(300000);
+  assert.equal(calls, 1);
+  live.stop();
+});

--- a/internal/webui/testdata/readersync.test.mjs
+++ b/internal/webui/testdata/readersync.test.mjs
@@ -1,0 +1,202 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { catchupState, candidateID, topicRefresh } from "../static/reader-sync.js";
+
+const op = (id, device = "phone", progression = 0.6) => ({
+  op_id: id, device_id: device, work_id: "work", progression,
+  locator: { href: "chapter.xhtml", locations: { totalProgression: progression, fragments: ["epubcfi(/6/2)"] } },
+});
+function state() {
+  const s = catchupState();
+  s.bind("account", "work", "browser");
+  s.baseline(op("opening"));
+  return s;
+}
+
+test("live positions are held while reading and offered only on resume", () => {
+  const s = state(), remote = op("new");
+  s.observe(remote);
+  assert.equal(s.offer(), null);
+  s.resume(); // duplicate visible/focus-like event is not a resume
+  assert.equal(s.offer(), null);
+  s.hide(); s.resume();
+  const offer = s.offer();
+  assert.equal(offer.op.op_id, "new");
+  assert.deepEqual(s.accept(offer), remote);
+  assert.equal(s.offer(), null);
+});
+
+test("resume may await its snapshot, but later visible events do not nag", () => {
+  const s = state();
+  s.hide(); s.resume();
+  s.observe(op("first"));
+  assert.equal(s.offer().op.op_id, "first");
+  s.dismiss();
+  s.observe(op("second"));
+  assert.equal(s.offer(), null);
+  s.hide(); s.resume();
+  assert.equal(s.offer().op.op_id, "second");
+});
+
+test("incoming updates never retarget a displayed offer; stale acceptance is refused", () => {
+  const s = state();
+  s.observe(op("one")); s.hide(); s.resume();
+  const offer = s.offer();
+  s.observe(op("two"));
+  assert.equal(s.offer(), offer);
+  assert.equal(offer.op.op_id, "one");
+  assert.equal(s.accept(offer), null);
+});
+
+test("local movement, account/work/token replacement and hidden state invalidate acceptance", () => {
+  for (const invalidate of [
+    (s) => s.moved(),
+    (s) => s.bind("other", "work", "browser"),
+    (s) => s.bind("account", "other-work", "browser"),
+    (s) => s.bind("account", "work", "browser"),
+    (s) => s.hide(),
+  ]) {
+    const s = state();
+    s.observe(op("one")); s.hide(); s.resume();
+    const offer = s.offer();
+    invalidate(s);
+    assert.equal(s.accept(offer), null);
+  }
+});
+
+test("new local page does not rediscover the discarded remote candidate", () => {
+  const s = state();
+  s.observe(op("remote"));
+  s.moved();
+  s.hide(); s.resume();
+  s.observe(op("remote"));
+  assert.equal(s.offer(), null);
+});
+
+test("dismissed and baseline operations do not reappear", () => {
+  const s = state();
+  s.observe(op("opening")); s.hide(); s.resume();
+  assert.equal(s.offer(), null);
+  s.observe(op("one")); s.hide(); s.resume();
+  s.offer(); s.dismiss();
+  s.hide(); s.resume(); s.observe(op("one"));
+  assert.equal(s.offer(), null);
+});
+
+test("self-authorship requires actual op/device, not shared browser device alone", () => {
+  const s = state();
+  s.wrote(op("mine", "browser"));
+  s.observe(op("mine", "browser")); s.hide(); s.resume();
+  assert.equal(s.offer(), null);
+  s.observe(op("other-tab", "browser")); s.hide(); s.resume();
+  assert.equal(s.offer().op.op_id, "other-tab");
+  s.dismiss();
+  s.observe(op("mine", "phone")); s.hide(); s.resume();
+  assert.equal(s.offer().op.device_id, "phone");
+});
+
+test("self op identity survives a same-account credential renewal", () => {
+  const s = state();
+  s.wrote(op("mine", "browser"));
+  s.bind("account", "work", "browser");
+  s.observe(op("mine", "browser")); s.hide(); s.resume();
+  assert.equal(s.offer(), null);
+});
+
+test("credential renewal during a resume keeps its owed offer, not an old target", () => {
+  const s = state();
+  s.observe(op("old")); s.hide(); s.resume();
+  s.bind("account", "work", "browser");
+  s.observe(op("fresh"));
+  assert.equal(s.offer().op.op_id, "fresh");
+});
+
+test("full locator and identity survive snapshots without mutable aliases", () => {
+  const s = state(), remote = op("id");
+  s.observe(remote);
+  remote.locator.href = "mutated.xhtml";
+  s.hide(); s.resume();
+  const offer = s.offer();
+  assert.equal(offer.id, candidateID("account", "work", op("id")));
+  assert.equal(s.accept(offer).locator.href, "chapter.xhtml");
+  assert.notEqual(candidateID("account", "work", op("id")), candidateID("other", "work", op("id")));
+  assert.notEqual(candidateID("account", "work", op("id")), candidateID("account", "work", op("id", "other")));
+});
+
+const flush = async () => { for (let i = 0; i < 20; i++) await Promise.resolve(); };
+function queue(refresh) {
+  let scheduled = null;
+  const q = topicRefresh({
+    refresh,
+    setTimer(fn) { scheduled = fn; return 1; },
+    clearTimer() { scheduled = null; },
+  });
+  return {
+    q,
+    async run() { const f = scheduled; scheduled = null; f?.(); await flush(); },
+    pending: () => !!scheduled,
+  };
+}
+
+test("topic bursts coalesce with at most one follow-up for each held topic", async () => {
+  const calls = [];
+  let release;
+  const { q, run, pending } = queue(async (topic) => {
+    calls.push(topic);
+    if (calls.length === 1) await new Promise((r) => { release = r; });
+    return true;
+  });
+  q.owe(["positions", "annotations", "insights"]); q.start();
+  await run();
+  for (let i = 0; i < 100; i++) q.owe(["positions", "annotations"]);
+  assert.deepEqual(calls, ["positions"]);
+  release(); await flush();
+  assert.deepEqual(calls, ["positions", "annotations"]);
+  assert.equal(pending(), true);
+  await run();
+  assert.deepEqual(calls, ["positions", "annotations", "positions", "annotations"]);
+  assert.equal(pending(), false);
+});
+
+test("failed topic stays owed without another event and does not lose other topics", async () => {
+  const calls = [];
+  const { q, run, pending } = queue(async (topic) => {
+    calls.push(topic);
+    if (calls.length === 1) throw new Error("offline");
+    return true;
+  });
+  q.start(); q.owe(["positions", "annotations"]);
+  await run();
+  assert.deepEqual(calls, ["positions", "annotations"]);
+  assert.equal(pending(), true);
+  await run();
+  assert.deepEqual(calls, ["positions", "annotations", "positions"]);
+});
+
+test("hidden stops reads; restart preserves debt; account reset drops it", async () => {
+  const calls = [];
+  const { q, run, pending } = queue(async (topic) => { calls.push(topic); return true; });
+  q.start(); q.owe(["positions"]); q.stop();
+  await run();
+  assert.deepEqual(calls, []);
+  q.start(); await run();
+  assert.deepEqual(calls, ["positions"]);
+  q.owe(["annotations"]); q.reset();
+  await run();
+  assert.equal(pending(), false);
+  assert.deepEqual(calls, ["positions"]);
+});
+
+test("failure from a previous account does not requeue on the new account", async () => {
+  let reject;
+  const calls = [];
+  const { q, run, pending } = queue(async (topic) => {
+    calls.push(topic);
+    await new Promise((_, r) => { reject = r; });
+  });
+  q.start(); q.owe(["positions", "annotations"]); await run();
+  q.reset();
+  reject(new Error("old response")); await flush();
+  assert.equal(pending(), false);
+  assert.deepEqual(calls, ["positions"]);
+});


### PR DESCRIPTION
## Summary

The server now tells connected clients when reading positions, annotations, or statistics have changed. Clients then read the existing durable feeds, so the stream accelerates refreshes without becoming a second source of truth.

## Changes

- Added authenticated, scope-filtered live invalidation events with heartbeats and stream limits.
- Published notifications after successful storage commits only.
- Added web reader refresh, annotation replacement, and resume-only position catch-up.
- Documented the API, client behavior, proxy requirements, and deployment impact.

## Testing

- [x] Focused `go test -race ./internal/api ./internal/live ./internal/store/...` with SQLite and disposable PostgreSQL coverage.
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files.
- [x] `go tool templ generate ./internal/webui/` completed with generated output checked.
- [x] `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish` passed.
- [x] Manually tested the API and web reader through a disposable reverse proxy and headless browser.

## Screenshots, logs, or API examples

The attached screenshot shows the web reader offering position catch-up after resume.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.

![Web reader resume-only catch-up](https://github.com/user-attachments/assets/bf412b6e-29e4-41ec-a0c8-2b81ef5f81cc)