### PR TITLE
fix: quiet the half-hourly Calibre scan noise

### DIFF
--- a/internal/content/calibre_linux.go
+++ b/internal/content/calibre_linux.go
@@ -72,8 +72,33 @@ func (r *Reconciler) reconcileCalibre(
 	}
 	defer root.Close()
 
+	// What the catalog already holds, so a book that has been unservable
+	// for weeks does not say so again on every half-hourly pass: the
+	// interesting moments are becoming missing and coming back, and the
+	// prior status is what tells them apart from staying gone.
+	known, err := r.catalog.BooksInFolder(ctx, folder.ID)
+	if err != nil {
+		return store.ReconcileResult{}, err
+	}
+	priorStatus := make(map[int64]store.BookStatus, len(known))
+	for _, b := range known {
+		if b.CalibreID != nil {
+			priorStatus[*b.CalibreID] = b.Status
+		}
+	}
+
 	observed := make([]store.ObservedBook, 0, len(books))
 	complete := true
+	// Transitions are worth an INFO line, but only once the store has
+	// committed them: a line written during the scan would claim a
+	// change a failed reconcile never made, then claim it again on the
+	// retry that did.
+	type transition struct {
+		msg       string
+		calibreID int64
+		title     string
+	}
+	var transitions []transition
 	for _, book := range books {
 		if err := ctx.Err(); err != nil {
 			return store.ReconcileResult{}, err
@@ -103,8 +128,28 @@ func (r *Reconciler) reconcileCalibre(
 			// of it survive, and so one such book does not declare the
 			// whole pass blind and stop it concluding anything.
 			if errors.Is(err, fs.ErrNotExist) {
-				r.log.Info("calibre book has no file on disk",
-					"folder", folder.ID, "calibre_id", book.ID)
+				// Say it once, when it happens: only a book the catalog
+				// held as active has just vanished. One it already
+				// carries as missing has been reported, and one it never
+				// held stays a debug line too — the store keeps no row
+				// for a book that has never been servable, so an INFO
+				// here would repeat every pass, forever. A half-hourly
+				// reminder is noise an operator learns to ignore, which
+				// is worse than silence.
+				switch priorStatus[book.ID] {
+				case store.BookActive:
+					transitions = append(transitions, transition{
+						"calibre book has no file on disk",
+						book.ID, book.Title})
+				case store.BookMissing:
+					r.log.Debug("calibre book still has no file on disk",
+						"folder", folder.ID, "calibre_id", book.ID,
+						"title", book.Title)
+				default:
+					r.log.Debug("calibre book has never had a file on disk",
+						"folder", folder.ID, "calibre_id", book.ID,
+						"title", book.Title)
+				}
 				calibreID := book.ID
 				observed = append(observed, store.ObservedBook{
 					CalibreID:  &calibreID,
@@ -117,9 +162,25 @@ func (r *Reconciler) reconcileCalibre(
 			complete = false
 			continue
 		}
+		// The other half of the transition: the file is back, so the
+		// store will return the row to active, and the log says which
+		// book that was rather than leaving a bare returned=1 counter.
+		if priorStatus[book.ID] == store.BookMissing {
+			transitions = append(transitions, transition{
+				"calibre book has a file on disk again",
+				book.ID, book.Title})
+		}
 		observed = append(observed, obs)
 	}
-	return r.catalog.ReconcileFolder(ctx, folder.ID, observed, complete, r.now())
+	result, err := r.catalog.ReconcileFolder(ctx, folder.ID, observed, complete, r.now())
+	if err != nil {
+		return store.ReconcileResult{}, err
+	}
+	for _, tr := range transitions {
+		r.log.Info(tr.msg, "folder", folder.ID,
+			"calibre_id", tr.calibreID, "title", tr.title)
+	}
+	return result, nil
 }
 
 // readCalibreBookFormats reads the first of a book's formats that is

--- a/internal/content/calibre_log_transitions_linux_test.go
+++ b/internal/content/calibre_log_transitions_linux_test.go
@@ -1,0 +1,125 @@
+//go:build linux
+
+package content
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/chmouel/liseur-sync/internal/epub"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// TestACalibreMissingFileIsLoggedOnTransitionsOnly. The interesting
+// moments in a book's absence are its edges: the pass that watched an
+// active book vanish, and the pass that found it back. Every pass in
+// between is the same fact restated, and a reminder every half hour is
+// noise an operator learns to ignore — which is worse than silence,
+// because the line that matters then scrolls past unread. A book that
+// has never been servable never gets past debug either: the store keeps
+// no row for it, so there is no state an INFO-once could hang off.
+func TestACalibreMissingFileIsLoggedOnTransitionsOnly(t *testing.T) {
+	root := writeCalibreLibrary(t)
+	catalog := newFakeCatalog()
+	folder := store.Folder{ID: "f-calibre", RootPath: root, Kind: store.FolderCalibre}
+
+	var buf bytes.Buffer
+	r := NewReconciler(catalog, ScanLimits{}, epub.DefaultLimits(),
+		slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	pass := func() {
+		t.Helper()
+		if _, err := r.Reconcile(context.Background(), folder); err != nil {
+			t.Fatal(err)
+		}
+	}
+	logged := func(msg string) int {
+		return strings.Count(buf.String(), msg)
+	}
+	goneID := int64(2)
+	markActive := func() {
+		// What the catalog holds after 'Gone' had a servable file: the
+		// real store would carry the row as active from that pass.
+		catalog.mu.Lock()
+		catalog.known[folder.ID] = []store.KnownBook{
+			{ID: "b-gone", CalibreID: &goneID, Status: store.BookActive},
+		}
+		catalog.mu.Unlock()
+	}
+
+	// A book metadata.db listed before the server ever saw a file for
+	// it is not a transition: there is no row to remember it by, so an
+	// INFO here would repeat on every pass, forever.
+	pass()
+	if n := logged("no file on disk"); n != 0 {
+		t.Fatalf("a never-servable book was reported at INFO:\n%s", buf.String())
+	}
+
+	// The disappearance of a book the catalog held as active is news,
+	// said once.
+	markActive()
+	buf.Reset()
+	pass()
+	if n := logged("calibre book has no file on disk"); n != 1 {
+		t.Fatalf("an active book vanishing should be reported once, got %d:\n%s", n, buf.String())
+	}
+	if !strings.Contains(buf.String(), `"title":"Gone"`) {
+		t.Fatalf("the report should name the book:\n%s", buf.String())
+	}
+
+	// The next pass over the same absence: the fake, like the store,
+	// now carries the row as missing, and the pass says nothing at INFO.
+	buf.Reset()
+	pass()
+	if n := logged("no file on disk"); n != 0 {
+		t.Fatalf("a book already carried as missing was reported again:\n%s", buf.String())
+	}
+
+	// The file comes back: the return is news, said once.
+	writeBook(t, root, filepath.Join("A Writer/Gone (2)", "Gone.epub"), "Gone")
+	buf.Reset()
+	pass()
+	if n := logged("calibre book has a file on disk again"); n != 1 {
+		t.Fatalf("the return should be reported once, got %d:\n%s", n, buf.String())
+	}
+
+	// A settled library says nothing at all.
+	buf.Reset()
+	pass()
+	if buf.Len() != 0 {
+		t.Fatalf("a pass over a settled library should be silent:\n%s", buf.String())
+	}
+}
+
+// TestACalibreTransitionIsNotLoggedWhenTheStoreRejectsThePass. A
+// transition line is a claim about the catalog, so it may only be
+// written once the store has committed it: logged during the scan it
+// would announce a change a failed reconcile never made, and then
+// announce it again on the retry that did.
+func TestACalibreTransitionIsNotLoggedWhenTheStoreRejectsThePass(t *testing.T) {
+	root := writeCalibreLibrary(t)
+	catalog := newFakeCatalog()
+	folder := store.Folder{ID: "f-calibre", RootPath: root, Kind: store.FolderCalibre}
+	goneID := int64(2)
+	catalog.mu.Lock()
+	catalog.known[folder.ID] = []store.KnownBook{
+		{ID: "b-gone", CalibreID: &goneID, Status: store.BookActive},
+	}
+	catalog.fail = true
+	catalog.mu.Unlock()
+
+	var buf bytes.Buffer
+	r := NewReconciler(catalog, ScanLimits{}, epub.DefaultLimits(),
+		slog.New(slog.NewJSONHandler(&buf, nil)))
+
+	if _, err := r.Reconcile(context.Background(), folder); err == nil {
+		t.Fatal("the fake was told to fail and did not")
+	}
+	if strings.Contains(buf.String(), "no file on disk") {
+		t.Fatalf("a transition was announced for a pass the store rejected:\n%s", buf.String())
+	}
+}

--- a/internal/content/pass_linux_test.go
+++ b/internal/content/pass_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -32,6 +33,7 @@ type fakeCatalog struct {
 	calls    int
 	observed []store.ObservedBook
 	complete bool
+	fail     bool
 	changed  chan struct{}
 }
 
@@ -65,17 +67,39 @@ func (c *fakeCatalog) ReconcileFolder(
 	c.calls++
 	c.observed = observed
 	c.complete = complete
+	if c.fail {
+		return store.ReconcileResult{}, errors.New("the catalog was told to reject this pass")
+	}
 	// Only a pass allowed to conclude anything gets to rewrite what is
-	// known, which is the same rule the real store enforces.
+	// known, which is the same rule the real store enforces — including
+	// its treatment of an unservable observation: an existing row is
+	// marked missing and kept, a book that has never been servable gets
+	// no row at all.
 	if complete && len(observed) > 0 {
+		prior := map[int64]store.KnownBook{}
+		for _, b := range c.known[folderID] {
+			if b.CalibreID != nil {
+				prior[*b.CalibreID] = b
+			}
+		}
 		books := make([]store.KnownBook, 0, len(observed))
 		for _, o := range observed {
+			if o.Unservable {
+				if o.CalibreID != nil {
+					if b, ok := prior[*o.CalibreID]; ok {
+						b.Status = store.BookMissing
+						books = append(books, b)
+					}
+				}
+				continue
+			}
 			books = append(books, store.KnownBook{
 				ID:            folderID + "-" + o.RelativePath,
 				RelativePath:  o.RelativePath,
 				SizeBytes:     o.SizeBytes,
 				MTime:         o.MTime,
 				ContentSHA256: o.ContentSHA256,
+				CalibreID:     o.CalibreID,
 				Status:        store.BookActive,
 			})
 		}

--- a/internal/store/postgres/reconcile.go
+++ b/internal/store/postgres/reconcile.go
@@ -204,7 +204,7 @@ func (s *Store) ReconcileFolder(
 				}
 			}
 
-			relationsChanged, err := replaceRelationsTx(ctx, tx, folderID, bookID, obs, at)
+			relationsChanged, err := replaceRelationsTx(ctx, tx, folderID, bookID, obs, at, refreshing)
 			if err != nil {
 				return err
 			}
@@ -354,11 +354,12 @@ func existingBooksTx(
 			id, path, sha string
 			calibreID     sql.NullInt64
 			cover         sql.NullString
+			coverSHA      sql.NullString
 			facts         store.BookFacts
 		)
 		if err := rows.Scan(&id, &path, &calibreID, &sha,
 			&facts.SizeBytes, &facts.MTime, &facts.OriginalFilename,
-			&facts.MediaType, &cover, &facts.CoverSHA256,
+			&facts.MediaType, &cover, &coverSHA,
 			&facts.Title, &facts.Subtitle, &facts.Description,
 			&facts.Publisher, &facts.PublishedDate); err != nil {
 			return nil, err
@@ -366,6 +367,7 @@ func existingBooksTx(
 		facts.RelativePath = path
 		facts.ContentSHA256 = sha
 		facts.CoverRelativePath = cover.String
+		facts.CoverSHA256 = coverSHA.String
 		prior := priorBook{id: id, path: path, sha256: sha, facts: facts}
 		switch {
 		case byCalibreID && calibreID.Valid:
@@ -711,11 +713,17 @@ func primaryAuthorOf(obs store.ObservedBook) string {
 // itself — is what a pass counts as an update.
 func replaceRelationsTx(
 	ctx context.Context, tx *sql.Tx, folderID, bookID string,
-	obs store.ObservedBook, at time.Time,
+	obs store.ObservedBook, at time.Time, detectChange bool,
 ) (bool, error) {
-	before, err := relationsFingerprintTx(ctx, tx, folderID, bookID)
-	if err != nil {
-		return false, err
+	// The fingerprints cost ten SELECTs per book, so only the refresh
+	// path — the one that reports Updated — pays for them; an insert
+	// already counted as Added.
+	var before string
+	if detectChange {
+		var err error
+		if before, err = relationsFingerprintTx(ctx, tx, folderID, bookID); err != nil {
+			return false, err
+		}
 	}
 	for _, table := range []string{
 		"book_identifiers", "book_languages", "book_tags",
@@ -806,6 +814,9 @@ func replaceRelationsTx(
 			folderID, bookID, contributorID, role, c.Position); err != nil {
 			return false, err
 		}
+	}
+	if !detectChange {
+		return false, nil
 	}
 	after, err := relationsFingerprintTx(ctx, tx, folderID, bookID)
 	if err != nil {

--- a/internal/store/postgres/reconcile.go
+++ b/internal/store/postgres/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/metadata"
@@ -147,6 +148,13 @@ func (s *Store) ReconcileFolder(
 			}
 
 			var bookID string
+			// refreshing marks the update path, where Updated is only
+			// counted if the row's facts or its relations actually
+			// moved — a pass that re-read everything and found it as
+			// recorded changed nothing worth a log line.
+			refreshing := false
+			factsChanged := false
+			statusReturned := false
 			switch {
 			case had && obs.Unchanged:
 				// The pass recognised this file by its stat and did not
@@ -172,6 +180,7 @@ func (s *Store) ReconcileFolder(
 				}
 				if returned {
 					result.Returned++
+					statusReturned = true
 				}
 				// The same book with different bytes: a Calibre metadata
 				// edit rewrites the publication in place. Whoever was
@@ -183,7 +192,8 @@ func (s *Store) ReconcileFolder(
 					return err
 				}
 				result.Rekeyed += rekeyed
-				result.Updated++
+				refreshing = true
+				factsChanged = prior.facts.DiffersFrom(obs)
 			default:
 				bookID = store.NewID()
 				if err := insertBookTx(ctx, tx, folderID, bookID, obs, at); err != nil {
@@ -194,8 +204,24 @@ func (s *Store) ReconcileFolder(
 				}
 			}
 
-			if err := replaceRelationsTx(ctx, tx, folderID, bookID, obs, at); err != nil {
+			relationsChanged, err := replaceRelationsTx(ctx, tx, folderID, bookID, obs, at)
+			if err != nil {
 				return err
+			}
+			if refreshing && (factsChanged || relationsChanged) {
+				result.Updated++
+			}
+			// updated_at is a modification time clients see (catalog
+			// JSON, OPDS, conditional GETs), so a pass that merely
+			// re-read the book must not advance it. A return counts:
+			// missing→active is a visible change even when every fact
+			// matches.
+			if refreshing && (factsChanged || relationsChanged || statusReturned) {
+				if _, err := tx.ExecContext(ctx, q(
+					`UPDATE books SET updated_at = ? WHERE id = ? AND folder_id = ?`),
+					at.UTC(), bookID, folderID); err != nil {
+					return err
+				}
 			}
 			if err := reindexBookTx(ctx, tx, bookID); err != nil {
 				return err
@@ -295,21 +321,28 @@ func observationKey(obs store.ObservedBook, byCalibreID bool) (string, error) {
 }
 
 // priorBook is what the catalog already holds for one identity key: the
-// row's id, and the digest it was last written with. The digest is
-// carried because a book whose bytes changed while keeping its identity
-// — the shape of every Calibre metadata edit — is the one case where a
-// reader's work graph has to be told something.
+// row's id, its material facts, and the digest it was last written
+// with. The digest is carried because a book whose bytes changed while
+// keeping its identity — the shape of every Calibre metadata edit — is
+// the one case where a reader's work graph has to be told something.
+// The facts are read here, before a Calibre pass parks every path, so
+// they describe the row as the last pass left it rather than the parked
+// intermediate state.
 type priorBook struct {
 	id     string
 	path   string
 	sha256 string
+	facts  store.BookFacts
 }
 
 func existingBooksTx(
 	ctx context.Context, tx *sql.Tx, folderID string, byCalibreID bool,
 ) (map[string]priorBook, error) {
 	rows, err := tx.QueryContext(ctx, q(
-		`SELECT id, relative_path, calibre_id, content_sha256
+		`SELECT id, relative_path, calibre_id, content_sha256,
+		        size_bytes, mtime, original_filename, media_type,
+		        cover_relative_path, cover_sha256,
+		        title, subtitle, description, publisher, published_date
 		 FROM books WHERE folder_id = ?`), folderID)
 	if err != nil {
 		return nil, err
@@ -320,11 +353,20 @@ func existingBooksTx(
 		var (
 			id, path, sha string
 			calibreID     sql.NullInt64
+			cover         sql.NullString
+			facts         store.BookFacts
 		)
-		if err := rows.Scan(&id, &path, &calibreID, &sha); err != nil {
+		if err := rows.Scan(&id, &path, &calibreID, &sha,
+			&facts.SizeBytes, &facts.MTime, &facts.OriginalFilename,
+			&facts.MediaType, &cover, &facts.CoverSHA256,
+			&facts.Title, &facts.Subtitle, &facts.Description,
+			&facts.Publisher, &facts.PublishedDate); err != nil {
 			return nil, err
 		}
-		prior := priorBook{id: id, path: path, sha256: sha}
+		facts.RelativePath = path
+		facts.ContentSHA256 = sha
+		facts.CoverRelativePath = cover.String
+		prior := priorBook{id: id, path: path, sha256: sha, facts: facts}
 		switch {
 		case byCalibreID && calibreID.Valid:
 			out[fmt.Sprintf("c:%d", calibreID.Int64)] = prior
@@ -383,13 +425,13 @@ func updateBookTx(
 			original_filename = ?, media_type = ?, calibre_id = ?,
 			cover_relative_path = ?, cover_sha256 = ?,
 			title = ?, subtitle = ?, description = ?, publisher = ?,
-			published_date = ?, updated_at = ?, seen_at = ?, absent_at = NULL
+			published_date = ?, seen_at = ?, absent_at = NULL
 		 WHERE id = ? AND folder_id = ?`),
 		obs.RelativePath, obs.SizeBytes, obs.MTime.UTC(), obs.ContentSHA256,
 		obs.OriginalFilename, mediaTypeOf(obs), nullInt64(obs.CalibreID),
 		nullStr(obs.CoverRelativePath), obs.CoverSHA256,
 		obs.Title, obs.Subtitle, obs.Description, obs.Publisher, obs.PublishedDate,
-		at.UTC(), at.UTC(),
+		at.UTC(),
 		bookID, folderID)
 	return store.BookStatus(status) == store.BookMissing, err
 }
@@ -664,11 +706,17 @@ func primaryAuthorOf(obs store.ObservedBook) string {
 // replaceRelationsTx rewrites a book's metadata sets wholesale. With no
 // manual editing and no external providers there is one source per
 // folder and nothing to merge, so "what the folder says now" simply
-// replaces "what it said last time".
+// replaces "what it said last time". It reports whether the rewrite
+// left different rows behind, because that difference — not the rewrite
+// itself — is what a pass counts as an update.
 func replaceRelationsTx(
 	ctx context.Context, tx *sql.Tx, folderID, bookID string,
 	obs store.ObservedBook, at time.Time,
-) error {
+) (bool, error) {
+	before, err := relationsFingerprintTx(ctx, tx, folderID, bookID)
+	if err != nil {
+		return false, err
+	}
 	for _, table := range []string{
 		"book_identifiers", "book_languages", "book_tags",
 		"book_series", "book_contributors",
@@ -676,7 +724,7 @@ func replaceRelationsTx(
 		if _, err := tx.ExecContext(ctx, q(
 			`DELETE FROM `+table+` WHERE folder_id = ? AND book_id = ?`),
 			folderID, bookID); err != nil {
-			return err
+			return false, err
 		}
 	}
 
@@ -688,7 +736,7 @@ func replaceRelationsTx(
 			`INSERT INTO book_identifiers (folder_id, book_id, scheme, value)
 			 VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING`),
 			folderID, bookID, id.Scheme, id.Value); err != nil {
-			return err
+			return false, err
 		}
 	}
 	for _, lang := range obs.Languages {
@@ -699,14 +747,14 @@ func replaceRelationsTx(
 			`INSERT INTO book_languages (folder_id, book_id, language)
 			 VALUES (?, ?, ?) ON CONFLICT DO NOTHING`),
 			folderID, bookID, lang); err != nil {
-			return err
+			return false, err
 		}
 	}
 	for _, tag := range obs.Tags {
 		tagID, err := resolveEntityTx(ctx, tx, "tags", tag, at)
 		if err != nil || tagID == "" {
 			if err != nil {
-				return err
+				return false, err
 			}
 			continue
 		}
@@ -714,14 +762,14 @@ func replaceRelationsTx(
 			`INSERT INTO book_tags (folder_id, book_id, tag_id)
 			 VALUES (?, ?, ?) ON CONFLICT DO NOTHING`),
 			folderID, bookID, tagID); err != nil {
-			return err
+			return false, err
 		}
 	}
 	for _, sr := range obs.Series {
 		seriesID, err := resolveSeriesTx(ctx, tx, folderID, sr.Name, at)
 		if err != nil || seriesID == "" {
 			if err != nil {
-				return err
+				return false, err
 			}
 			continue
 		}
@@ -734,14 +782,14 @@ func replaceRelationsTx(
 			 VALUES (?, ?, ?, ?)
 			 ON CONFLICT (book_id, series_id) DO UPDATE SET position = excluded.position`),
 			folderID, bookID, seriesID, position); err != nil {
-			return err
+			return false, err
 		}
 	}
 	for _, c := range obs.Contributors {
 		contributorID, err := resolveEntityTx(ctx, tx, "contributors", c.Name, at)
 		if err != nil || contributorID == "" {
 			if err != nil {
-				return err
+				return false, err
 			}
 			continue
 		}
@@ -756,10 +804,63 @@ func replaceRelationsTx(
 			 ON CONFLICT (book_id, contributor_id, role)
 			 DO UPDATE SET position = excluded.position`),
 			folderID, bookID, contributorID, role, c.Position); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	after, err := relationsFingerprintTx(ctx, tx, folderID, bookID)
+	if err != nil {
+		return false, err
+	}
+	return before != after, nil
+}
+
+// relationsFingerprintQueries canonicalize one book's relation rows,
+// one line per row, so before-and-after strings compare a rewrite for
+// effect. Ordering is fixed and every query carries (folderID, bookID).
+var relationsFingerprintQueries = []string{
+	`SELECT scheme || ':' || value FROM book_identifiers
+	  WHERE folder_id = ? AND book_id = ? ORDER BY scheme, value`,
+	`SELECT language FROM book_languages
+	  WHERE folder_id = ? AND book_id = ? ORDER BY language`,
+	`SELECT tag_id FROM book_tags
+	  WHERE folder_id = ? AND book_id = ? ORDER BY tag_id`,
+	`SELECT series_id || '@' || COALESCE(CAST(position AS TEXT), '')
+	   FROM book_series
+	  WHERE folder_id = ? AND book_id = ? ORDER BY series_id`,
+	`SELECT contributor_id || '#' || role || '#' || CAST(position AS TEXT)
+	   FROM book_contributors
+	  WHERE folder_id = ? AND book_id = ?
+	  ORDER BY contributor_id, role`,
+}
+
+// relationsFingerprintTx reads one book's relations into a canonical
+// string. It only ever compares a book with itself within one
+// transaction on one backend, so the text of a REAL cast never has to
+// agree across engines — only with itself.
+func relationsFingerprintTx(
+	ctx context.Context, tx *sql.Tx, folderID, bookID string,
+) (string, error) {
+	var out strings.Builder
+	for i, query := range relationsFingerprintQueries {
+		rows, err := tx.QueryContext(ctx, q(query), folderID, bookID)
+		if err != nil {
+			return "", err
+		}
+		for rows.Next() {
+			var line string
+			if err := rows.Scan(&line); err != nil {
+				rows.Close()
+				return "", err
+			}
+			fmt.Fprintf(&out, "%d:%s\n", i, line)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", err
+		}
+		rows.Close()
+	}
+	return out.String(), nil
 }
 
 // resolveSeriesTx resolves an observed series name to the series it
@@ -855,11 +956,23 @@ func touchBookTx(
 		bookID, folderID).Scan(&status); err != nil {
 		return false, err
 	}
+	returned := store.BookStatus(status) == store.BookMissing
+	// A return is a visible change even though no fact moved, so it is
+	// the one touch that advances the client-facing updated_at.
+	if returned {
+		_, err := tx.ExecContext(ctx, q(
+			`UPDATE books SET status = 'active', relative_path = ?, size_bytes = ?,
+			        mtime = ?, seen_at = ?, updated_at = ?, absent_at = NULL
+			 WHERE id = ? AND folder_id = ?`),
+			obs.RelativePath, obs.SizeBytes, obs.MTime.UTC(), at.UTC(),
+			at.UTC(), bookID, folderID)
+		return true, err
+	}
 	_, err := tx.ExecContext(ctx, q(
 		`UPDATE books SET status = 'active', relative_path = ?, size_bytes = ?,
 		        mtime = ?, seen_at = ?, absent_at = NULL
 		 WHERE id = ? AND folder_id = ?`),
 		obs.RelativePath, obs.SizeBytes, obs.MTime.UTC(), at.UTC(),
 		bookID, folderID)
-	return store.BookStatus(status) == store.BookMissing, err
+	return false, err
 }

--- a/internal/store/sqlite/reconcile.go
+++ b/internal/store/sqlite/reconcile.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/metadata"
@@ -142,6 +143,13 @@ func (s *Store) ReconcileFolder(
 			}
 
 			var bookID string
+			// refreshing marks the update path, where Updated is only
+			// counted if the row's facts or its relations actually
+			// moved — a pass that re-read everything and found it as
+			// recorded changed nothing worth a log line.
+			refreshing := false
+			factsChanged := false
+			statusReturned := false
 			switch {
 			case had && obs.Unchanged:
 				// The pass recognised this file by its stat and did not
@@ -167,6 +175,7 @@ func (s *Store) ReconcileFolder(
 				}
 				if returned {
 					result.Returned++
+					statusReturned = true
 				}
 				// The same book with different bytes: a Calibre metadata
 				// edit rewrites the publication in place. Whoever was
@@ -178,7 +187,8 @@ func (s *Store) ReconcileFolder(
 					return err
 				}
 				result.Rekeyed += rekeyed
-				result.Updated++
+				refreshing = true
+				factsChanged = prior.facts.DiffersFrom(obs)
 			default:
 				bookID = store.NewID()
 				if err := insertBookTx(ctx, tx, folderID, bookID, obs, at); err != nil {
@@ -189,8 +199,24 @@ func (s *Store) ReconcileFolder(
 				}
 			}
 
-			if err := replaceRelationsTx(ctx, tx, folderID, bookID, obs, at); err != nil {
+			relationsChanged, err := replaceRelationsTx(ctx, tx, folderID, bookID, obs, at)
+			if err != nil {
 				return err
+			}
+			if refreshing && (factsChanged || relationsChanged) {
+				result.Updated++
+			}
+			// updated_at is a modification time clients see (catalog
+			// JSON, OPDS, conditional GETs), so a pass that merely
+			// re-read the book must not advance it. A return counts:
+			// missing→active is a visible change even when every fact
+			// matches.
+			if refreshing && (factsChanged || relationsChanged || statusReturned) {
+				if _, err := tx.ExecContext(ctx,
+					`UPDATE books SET updated_at = ? WHERE id = ? AND folder_id = ?`,
+					formatTime(at), bookID, folderID); err != nil {
+					return err
+				}
 			}
 			if err := reindexBookTx(ctx, tx, bookID); err != nil {
 				return err
@@ -290,21 +316,28 @@ func observationKey(obs store.ObservedBook, byCalibreID bool) (string, error) {
 }
 
 // priorBook is what the catalog already holds for one identity key: the
-// row's id, and the digest it was last written with. The digest is
-// carried because a book whose bytes changed while keeping its identity
-// — the shape of every Calibre metadata edit — is the one case where a
-// reader's work graph has to be told something.
+// row's id, its material facts, and the digest it was last written
+// with. The digest is carried because a book whose bytes changed while
+// keeping its identity — the shape of every Calibre metadata edit — is
+// the one case where a reader's work graph has to be told something.
+// The facts are read here, before a Calibre pass parks every path, so
+// they describe the row as the last pass left it rather than the parked
+// intermediate state.
 type priorBook struct {
 	id     string
 	path   string
 	sha256 string
+	facts  store.BookFacts
 }
 
 func existingBooksTx(
 	ctx context.Context, tx *sql.Tx, folderID string, byCalibreID bool,
 ) (map[string]priorBook, error) {
 	rows, err := tx.QueryContext(ctx,
-		`SELECT id, relative_path, calibre_id, content_sha256
+		`SELECT id, relative_path, calibre_id, content_sha256,
+		        size_bytes, mtime, original_filename, media_type,
+		        cover_relative_path, cover_sha256,
+		        title, subtitle, description, publisher, published_date
 		 FROM books WHERE folder_id = ?`, folderID)
 	if err != nil {
 		return nil, err
@@ -315,11 +348,24 @@ func existingBooksTx(
 		var (
 			id, path, sha string
 			calibreID     sql.NullInt64
+			mtime         string
+			cover         sql.NullString
+			facts         store.BookFacts
 		)
-		if err := rows.Scan(&id, &path, &calibreID, &sha); err != nil {
+		if err := rows.Scan(&id, &path, &calibreID, &sha,
+			&facts.SizeBytes, &mtime, &facts.OriginalFilename, &facts.MediaType,
+			&cover, &facts.CoverSHA256,
+			&facts.Title, &facts.Subtitle, &facts.Description,
+			&facts.Publisher, &facts.PublishedDate); err != nil {
 			return nil, err
 		}
-		prior := priorBook{id: id, path: path, sha256: sha}
+		if facts.MTime, err = parseTime(mtime); err != nil {
+			return nil, err
+		}
+		facts.RelativePath = path
+		facts.ContentSHA256 = sha
+		facts.CoverRelativePath = cover.String
+		prior := priorBook{id: id, path: path, sha256: sha, facts: facts}
 		switch {
 		case byCalibreID && calibreID.Valid:
 			out[fmt.Sprintf("c:%d", calibreID.Int64)] = prior
@@ -383,13 +429,13 @@ func updateBookTx(
 			original_filename = ?, media_type = ?, calibre_id = ?,
 			cover_relative_path = ?, cover_sha256 = ?,
 			title = ?, subtitle = ?, description = ?, publisher = ?,
-			published_date = ?, updated_at = ?, seen_at = ?, absent_at = NULL
+			published_date = ?, seen_at = ?, absent_at = NULL
 		 WHERE id = ? AND folder_id = ?`,
 		obs.RelativePath, obs.SizeBytes, formatTime(obs.MTime), obs.ContentSHA256,
 		obs.OriginalFilename, mediaTypeOf(obs), nullInt64(obs.CalibreID),
 		nullStr(obs.CoverRelativePath), obs.CoverSHA256,
 		obs.Title, obs.Subtitle, obs.Description, obs.Publisher, obs.PublishedDate,
-		formatTime(at), formatTime(at),
+		formatTime(at),
 		bookID, folderID)
 	return store.BookStatus(status) == store.BookMissing, err
 }
@@ -664,11 +710,17 @@ func primaryAuthorOf(obs store.ObservedBook) string {
 // replaceRelationsTx rewrites a book's metadata sets wholesale. With no
 // manual editing and no external providers there is one source per
 // folder and nothing to merge, so "what the folder says now" simply
-// replaces "what it said last time".
+// replaces "what it said last time". It reports whether the rewrite
+// left different rows behind, because that difference — not the rewrite
+// itself — is what a pass counts as an update.
 func replaceRelationsTx(
 	ctx context.Context, tx *sql.Tx, folderID, bookID string,
 	obs store.ObservedBook, at time.Time,
-) error {
+) (bool, error) {
+	before, err := relationsFingerprintTx(ctx, tx, folderID, bookID)
+	if err != nil {
+		return false, err
+	}
 	for _, table := range []string{
 		"book_identifiers", "book_languages", "book_tags",
 		"book_series", "book_contributors",
@@ -676,7 +728,7 @@ func replaceRelationsTx(
 		if _, err := tx.ExecContext(ctx,
 			`DELETE FROM `+table+` WHERE folder_id = ? AND book_id = ?`,
 			folderID, bookID); err != nil {
-			return err
+			return false, err
 		}
 	}
 
@@ -688,7 +740,7 @@ func replaceRelationsTx(
 			`INSERT INTO book_identifiers (folder_id, book_id, scheme, value)
 			 VALUES (?, ?, ?, ?) ON CONFLICT DO NOTHING`,
 			folderID, bookID, id.Scheme, id.Value); err != nil {
-			return err
+			return false, err
 		}
 	}
 	for _, lang := range obs.Languages {
@@ -699,14 +751,14 @@ func replaceRelationsTx(
 			`INSERT INTO book_languages (folder_id, book_id, language)
 			 VALUES (?, ?, ?) ON CONFLICT DO NOTHING`,
 			folderID, bookID, lang); err != nil {
-			return err
+			return false, err
 		}
 	}
 	for _, tag := range obs.Tags {
 		tagID, err := resolveEntityTx(ctx, tx, "tags", tag, at)
 		if err != nil || tagID == "" {
 			if err != nil {
-				return err
+				return false, err
 			}
 			continue
 		}
@@ -714,14 +766,14 @@ func replaceRelationsTx(
 			`INSERT INTO book_tags (folder_id, book_id, tag_id)
 			 VALUES (?, ?, ?) ON CONFLICT DO NOTHING`,
 			folderID, bookID, tagID); err != nil {
-			return err
+			return false, err
 		}
 	}
 	for _, sr := range obs.Series {
 		seriesID, err := resolveSeriesTx(ctx, tx, folderID, sr.Name, at)
 		if err != nil || seriesID == "" {
 			if err != nil {
-				return err
+				return false, err
 			}
 			continue
 		}
@@ -734,14 +786,14 @@ func replaceRelationsTx(
 			 VALUES (?, ?, ?, ?)
 			 ON CONFLICT (book_id, series_id) DO UPDATE SET position = excluded.position`,
 			folderID, bookID, seriesID, position); err != nil {
-			return err
+			return false, err
 		}
 	}
 	for _, c := range obs.Contributors {
 		contributorID, err := resolveEntityTx(ctx, tx, "contributors", c.Name, at)
 		if err != nil || contributorID == "" {
 			if err != nil {
-				return err
+				return false, err
 			}
 			continue
 		}
@@ -756,10 +808,63 @@ func replaceRelationsTx(
 			 ON CONFLICT (book_id, contributor_id, role)
 			 DO UPDATE SET position = excluded.position`,
 			folderID, bookID, contributorID, role, c.Position); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	after, err := relationsFingerprintTx(ctx, tx, folderID, bookID)
+	if err != nil {
+		return false, err
+	}
+	return before != after, nil
+}
+
+// relationsFingerprintQueries canonicalize one book's relation rows,
+// one line per row, so before-and-after strings compare a rewrite for
+// effect. Ordering is fixed and every query carries (folderID, bookID).
+var relationsFingerprintQueries = []string{
+	`SELECT scheme || ':' || value FROM book_identifiers
+	  WHERE folder_id = ? AND book_id = ? ORDER BY scheme, value`,
+	`SELECT language FROM book_languages
+	  WHERE folder_id = ? AND book_id = ? ORDER BY language`,
+	`SELECT tag_id FROM book_tags
+	  WHERE folder_id = ? AND book_id = ? ORDER BY tag_id`,
+	`SELECT series_id || '@' || COALESCE(CAST(position AS TEXT), '')
+	   FROM book_series
+	  WHERE folder_id = ? AND book_id = ? ORDER BY series_id`,
+	`SELECT contributor_id || '#' || role || '#' || CAST(position AS TEXT)
+	   FROM book_contributors
+	  WHERE folder_id = ? AND book_id = ?
+	  ORDER BY contributor_id, role`,
+}
+
+// relationsFingerprintTx reads one book's relations into a canonical
+// string. It only ever compares a book with itself within one
+// transaction on one backend, so the text of a REAL cast never has to
+// agree across engines — only with itself.
+func relationsFingerprintTx(
+	ctx context.Context, tx *sql.Tx, folderID, bookID string,
+) (string, error) {
+	var out strings.Builder
+	for i, query := range relationsFingerprintQueries {
+		rows, err := tx.QueryContext(ctx, query, folderID, bookID)
+		if err != nil {
+			return "", err
+		}
+		for rows.Next() {
+			var line string
+			if err := rows.Scan(&line); err != nil {
+				rows.Close()
+				return "", err
+			}
+			fmt.Fprintf(&out, "%d:%s\n", i, line)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return "", err
+		}
+		rows.Close()
+	}
+	return out.String(), nil
 }
 
 // resolveSeriesTx resolves an observed series name to the series it
@@ -863,11 +968,23 @@ func touchBookTx(
 		bookID, folderID).Scan(&status); err != nil {
 		return false, err
 	}
+	returned := store.BookStatus(status) == store.BookMissing
+	// A return is a visible change even though no fact moved, so it is
+	// the one touch that advances the client-facing updated_at.
+	if returned {
+		_, err := tx.ExecContext(ctx,
+			`UPDATE books SET status = 'active', relative_path = ?, size_bytes = ?,
+			        mtime = ?, seen_at = ?, updated_at = ?, absent_at = NULL
+			 WHERE id = ? AND folder_id = ?`,
+			obs.RelativePath, obs.SizeBytes, formatTime(obs.MTime), formatTime(at),
+			formatTime(at), bookID, folderID)
+		return true, err
+	}
 	_, err := tx.ExecContext(ctx,
 		`UPDATE books SET status = 'active', relative_path = ?, size_bytes = ?,
 		        mtime = ?, seen_at = ?, absent_at = NULL
 		 WHERE id = ? AND folder_id = ?`,
 		obs.RelativePath, obs.SizeBytes, formatTime(obs.MTime), formatTime(at),
 		bookID, folderID)
-	return store.BookStatus(status) == store.BookMissing, err
+	return false, err
 }

--- a/internal/store/sqlite/reconcile.go
+++ b/internal/store/sqlite/reconcile.go
@@ -199,7 +199,7 @@ func (s *Store) ReconcileFolder(
 				}
 			}
 
-			relationsChanged, err := replaceRelationsTx(ctx, tx, folderID, bookID, obs, at)
+			relationsChanged, err := replaceRelationsTx(ctx, tx, folderID, bookID, obs, at, refreshing)
 			if err != nil {
 				return err
 			}
@@ -350,11 +350,12 @@ func existingBooksTx(
 			calibreID     sql.NullInt64
 			mtime         string
 			cover         sql.NullString
+			coverSHA      sql.NullString
 			facts         store.BookFacts
 		)
 		if err := rows.Scan(&id, &path, &calibreID, &sha,
 			&facts.SizeBytes, &mtime, &facts.OriginalFilename, &facts.MediaType,
-			&cover, &facts.CoverSHA256,
+			&cover, &coverSHA,
 			&facts.Title, &facts.Subtitle, &facts.Description,
 			&facts.Publisher, &facts.PublishedDate); err != nil {
 			return nil, err
@@ -365,6 +366,7 @@ func existingBooksTx(
 		facts.RelativePath = path
 		facts.ContentSHA256 = sha
 		facts.CoverRelativePath = cover.String
+		facts.CoverSHA256 = coverSHA.String
 		prior := priorBook{id: id, path: path, sha256: sha, facts: facts}
 		switch {
 		case byCalibreID && calibreID.Valid:
@@ -715,11 +717,17 @@ func primaryAuthorOf(obs store.ObservedBook) string {
 // itself — is what a pass counts as an update.
 func replaceRelationsTx(
 	ctx context.Context, tx *sql.Tx, folderID, bookID string,
-	obs store.ObservedBook, at time.Time,
+	obs store.ObservedBook, at time.Time, detectChange bool,
 ) (bool, error) {
-	before, err := relationsFingerprintTx(ctx, tx, folderID, bookID)
-	if err != nil {
-		return false, err
+	// The fingerprints cost ten SELECTs per book, so only the refresh
+	// path — the one that reports Updated — pays for them; an insert
+	// already counted as Added.
+	var before string
+	if detectChange {
+		var err error
+		if before, err = relationsFingerprintTx(ctx, tx, folderID, bookID); err != nil {
+			return false, err
+		}
 	}
 	for _, table := range []string{
 		"book_identifiers", "book_languages", "book_tags",
@@ -810,6 +818,9 @@ func replaceRelationsTx(
 			folderID, bookID, contributorID, role, c.Position); err != nil {
 			return false, err
 		}
+	}
+	if !detectChange {
+		return false, nil
 	}
 	after, err := relationsFingerprintTx(ctx, tx, folderID, bookID)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -886,7 +886,13 @@ type ObservedContributor struct {
 // persisted: a pass holds no state, and running it twice is running it
 // once.
 type ReconcileResult struct {
-	Added    int
+	Added int
+	// Updated counts books whose stored facts or relations materially
+	// changed, not books a pass merely re-read. A Calibre pass re-reads
+	// every row of metadata.db every time (ADR-0022), so counting
+	// writes would report the whole library as updated twice an hour;
+	// counting differences is what lets a pass over an untouched folder
+	// say, honestly, that nothing happened.
 	Updated  int
 	Replaced int
 	Missing  int
@@ -909,6 +915,57 @@ type ReconcileResult struct {
 func (r ReconcileResult) Changed() bool {
 	return r.Added+r.Updated+r.Replaced+r.Missing+
 		r.Returned+r.Purged+r.Rekeyed > 0
+}
+
+// BookFacts is the material state of one catalog row: the columns a
+// pass writes that are about the book rather than about the pass
+// (seen_at, updated_at and status are about the pass). A backend
+// compares them with an observation to tell a write that changed the
+// book from one that merely refreshed it, which is the difference
+// ReconcileResult.Updated reports.
+type BookFacts struct {
+	RelativePath      string
+	SizeBytes         int64
+	MTime             time.Time
+	ContentSHA256     string
+	OriginalFilename  string
+	MediaType         string
+	CoverRelativePath string // empty when the row has none
+	CoverSHA256       string
+	Title             string
+	Subtitle          string
+	Description       string
+	Publisher         string
+	PublishedDate     string
+}
+
+// DiffersFrom reports whether writing this observation would change the
+// row's material columns. MTime is compared at microsecond precision,
+// the finest both backends round-trip.
+func (f BookFacts) DiffersFrom(obs ObservedBook) bool {
+	cover := ""
+	if obs.CoverRelativePath != nil {
+		cover = *obs.CoverRelativePath
+	}
+	mediaType := obs.MediaType
+	if mediaType == "" {
+		mediaType = "application/epub+zip"
+	}
+	sameMTime := f.MTime.UTC().Truncate(time.Microsecond).
+		Equal(obs.MTime.UTC().Truncate(time.Microsecond))
+	return f.RelativePath != obs.RelativePath ||
+		f.SizeBytes != obs.SizeBytes ||
+		!sameMTime ||
+		f.ContentSHA256 != obs.ContentSHA256 ||
+		f.OriginalFilename != obs.OriginalFilename ||
+		f.MediaType != mediaType ||
+		f.CoverRelativePath != cover ||
+		f.CoverSHA256 != obs.CoverSHA256 ||
+		f.Title != obs.Title ||
+		f.Subtitle != obs.Subtitle ||
+		f.Description != obs.Description ||
+		f.Publisher != obs.Publisher ||
+		f.PublishedDate != obs.PublishedDate
 }
 
 // KnownBook is what ReconcileFolder's caller already has on record for

--- a/internal/store/storetest/reconcile.go
+++ b/internal/store/storetest/reconcile.go
@@ -168,13 +168,16 @@ func testReconcileMissingAndReturning(t *testing.T, open OpenFunc) {
 	}
 
 	returnedAt := missingAt.Add(time.Hour)
+	// The file is back with the same stat, so the pass recognises it
+	// without a re-read: the return travels the Unchanged fast path,
+	// which is the one touch that must still move updated_at — the book
+	// visibly changed from missing to active even though no fact did.
 	returning := store.ObservedBook{
-		RelativePath: "gone.epub", SizeBytes: 10, MTime: now,
-		ContentSHA256: "sha-gone", Title: "Comes And Goes",
+		RelativePath: "gone.epub", SizeBytes: 10, MTime: now, Unchanged: true,
 	}
 	result = doReconcile(t, s, folder.ID, []store.ObservedBook{returning}, true, returnedAt)
-	if result.Returned != 1 {
-		t.Fatalf("want one returned book, got %+v", result)
+	if result.Returned != 1 || result.Updated != 0 {
+		t.Fatalf("want one returned book and nothing updated, got %+v", result)
 	}
 	got, err = s.CatalogBookByID(ctx, "", bookID)
 	if err != nil {
@@ -185,6 +188,12 @@ func testReconcileMissingAndReturning(t *testing.T, open OpenFunc) {
 	}
 	if got.AbsentAt != nil {
 		t.Fatalf("AbsentAt not cleared: %+v", got.AbsentAt)
+	}
+	if got.SeenAt == nil || !got.SeenAt.UTC().Equal(returnedAt) {
+		t.Fatalf("the return did not refresh seen_at: %+v", got.SeenAt)
+	}
+	if !got.UpdatedAt.UTC().Equal(returnedAt) {
+		t.Fatalf("the return did not move updated_at: %+v", got.UpdatedAt)
 	}
 }
 
@@ -346,6 +355,92 @@ func testReconcileUnchangedKeepsMetadata(t *testing.T, open OpenFunc) {
 	}
 	if len(relations.Series[bookID]) != 1 || relations.Series[bookID][0].Name != "Terra Ignota" {
 		t.Fatalf("series blanked by an unchanged observation: %+v", relations.Series[bookID])
+	}
+}
+
+// testReconcileRepeatPassCountsNoUpdates covers the honesty of
+// Updated. A Calibre pass re-reads every row of metadata.db every time
+// (ADR-0022), so it re-submits full observations for books nothing
+// touched; counting those writes would report a whole library as
+// updated twice an hour and bury the pass that actually changed
+// something. Updated therefore counts differences, in the row's facts
+// or in its relations, and a pass over an untouched folder reports
+// that nothing happened.
+func testReconcileRepeatPassCountsNoUpdates(t *testing.T, open OpenFunc) {
+	s := open(t)
+	folder := MkFolder(t, s, "calibre-repeat", store.FolderCalibre)
+	now := time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)
+
+	calibreID := int64(30)
+	observe := func(title string, tags []string) store.ObservedBook {
+		return store.ObservedBook{
+			CalibreID: &calibreID, RelativePath: "A Writer/Book (30)/book.epub",
+			SizeBytes: 100, MTime: now, ContentSHA256: "sha-repeat",
+			Title: title, Tags: tags,
+			Contributors: []store.ObservedContributor{
+				{Name: "A Writer", Role: store.ContributorRoleAuthor},
+			},
+			Series: []store.ObservedSeries{{Name: "A Series", Position: Ptr(1.0)}},
+		}
+	}
+
+	first := doReconcile(t, s, folder.ID,
+		[]store.ObservedBook{observe("Book", []string{"history"})}, true, now)
+	if first.Added != 1 {
+		t.Fatalf("first pass: %+v", first)
+	}
+	bookID := knownByCalibreID(t, s, folder.ID)[calibreID].ID
+
+	// The same observation again, as every safety-timer pass submits it.
+	second := doReconcile(t, s, folder.ID,
+		[]store.ObservedBook{observe("Book", []string{"history"})},
+		true, now.Add(30*time.Minute))
+	if second.Updated != 0 || second.Changed() {
+		t.Fatalf("an untouched book was reported updated: %+v", second)
+	}
+	// The pass proved the file present, so seen_at advances — but
+	// updated_at is the modification time clients see, and nothing was
+	// modified.
+	afterRepeat, err := s.CatalogBookByID(context.Background(), "", bookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !afterRepeat.UpdatedAt.Equal(now) {
+		t.Fatalf("an untouched book's updated_at moved: %v", afterRepeat.UpdatedAt)
+	}
+	if afterRepeat.SeenAt == nil || !afterRepeat.SeenAt.Equal(now.Add(30*time.Minute)) {
+		t.Fatalf("the repeat pass did not refresh seen_at: %v", afterRepeat.SeenAt)
+	}
+
+	// A metadata edit in the row's own columns.
+	third := doReconcile(t, s, folder.ID,
+		[]store.ObservedBook{observe("Book, Revised", []string{"history"})},
+		true, now.Add(time.Hour))
+	if third.Updated != 1 {
+		t.Fatalf("a title edit was not counted: %+v", third)
+	}
+	afterEdit, err := s.CatalogBookByID(context.Background(), "", bookID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !afterEdit.UpdatedAt.Equal(now.Add(time.Hour)) {
+		t.Fatalf("a real edit did not move updated_at: %v", afterEdit.UpdatedAt)
+	}
+
+	// An edit that only moves relations: same row facts, one more tag.
+	fourth := doReconcile(t, s, folder.ID,
+		[]store.ObservedBook{observe("Book, Revised", []string{"history", "essays"})},
+		true, now.Add(2*time.Hour))
+	if fourth.Updated != 1 {
+		t.Fatalf("a tag-only edit was not counted: %+v", fourth)
+	}
+
+	// And the edited state, resubmitted, is quiet again.
+	fifth := doReconcile(t, s, folder.ID,
+		[]store.ObservedBook{observe("Book, Revised", []string{"history", "essays"})},
+		true, now.Add(3*time.Hour))
+	if fifth.Updated != 0 || fifth.Changed() {
+		t.Fatalf("the settled state was reported updated: %+v", fifth)
 	}
 }
 

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -179,6 +179,9 @@ func Run(t *testing.T, open OpenFunc) {
 	t.Run("ReconcileUnchangedKeepsMetadata", func(t *testing.T) {
 		testReconcileUnchangedKeepsMetadata(t, open)
 	})
+	t.Run("ReconcileRepeatPassCountsNoUpdates", func(t *testing.T) {
+		testReconcileRepeatPassCountsNoUpdates(t, open)
+	})
 	t.Run("ReconcileCalibrePathMoveKeepsIdentity", func(t *testing.T) {
 		testReconcileCalibrePathMoveKeepsIdentity(t, open)
 	})


### PR DESCRIPTION
## Summary

Every 30 minutes the safety scan over a Calibre folder logged `folder reconciled ... updated=82` and one "calibre book has no file on disk" line per stale book, even when nothing had changed. This made the log useless for spotting real changes and made every book look freshly modified to reading apps after each scan.

Now a scan reports what changed, not what it wrote:

- `updated` counts books whose stored facts or relations actually differ, so a scan over an untouched library logs nothing.
- A book whose file is gone is reported once, when it disappears, and once more when it comes back. In between it stays a debug line.
- `updated_at` moves only when a book materially changed or returned from missing, so catalog and OPDS clients stop seeing phantom modifications every half hour. `seen_at` still refreshes on every scan.
- Transition log lines are written only after the store commits the scan, so a failed scan cannot announce a change it never made.

## Changes

- `ReconcileFolder` (SQLite and Postgres) compares prior row facts and a relations fingerprint before counting a book as updated, and bumps `updated_at` only on material change or a missing-to-active return, including the stat-match fast path.
- The Calibre scan checks each book's prior catalog status and logs missing/restored transitions at INFO once, after the reconcile succeeds.
- Shared store tests cover repeat scans, metadata-only and relations-only edits, timestamp stability, and the fast-path return; new content tests cover transition-only logging and a store-rejected scan.

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [ ] If `.templ` files changed: `go tool templ generate ./internal/webui/` and committed generated output
- [ ] If `docs/openapi.yaml` changed: `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish`
- [x] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable — Postgres store suite run against a real database; diagnosed on the live deployment where the noise was observed

## Screenshots, logs, or API examples

Before, every half-hourly pass:

```
INFO calibre book has no file on disk folder=... calibre_id=30
INFO calibre book has no file on disk folder=... calibre_id=39
INFO calibre book has no file on disk folder=... calibre_id=58
INFO folder reconciled folder=... name=Calibre added=0 updated=82 ...
```

After: an untouched pass logs nothing at INFO; the missing-file lines appear once per disappearance and name the book's title.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [ ] I have updated related API and integration documentation where needed.
- [ ] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.
