### PR TITLE
feat: Make cross-device reading stats accurate and resilient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,25 @@ of them.
   (`foreign_pos` is stored verbatim but is a payload, not a shape).
 - **Never fabricate page numbers.** Statistics come from progression
   fractions; pages derive from edition page counts when known.
+  Koplugin's reported page contribution is source-specific, not a
+  universal pagination scheme.
+- Statistics API and web totals share `insights.Build` over one coherent
+  `StatisticsSnapshot`; do not add a total-history row cap. Native
+  `active_ms` is optional and authoritative, including zero, independent
+  of wall-clock span or idle. Negotiate through insights capabilities or
+  token introspection's `session_active_ms`; browser credentials must
+  not gain `read-insights` just to upload measured duration.
+- Raw sessions and v2 rollups use account-local end-day attribution.
+  Preserve measured pace separately from inferred totals, and write
+  exact archived contributions with fingerprints in the rollup
+  transaction. Keep legacy split-day buckets unchanged; never invent a
+  backfill or rebucket archived dates after a timezone change.
+- Snapshot overlap requires full original native payloads and device
+  ids read against the same revision as the aggregates. An upload
+  acknowledgement is not proof. Return `complete: false` for unknown
+  archive proof or incompatible legacy/timezone history. Encode
+  `stats_revision` as a decimal string. Calendar chunks filter daily
+  output only; clients must match revisions before combining chunks.
 - **No redirects on API routes.** `301`s exist only under `/ui`.
 - **Content change is not identity transfer.** A file whose bytes
   changed at a path is a new catalog book: delete the old row and its

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -309,41 +309,119 @@ defines the wire and lifecycle contract.
   "start_progression": 0.401,
   "end_progression":   0.413,
   "idle_ms":           30000,
-  "origin":            "native | koplugin"
+  "active_ms":         120000,
+  "origin":            "native | koplugin | inferred"
 }
 ```
 
 `POST /v1/sessions` accepts batches, idempotent on `session_id`. Rows
 are never updated in place; a session is a historical fact. Immutable
 native and inferred sessions older than the configurable retention
-window are reduced to per-work, timezone-local daily totals, then their
-raw rows are removed. A compact fingerprint preserves the original
-idempotency and conflict behavior. Mutable koplugin supersession chains
-stay raw because a later revision may replace them.
+window become v2 per-work daily totals, attributed wholly to their end
+day in the account timezone. The rollup transaction removes the raw rows
+and stores each session's fingerprint and exact archived contribution.
+Measured duration and progression stay separate from inferred totals
+so retention does not change pace or ETA. Mutable koplugin supersession
+chains stay raw because a later revision may replace them.
+
+`active_ms` is optional, including an explicit zero, and accepts integers
+from 0 through 9007199254740991. It carries monotonic measured duration,
+independent of wall-clock span and `idle_ms`; the server does not clamp
+it to either. Without it, active duration is wall-clock span minus idle.
+End time must still be at or after start time, and idle must lie within
+that span. Clients negotiate support through insights capabilities or
+`GET /v1/token` (`session_active_ms: true`) before including the field.
+An accepted payload must not gain or lose it on retry.
+
+Existing split-day `session_rollups` remain unchanged. Migration 7 adds
+separate `session_rollups_v2` and archive proof; it does not reconstruct
+old sessions, backfill measured duration, or reinterpret old buckets.
+Archived days keep their original timezone. Changing the account
+timezone cannot recover historical end instants from daily totals.
 
 The design principle, learned from the Liseur/KoInsight investigation:
 **never fabricate resolution you didn't measure.** liseur-sync requires
-`start/end_progression` and derives everything else server-side:
+`start/end_progression` and derives aggregates server-side:
 
-- pages read = progression delta × edition page count, when known
-- reading speed = progression delta / active duration, per work and
-  rolling
+- pages read = positive progression delta × edition page count, when known;
+  koplugin's reported page contribution is retained as source-specific data,
+  not a universal pagination scheme
+- reading speed = measured positive progression delta / measured active
+  duration in the selected window; inferred sessions never supply pace
 - streaks, per-book time, calendar heatmaps: raw sessions plus
   daily rollups
 
 ### 6.2 Insight API
 
-Read-only aggregation endpoints, all per-user:
+Read-only aggregation endpoints, all per-user and requiring `read-insights`:
 
 ```
 GET /v1/insights/summary?range=30d      totals, streak, speed trend
 GET /v1/insights/works                  all per-book aggregates
 GET /v1/insights/works/{id}             per-book: time, sessions, pace, ETA
 GET /v1/insights/calendar?year=2026     daily minutes for heatmaps
+GET /v1/insights/capabilities          protocol and attribution versions, limits
+POST /v1/insights/snapshot             coherent totals and actual local overlap
 ```
 
-ETA = remaining progression / rolling speed, the same estimator Liseur
-ships on-device, now computable across all devices' sessions combined.
+The API and web dashboard use `insights.Build` over a single transactional
+`StatisticsSnapshot`: effective sessions, rollups, positions, editions,
+work metadata, timezone and revision. There is no 10000-row cap on server
+history. Raw sessions and v2 rollups use the same end-day attribution in
+totals and calendars. ETA uses current remaining progression and measured
+pace in the selected window; it is null without usable pace. Legacy
+rollups with unknown measured contributions suppress pace and ETA.
+
+A snapshot request carries a client `snapshot_id`, account timezone,
+aggregate bounds, full original native session candidates with their
+original `device_id`, and local positive-activity days. The answer echoes
+account, id, timezone, bounds and protocol/attribution versions, with a
+decimal-string `stats_revision`. It returns server summary/work/day totals,
+actual overlap with those candidates, and an all-history combined streak.
+The candidate and local-day arrays each allow at most 10000 entries;
+`ops.max_body_bytes` still bounds the body.
+
+Clients may combine additive totals as server + captured local - actual
+overlap only after checking the response identity, bounds and `complete`.
+An upload acknowledgement, receipt or op cursor is not proof that this
+snapshot contains a session. Payload mismatch, unknown archived proof,
+legacy buckets or incompatible archived timezone make it incomplete.
+Legacy servers and incomplete responses require a local-only fallback.
+
+Calendar chunks contain at most 4000 inclusive days. Explicit calendar
+bounds filter only daily output, never summary, works or streak. For
+`range: all`, the default calendar runs from the server's earliest positive
+activity day through today, clipped to the latest 4000 days; no activity
+means today alone. Clients requesting older chunks must keep the captured
+local evidence fixed and require the same revision and response identity
+across chunks. The full wire contract is in `openapi.yaml` and
+`integrating.md`.
+
+#### Statistics read cost
+
+`internal/insights/statistics_benchmark_test.go` compares the former
+summary-plus-works read path with `StatisticsSnapshot` plus `Build`.
+The former works handler already batched session reads; repeated edition
+lookups and per-work metadata/position reads caused the N+1 cost.
+The snapshot uses six SELECTs plus `ceil(candidate_count / 500)` archive
+lookups, with no reads in `Build`. For the lifetime fixture, the former
+path used 20216 helper reads. These counts come from source and helper
+calls, not SQL tracing, and exclude transaction control.
+
+A local synthetic run on 2026-09-05 used 12000 raw sessions across 24
+works and 1500 days, three warm iterations without the race detector:
+
+| Window | Backend | Former summary + works (ms) | Snapshot + Build (ms) |
+| --- | --- | ---: | ---: |
+| Lifetime | SQLite | 472.54 | 57.36 |
+| Lifetime | PostgreSQL | 2038.20 | 38.68 |
+| 30 days | SQLite | 82.41 | 54.50 |
+| 30 days | PostgreSQL | 102.81 | 35.99 |
+
+Timing excludes setup and HTTP/JSON overhead. The fixture has no rollups;
+`Build` also produces calendar/coverage data absent from the former
+comparison outputs. These measurements are not a production latency
+guarantee.
 
 ### 6.3 Sessions inferred for position-only devices
 
@@ -351,8 +429,8 @@ A stock KOReader device syncing via the kosync adapter sends positions
 but no sessions. The server can infer coarse sessions from its op log:
 consecutive ops from one device with gaps below the configured threshold
 form an inferred session with `origin: "inferred"`, always
-distinguishable from measured ones and excluded from speed statistics by
-default. Better than nothing, honest about being so. KOReader's
+distinguishable from measured ones and excluded from pace and ETA,
+including after rollup. KOReader's
 statistics plugin, where installed, reports measured sessions via the
 koplugin adapter instead. The web reader measures its own
 ([ADR-0030](adr/0030-web-reader-reading-sessions.md)): a sitting bounded
@@ -626,7 +704,14 @@ aliases            user_id, kind, value, work_id
 ops                user_id, seq, op_id, work_id, edition_sha?, device_id,
                    client_ts, progression, locator_json?, foreign_pos?, origin
 sessions           user_id, session_id, work_id, device_id, started_at,
-                   ended_at, start_prog, end_prog, idle_ms, origin
+                   ended_at, start_prog, end_prog, idle_ms, active_ms?,
+                   reported_pages?, origin
+session_rollups    user_id, work_id, day, legacy split-day totals
+session_rollups_v2 user_id, work_id, day, timezone, attribution_version,
+                   totals, measured_active_seconds, measured_prog_delta
+session_tombstones user_id, session_id, fingerprint, work_id?, day?,
+                   timezone?, attribution_version, present, contributions
+stats_revisions    user_id, revision
 folders            id, name, root_path, kind
 user_folders        user_id, folder_id
 books              id, folder_id, status, relative_path, calibre_id?,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -539,6 +539,38 @@ Migrations run at startup under a cross-process lock. If a migration
 fails, the server refuses to start rather than run against a partially
 migrated schema. Back up before upgrades.
 
+### Reading statistics, migration 7
+
+Both SQLite and PostgreSQL append `statisticsStorage` as migration 7,
+after the folder-grant repair in migration 6. It adds nullable
+`sessions.active_ms` and `sessions.reported_pages`, per-account
+`stats_revisions`, separate `session_rollups_v2`, and contribution fields
+on `session_tombstones`. Revision triggers cover changes to statistics
+inputs, including timezone, positions and metadata.
+
+The upgrade leaves existing session payloads, legacy split-day rollups
+and fingerprints intact. There is no duration backfill or conversion of
+old daily buckets. Retained raw sessions now count on their end day in
+both totals and calendars; future compaction writes that same attribution
+with measured pace and exact archived overlap proof. Older tombstones
+still enforce idempotency but cannot prove their original contribution.
+
+Legacy rollups remain visible in server totals. They make the new
+snapshot response `complete: false`, so clients requiring an exact union
+with local sessions must fall back to local-only statistics. Upgrading
+cannot recover already discarded session timestamps or source-specific
+pace. A later account timezone change likewise cannot rebucket archived
+days; v2 records retain their original timezone and incompatible history
+also makes snapshots incomplete.
+
+Clients should negotiate `active_ms` before sending it, through
+`GET /v1/insights/capabilities` with `read-insights`, or the
+`session_active_ms` field on authenticated `GET /v1/token` without that
+scope. No additional configuration enables the snapshot endpoint;
+`ops.max_body_bytes` bounds its requests. Calendar chunks are limited to
+4000 days and each evidence array to 10000 entries, not the server's
+total retained history.
+
 ### Folder grants, migration 4 and migration 6
 
 Read this before upgrading if you deliberately revoked folder access

--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -114,6 +114,7 @@ GET /v1/token
 {
   "id": "tok_7f3a",
   "account_id": "usr_31b0",
+  "session_active_ms": true,
   "device_id": "dev_9c21",
   "name": "Boox Palma",
   "scopes": ["sync", "library-read"]
@@ -143,6 +144,12 @@ cheapest way to check that a stored credential is still live.
 
 `HEAD /v1/token` is the same check without the body. It returns `200` if
 the secret is still good and `401` if it is not.
+
+`session_active_ms: true` advertises explicit measured duration on
+`POST /v1/sessions`. Missing or false means send the legacy payload
+without `active_ms`. This flag needs no `read-insights` scope, so the
+browser reader can negotiate duration while keeping its restricted
+`sync` and `library-read` scopes.
 
 ### A credential for code running in the browser
 
@@ -502,117 +509,209 @@ POST /v1/sessions
     "started_at": "…", "ended_at": "…",
     "start_progression": 0.401,
     "end_progression": 0.413,
-    "idle_ms": 30000
+    "idle_ms": 30000,
+    "active_ms": 120000
   }]
 }
 ```
 
 The same rules as ops: `session_id` is the idempotency key, batch
 freely, same id with another payload is a 409. Sessions are never
-updated after acceptance. Raw immutable sessions are retained for 180
-days by default, then reduced to daily totals. Insights remain complete;
-raw session history beyond the retention horizon is intentionally not
-available.
+updated after acceptance. Preserve the original payload and device id
+for retries and overlap candidates; adding `active_ms` to an already
+accepted session changes its identity and returns `409`.
 
-Do not send page numbers. The server derives pages from progression ×
-the edition's page count, and speed from progression delta over active
-time (duration minus `idle_ms`). If you only know pages, convert through
-`page / total_pages` yourself and say so in the fractions.
+Before sending `active_ms`, require `session_active_ms: true` from
+`GET /v1/token`, or `active_ms: true` from insights capabilities.
+It is an optional integer from 0 through 9007199254740991. Explicit zero
+means zero active time; omission or null uses wall-clock duration minus
+`idle_ms`. Measure it with a monotonic clock. The value is authoritative,
+even when wall-clock adjustments make it exceed the session span, and
+idle is not subtracted again. Start/end timestamps must still be ordered,
+and `idle_ms` must be nonnegative and no greater than their span.
+Out-of-range duration gets `active_out_of_range`; the batch stores nothing.
+
+Raw immutable sessions are retained for 180 days by default. New rollups
+keep their whole end-day contribution, measured pace and per-session
+overlap proof. Existing legacy split-day rollups remain visible but cannot
+certify a complete snapshot. Raw history beyond retention is unavailable.
+
+The native payload has no page-number field. The server derives pages
+from positive progression delta times an edition page count when known.
+The koplugin adapter also retains its reported page contribution, which
+is specific to that source, not pagination shared by other readers.
 
 ## Insights
 
-With a `read-insights` token:
+All `/v1/insights/*` routes require `read-insights`. The API and web
+dashboard share an aggregator over a coherent database transaction;
+server totals are not capped at 10000 sessions. The 10000 limit below
+applies only to request evidence.
 
-- `GET /v1/insights/summary?from=2026-07-13&to=2026-08-11`: totals,
-  streak, speed trend
-- `GET /v1/insights/works?from=…&to=…`: aggregates for every work with
-  reading history
-- `GET /v1/insights/works/{id}?from=…&to=…`: per-work time, pace, ETA
-- `GET /v1/insights/calendar?year=2026`: daily minutes for heatmaps
-- `GET /v1/insights/calendar?from=2025-04-01&to=2026-03-31`: the same,
-  over an arbitrary span
+### Combining local and server reading
 
-Every endpoint takes a span the same way: a `from`/`to` pair of
-`YYYY-MM-DD` days, **both inclusive**, resolved in the user's configured
-timezone. The older `range=Nd` (up to `3660d`) and `range=all` spellings
-still work, and `Nd` now means the last N *calendar* days ending today
-rather than N × 24 hours ending at the moment of the request — the
-difference is a partial extra day at the far end, which no client could
-reconcile against days it had counted for itself.
+First request `GET /v1/insights/capabilities`:
 
-Prefer `from`/`to`. A count of days is resolved against the server's
-clock; a pair of dates says exactly what was meant and comes back in the
-answer.
+```json
+{
+  "version": 1,
+  "account_id": "usr_31b0",
+  "all_time": true,
+  "active_ms": true,
+  "attribution_version": 2,
+  "timezone": "Europe/Paris",
+  "max_candidates": 10000,
+  "max_local_active_days": 10000,
+  "max_calendar_days": 4000,
+  "max_body_bytes": 1048576
+}
+```
 
-The summary and the works endpoints name the span they covered:
-`range_days` always, plus `from` and `to` when the span is bounded. The
-calendar echoes `from`, `to` and `range_days` only when it honoured an
-explicit `from`/`to` pair; a `year=` request comes back with `year` and
-`days` alone. **Check it.** A server too old to
-understand the parameters ignores them and answers about some other
-span, and the aggregates give no sign of it: thirty days of reading and
-ten years of it are both just a number of minutes. An answer that does
-not name back the days you asked about is not an answer to your
-question.
+Require the supported versions, `all_time: true`, and an `account_id`
+matching the captured account before using snapshots. Both evidence
+limits are explicit: `max_candidates` bounds session candidates and
+`max_local_active_days` bounds local activity dates. These fields are
+part of capability negotiation, not optional hints.
 
-Check an unbounded request too, against `range_days == 0`. An older
-server answers `range=all` with the ten-year horizon it used to apply,
-and an older one still does not know the word at all — and the summary,
-given nothing it understands, falls back on thirty days.
+Capture local totals and their evidence together, then send
+`POST /v1/insights/snapshot`:
 
-A span is optional on the works endpoints, where absent means everything
-on record — which is what they answered before spans existed. The
-summary defaults to `30d` instead, for the same reason. Say `range=all`
-rather than leaving it out if you mean a lifetime. A `range` that cannot
-be parsed is treated as absent, so a malformed span gets the endpoint's
-default rather than its whole history.
+```json
+{
+  "snapshot_id": "local-capture-42",
+  "timezone": "Europe/Paris",
+  "from": "2026-08-01",
+  "to": "2026-08-31",
+  "candidates": [{
+    "session_id": "sitting-42",
+    "work_id": "work-7",
+    "device_id": "original-device",
+    "started_at": "2026-08-12T20:00:00Z",
+    "ended_at": "2026-08-12T20:02:30Z",
+    "start_progression": 0.401,
+    "end_progression": 0.413,
+    "idle_ms": 30000,
+    "active_ms": 120000
+  }],
+  "local_active_days": ["2026-08-12"]
+}
+```
 
-Give the works endpoints the same span as the summary if the two are
-shown on one screen: a headline covering thirty days above rows covering
-a lifetime is a dashboard whose numbers cannot be added up.
+Each candidate is the full original native session payload plus its
+original `device_id`, including the original edition and duration fields
+when present. Do not substitute the current token's device id or rebuild
+an old upload from newer local metadata. Candidates are evidence only:
+this endpoint never uploads them and does not require `sync`.
+Session ids must be unique within the request. `snapshot_id` is a
+nonempty client identifier of at most 128 bytes; `device_id` is nonempty
+and at most 64 bytes.
 
-Each work carries `title` and `author` when the server has them. They
-are there so a client can list a work it holds no file for: reading done
-on another device is in the totals whether it can be named or not, and a
-list that silently omits it is smaller than the headline above it for no
-reason the reader can see. Both are absent rather than empty when the
-server has nothing to say, and a work you cannot name is better left out
-of a list than shown blank.
+Send either inclusive `from`/`to` dates or `range: "all"` / `"Nd"`
+(1 through 3660 calendar days ending today), not both. The snapshot route
+rejects missing or invalid aggregate bounds. Dates use the account's
+IANA timezone; a timezone different from the current account gets `409`.
+`local_active_days` contains positive local activity across all history,
+including outside the aggregate window, with no dates after server today.
+Each evidence array allows at most 10000 entries. Capabilities advertise
+`max_body_bytes`, the configured `ops.max_body_bytes` limit (1 MiB by
+default). Compare it with the complete serialized UTF-8 request size and
+reject oversized requests locally. Missing required capabilities mean
+local-only statistics; oversized HTTP requests get `413`. Do not truncate
+evidence and then claim a complete union.
+The limit covers the entire body, including trailing whitespace. Send
+one JSON value only; trailing JSON or garbage gets `400` within the limit.
 
-`streak_days` is deliberately **not** narrowed by the span. It counts
-consecutive days ending today or yesterday, looking back up to ten
-years, so asking about the last week does not report a hundred-day run
-as seven.
+The response contains:
 
-`range_days` reports how many days the answer covers, and is `0` for an
-unbounded one.
+| Field | Meaning |
+| --- | --- |
+| `version`, `attribution_version` | Snapshot protocol 1, end-day attribution 2. |
+| `account_id`, `snapshot_id`, `timezone` | Account identity, captured-local id and account timezone. |
+| `stats_revision` | Per-account decimal **string**, for example `"42"`, never a JSON number or op cursor. |
+| `range_days`, `from`, `to` | Aggregate bounds; `range_days: 0` and absent dates for `all`. |
+| `today`, `first_activity_day` | Account-local today and earliest server day with positive active time, or null. |
+| `calendar_from`, `calendar_to` | Inclusive bounds of this daily chunk. |
+| `complete`, `incomplete_reason` | Whether exact combination is supported; reason is present only when false. |
+| `summary` | Server `total_active_minutes`, `total_pages`, `sessions`, `streak_days`, `speed_prog_per_hour`. |
+| `works` | Server work rows, including works absent from the local library. |
+| `days` | Server daily rows: `date`, `minutes`, `pages`, `sessions`. Missing dates contribute zero. |
+| `overlap` | Actual included candidates: `total_active_minutes`, `sessions`, `works`, `days`. No top-level page total. |
+| `combined_streak_days` | Streak from all server positive-activity days unioned with `local_active_days`. |
 
-A sitting that straddles the first morning of the span counts, whole, on
-the day it *ended* — both in the summary and in the per-work rows, so
-the two cannot disagree. The calendar splits such a sitting across the
-midnight it crosses, because a day-by-day answer that did not would
-attribute an hour to a day it was not read on.
+Work rows carry `work_id`, `sessions`, `total_active_minutes`,
+`total_pages`, `current_progression`, nullable `eta_seconds` and
+`last_read_at`, plus `title`/`author` when known. They are sorted by active
+time descending, then work id. Overlap uses the same row shape, but its
+position/ETA fields are placeholders, not values to merge.
 
-The calendar additionally accepts `year`, and falls back to the current
-year when no usable span is given — which is what makes the echo the
-only way to tell an honoured request from an ignored one. A single
-calendar may not span more than 4000 days; a longer one is refused with
-`400` rather than served.
+For additive totals, use **server + captured local - actual overlap**.
+Do this only after checking `complete: true`, supported versions,
+account, timezone, snapshot id and both sets of bounds. Use the captured
+local values, not a live local query that may have changed during the
+request. An upload acknowledgement, receipt or op cursor proves no
+overlap with these totals. Use `combined_streak_days` for the union;
+streaks cannot be added or combined by maximum.
 
-All day boundaries are computed in the user's configured timezone.
-Rereading counts time but never negative pages. ETA is `null` until the
-user has enough speed history on the work.
+The server compares complete payload fingerprints within the same
+transaction as the aggregates. Absent candidates contribute zero overlap.
+For archived candidates it requires matching v2 proof, original timezone,
+and a contribution still present in the aggregate. Legacy rollups,
+timezone-incompatible archives or unknown proof make `complete` false;
+payload mismatches do too. Reasons are
+`legacy_or_different_timezone_rollups`, `candidate_payload_mismatch`,
+`unknown_archived_contribution`, `archived_timezone_mismatch` or
+`archived_work_missing`. Treat an unknown reason as incomplete too.
+Use local-only statistics when negotiation is unavailable or the response
+cannot certify the requested union. Do not guess a merge with legacy
+summary/calendar endpoints.
 
-`current_progression` and `eta_seconds` are never narrowed by the span
-either. Where the reader is in a book is true now, whatever span the
-totals beside it cover.
+Calendar bounds are independent of aggregate bounds: optional
+`calendar_from`/`calendar_to` filter only `days` and `overlap.days`,
+not summary, works or either streak. Both dates are required together,
+the inclusive span must be at most 4000 days, and for bounded aggregates
+it must lie inside their window. Without them, a bounded request uses
+its aggregate window. `range: "all"` defaults to the earliest positive
+server activity day through today, clipped to the latest 4000 days;
+an empty history defaults to today alone. `first_activity_day` still
+reports the earlier date when clipping occurs.
 
-`total_pages` will be `0` unless the work has a page count on its
-edition, and nothing in the native API sets one. A reflowable EPUB has
-no inherent number of pages, and one derived from a particular device's
-font size would make the total depend on which device synced. Report
-minutes and progression, which mean the same thing everywhere, and treat
-pages as something you may not have.
+For older history, request explicit calendar chunks and keep the same
+local capture, candidates and aggregate bounds. Require matching
+`stats_revision` strings, account, timezone, versions, snapshot id and
+aggregate bounds across all chunks; each must echo its requested calendar
+bounds. Restart the capture if any identity or revision changes. Do not
+sum the repeated summary/work totals across chunks.
+
+### Standalone aggregate queries
+
+`GET /v1/insights/summary`, `/works` and `/works/{id}` accept inclusive
+`from`/`to` or `range=Nd` / `range=all`. A valid date pair takes precedence.
+Summary defaults to `30d`; works defaults to all history. Invalid ranges
+use that endpoint's default. Responses echo `range_days`, plus `from` and
+`to` when bounded, and `timezone`. Summary and the works list also return
+`stats_revision` and `attribution_version`; the individual work route
+does not. Summary includes nullable `first_activity_day`.
+
+`GET /v1/insights/calendar` accepts a `from`/`to` pair of at most 4000
+days, or `year` (1971 through 2999, default current year). It returns
+`year`, `days`, timezone and revision/attribution metadata. It echoes
+aggregate bounds only for a valid explicit pair. Always check bounds:
+older servers may ignore parameters they do not understand.
+
+Raw sessions and v2 rollups count wholly on their account-local **end
+day**, in totals and calendars alike. Existing legacy split-day buckets
+keep their original dates; they are not backfilled or reinterpreted.
+Archived dates remain fixed if the account timezone changes, so exact
+rebucketing of historical totals is unavailable.
+
+Streaks use all positive-activity days, ending today or yesterday,
+independent of the selected window and without a ten-year cutoff.
+Rereads count time but never negative progression. Pace excludes inferred
+sessions, even after rollup. Current progression comes from the newest
+position regardless of window; ETA uses that position and measured pace
+inside the window. Unknown legacy pace suppresses speed and ETA.
+Pages may be zero without edition metadata; koplugin-reported pages
+retain that source's meaning.
 
 ## Browsing and downloading books
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -697,6 +697,10 @@ paths:
         `end_progression`); never derive page numbers yourself — the
         server derives pages from edition metadata when known. Same
         `session_id` with a different payload is a 409.
+        Optional `active_ms` is authoritative measured duration, including
+        zero, independent of wall-clock span and idle. Negotiate it through
+        insights capabilities or `GET /v1/token` (`session_active_ms: true`)
+        before sending it. Preserve its presence and value on retry.
       security: [{ deviceToken: [] }]  # requires sync scope
       requestBody:
         required: true
@@ -881,6 +885,84 @@ paths:
                     items: { $ref: "#/components/schemas/Annotation" }
         "404": { $ref: "#/components/responses/Error" }
 
+  /v1/insights/capabilities:
+    get:
+      tags: [insights]
+      summary: Negotiate statistics snapshot support
+      description: |
+        Requires `read-insights`. Returns the account id and timezone,
+        protocol and attribution versions, all-history support and request limits.
+        A sync-only client can negotiate session duration through
+        `GET /v1/token` instead; browser tokens do not need wider scopes.
+      security: [{ deviceToken: [] }]  # requires read-insights scope
+      responses:
+        "200":
+          description: Supported statistics protocol
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsightsCapabilities" }
+        "401": { $ref: "#/components/responses/Error" }
+        "403": { $ref: "#/components/responses/Error" }
+        "500": { $ref: "#/components/responses/Error" }
+
+  /v1/insights/snapshot:
+    post:
+      tags: [insights]
+      summary: Read coherent statistics and actual local-session overlap
+      description: |
+        Requires `read-insights`, not `sync`; candidates are evidence,
+        never uploaded. Reads effective sessions, rollups, archived proof,
+        positions, metadata, timezone and revision in one transaction.
+        Server history has no 10000-session cap.
+        The byte limit covers the entire body, including trailing whitespace.
+        Send one JSON value only; trailing JSON or garbage is invalid.
+
+        Candidates must contain the original native payload and original
+        device id, not the current token's device id. Only matching
+        contributions present in these aggregates count as overlap.
+        Upload acknowledgements, receipts and op cursors are not proof.
+        On a complete response, additive totals can be combined as
+        server + captured local - actual overlap. Keep the local capture
+        fixed and check account, snapshot id, timezone, versions and bounds.
+        Use local-only statistics if negotiation or complete proof is
+        unavailable, including on legacy servers.
+
+        Explicit calendar bounds affect only `days` and `overlap.days`.
+        Across chunks require the same decimal-string `stats_revision`
+        and response identity; do not sum repeated summary/work totals.
+      security: [{ deviceToken: [] }]  # requires read-insights scope
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/InsightsSnapshotInput" }
+      responses:
+        "200":
+          description: |
+            Coherent aggregates and overlap. An incomplete result still
+            returns totals, but cannot certify an exact local/server union.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/InsightsSnapshot" }
+        "400":
+          description: Invalid payload, duplicate candidate id, excessive evidence or invalid bounds.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "401": { $ref: "#/components/responses/Error" }
+        "403": { $ref: "#/components/responses/Error" }
+        "409":
+          description: Requested timezone differs from the account's current timezone.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "413":
+          description: Request body exceeds `ops.max_body_bytes`.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/Error" }
+        "500": { $ref: "#/components/responses/Error" }
+
   /v1/insights/summary:
     get:
       tags: [insights]
@@ -924,16 +1006,14 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  range_days: { type: integer, description: "Days covered; 0 when unbounded" }
-                  from: { type: string, format: date }
-                  to: { type: string, format: date }
-                  total_active_minutes: { type: number }
-                  total_pages: { type: number }
-                  sessions: { type: integer }
-                  streak_days: { type: integer }
-                  speed_prog_per_hour: { type: number }
+                allOf:
+                  - { $ref: "#/components/schemas/InsightsSummary" }
+                  - { $ref: "#/components/schemas/InsightsWindow" }
+                  - { $ref: "#/components/schemas/InsightsRevision" }
+                  - type: object
+                    required: [first_activity_day]
+                    properties:
+                      first_activity_day: { $ref: "#/components/schemas/InsightsFirstActivityDay" }
 
   /v1/insights/works/{id}:
     get:
@@ -963,9 +1043,9 @@ paths:
             The older spelling of a span: a whole number of calendar days
             from 1 through 3660, or `all`. Omitted, the aggregate covers
             the work's whole history, which is what this endpoint
-            answered before spans existed. `current_progression` and
-            `eta_seconds` are never narrowed: where the reader is in a
-            book is true now, whatever span the totals beside it cover.
+            answered before spans existed. `current_progression` is
+            always current; ETA uses that position and measured pace
+            within the selected window.
           schema: { type: string }
       responses:
         "200":
@@ -976,20 +1056,13 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  range_days: { type: integer, description: "Days covered; 0 when unbounded" }
-                  from: { type: string, format: date }
-                  to: { type: string, format: date }
-                  work_id: { type: string }
-                  title: { type: string, description: "The work's title; absent when the server has none" }
-                  author: { type: string, description: "The work's author; absent when the server has none" }
-                  sessions: { type: integer }
-                  total_active_minutes: { type: number }
-                  total_pages: { type: number }
-                  current_progression: { type: number }
-                  eta_seconds: { type: [number, "null"] }
-                  last_read_at: { type: [string, "null"], format: date-time }
+                allOf:
+                  - { $ref: "#/components/schemas/InsightsWork" }
+                  - { $ref: "#/components/schemas/InsightsWindow" }
+                  - type: object
+                    required: [timezone]
+                    properties:
+                      timezone: { type: string }
         "404": { $ref: "#/components/responses/Error" }
 
   /v1/insights/works:
@@ -1034,27 +1107,15 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                required: [works, range_days]
-                properties:
-                  range_days: { type: integer, description: "Days covered; 0 when unbounded" }
-                  from: { type: string, format: date }
-                  to: { type: string, format: date }
-                  works:
-                    type: array
-                    items:
-                      type: object
-                      required: [work_id, sessions, total_active_minutes, total_pages, current_progression]
-                      properties:
-                        work_id: { type: string }
-                        title: { type: string, description: "The work's title; absent when the server has none" }
-                        author: { type: string, description: "The work's author; absent when the server has none" }
-                        sessions: { type: integer }
-                        total_active_minutes: { type: number }
-                        total_pages: { type: number }
-                        current_progression: { type: number }
-                        eta_seconds: { type: [number, "null"] }
-                        last_read_at: { type: [string, "null"], format: date-time }
+                allOf:
+                  - { $ref: "#/components/schemas/InsightsWindow" }
+                  - { $ref: "#/components/schemas/InsightsRevision" }
+                  - type: object
+                    required: [works]
+                    properties:
+                      works:
+                        type: array
+                        items: { $ref: "#/components/schemas/InsightsWork" }
 
   /v1/insights/calendar:
     get:
@@ -1081,7 +1142,9 @@ paths:
       responses:
         "200":
           description: |
-            Days with activity; midnight-crossing sessions are split.
+            Days with recorded contributions. Raw sessions and v2 rollups
+            count wholly on their end day; legacy split-day buckets retain
+            their original attribution.
             `from`, `to` and `range_days` are echoed back only when
             `from`/`to` were honoured, so a client can tell this server
             from one that predates them, ignored them, and answered with
@@ -1089,22 +1152,20 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  year: { type: integer }
-                  from: { type: string, format: date }
-                  to: { type: string, format: date }
-                  range_days:
-                    type: integer
-                    description: Calendar days the answer covers, present only when `from`/`to` were honoured.
-                  days:
-                    type: array
-                    items:
-                      type: object
-                      properties:
-                        date: { type: string, format: date }
-                        minutes: { type: number }
-                        pages: { type: number }
+                allOf:
+                  - { $ref: "#/components/schemas/InsightsRevision" }
+                  - type: object
+                    required: [year, days]
+                    properties:
+                      year: { type: integer }
+                      from: { type: string, format: date }
+                      to: { type: string, format: date }
+                      range_days:
+                        type: integer
+                        description: Calendar days covered; present only when `from`/`to` were honoured.
+                      days:
+                        type: array
+                        items: { $ref: "#/components/schemas/InsightsDay" }
         "400": { $ref: "#/components/responses/Error" }
 
   /v1/folders:
@@ -2268,6 +2329,7 @@ components:
             - progression_out_of_range
             - locator_too_large
             - idle_out_of_range
+            - active_out_of_range
             - id_reused
             - batch_too_large
           description: |
@@ -2793,7 +2855,7 @@ components:
         uses for the same things; `created_at` and `revoked` are absent
         because a caller that reaches this route is neither revoked nor
         expired.
-      required: [id, account_id, device_id, name, scopes]
+      required: [id, account_id, device_id, name, scopes, session_active_ms]
       properties:
         id: { type: string }
         account_id:
@@ -2804,6 +2866,14 @@ components:
             compare it, not `device_id` or `id`, to decide whether a
             replaced credential is the same account (keep mirrors and
             cursors) or a different one (clear them).
+        session_active_ms:
+          type: boolean
+          const: true
+          description: |
+            Supports optional authoritative `active_ms` on native sessions.
+            Available without `read-insights`, including to browser tokens
+            with only `sync` and `library-read`. Older servers omit this;
+            omission or false means send the legacy payload without it.
         device_id: { type: string }
         name: { type: string }
         scope:
@@ -2868,6 +2938,267 @@ components:
             was not stored and never will be under this id.
         seq: { type: integer }
         reason: { type: string }
+    InsightsCapabilities:
+      type: object
+      required: [version, account_id, all_time, active_ms, attribution_version, timezone, max_candidates, max_local_active_days, max_calendar_days, max_body_bytes]
+      properties:
+        version: { type: integer, const: 1 }
+        account_id:
+          type: string
+          description: Stable account id of the authenticated caller; must match the client's captured account.
+        all_time:
+          type: boolean
+          const: true
+          description: Supports range all without a total-history row cap.
+        active_ms: { type: boolean, const: true }
+        attribution_version: { type: integer, const: 2 }
+        timezone: { type: string, description: "Account IANA timezone", example: Europe/Paris }
+        max_candidates: { type: integer, const: 10000 }
+        max_local_active_days:
+          type: integer
+          const: 10000
+          description: Maximum entries in snapshot local_active_days evidence.
+        max_calendar_days: { type: integer, const: 4000 }
+        max_body_bytes:
+          type: integer
+          format: int64
+          description: |
+            Configured `ops.max_body_bytes` request limit, default 1 MiB
+            (1048576 bytes). Clients check the complete serialized UTF-8
+            snapshot body against this bound before requesting a proof.
+          example: 1048576
+    InsightsWindow:
+      type: object
+      required: [range_days]
+      properties:
+        range_days:
+          type: integer
+          minimum: 0
+          description: Inclusive aggregate calendar days; 0 for unbounded history through today.
+        from: { type: string, format: date, description: "First aggregate day; absent when unbounded" }
+        to: { type: string, format: date, description: "Last aggregate day; absent when unbounded" }
+    InsightsRevision:
+      type: object
+      required: [timezone, stats_revision, attribution_version]
+      properties:
+        timezone: { type: string, description: Account IANA timezone }
+        stats_revision:
+          type: string
+          pattern: '^[0-9]+$'
+          example: "42"
+          description: |
+            Per-account monotonic statistics revision encoded as a decimal
+            string, never a JSON number or op cursor. It covers aggregate
+            inputs and archive proof. Require equality across calendar
+            chunks before combining them.
+        attribution_version:
+          type: integer
+          const: 2
+          description: |
+            Raw sessions and new rollups use whole end-day attribution.
+            This does not certify legacy history; check snapshot `complete`.
+    InsightsFirstActivityDay:
+      type: [string, "null"]
+      format: date
+      description: |
+        Earliest server day with positive active duration, across all
+        history through today, or null. Local evidence does not alter it.
+    InsightsSummary:
+      type: object
+      required: [total_active_minutes, total_pages, sessions, streak_days, speed_prog_per_hour]
+      properties:
+        total_active_minutes: { type: number }
+        total_pages:
+          type: number
+          description: Edition-derived or source-reported pages; not universal pagination.
+        sessions: { type: integer }
+        streak_days:
+          type: integer
+          description: |
+            Consecutive server days with positive active duration ending
+            today or yesterday, over all history, independent of bounds.
+        speed_prog_per_hour:
+          type: number
+          description: |
+            Measured positive progression divided by measured active hours
+            in the aggregate window. Inferred sessions never supply pace.
+            Zero without measured duration or with unknown legacy pace.
+    InsightsWork:
+      type: object
+      required: [work_id, sessions, total_active_minutes, total_pages, current_progression, eta_seconds, last_read_at]
+      properties:
+        work_id: { type: string }
+        title: { type: string, description: Absent when unknown }
+        author: { type: string, description: Absent when unknown }
+        sessions: { type: integer }
+        total_active_minutes: { type: number }
+        total_pages: { type: number }
+        current_progression:
+          type: number
+          description: Latest position regardless of window; 0 when none is known.
+        eta_seconds:
+          type: [number, "null"]
+          description: |
+            Current remaining progression divided by measured pace in the
+            selected window. Null without usable pace or position, with
+            unknown legacy pace, or when progression is already 1.
+        last_read_at:
+          type: [string, "null"]
+          format: date-time
+          description: |
+            Latest contributing session end in the window, or local
+            midnight for a rollup whose raw timestamp is no longer kept.
+    InsightsDay:
+      type: object
+      required: [date, minutes, pages, sessions]
+      properties:
+        date: { type: string, format: date }
+        minutes: { type: number }
+        pages: { type: number }
+        sessions: { type: integer }
+    InsightsCandidate:
+      allOf:
+        - { $ref: "#/components/schemas/SessionInput" }
+        - type: object
+          required: [device_id]
+          properties:
+            device_id:
+              type: string
+              minLength: 1
+              maxLength: 64
+              description: Original upload device id, not the current token's; at most 64 UTF-8 bytes.
+      description: |
+        Full original native session payload, including original optional
+        duration and edition fields, plus its original device id.
+        Evidence only; the snapshot endpoint never stores this session.
+    InsightsSnapshotInput:
+      type: object
+      required: [snapshot_id, timezone]
+      oneOf:
+        - required: [range]
+        - required: [from, to]
+      description: |
+        Choose `range` or a complete `from`/`to` pair, not both.
+        Capture local totals and evidence together; do not truncate the
+        evidence to fit the limits and then treat the union as complete.
+        The body is also bounded by `ops.max_body_bytes`.
+      properties:
+        snapshot_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          description: Client-local capture identifier, echoed unchanged; at most 128 UTF-8 bytes.
+        timezone:
+          type: string
+          description: Account IANA timezone from capabilities; a mismatch returns 409.
+        range:
+          type: string
+          pattern: '^(all|[1-9][0-9]*d)$'
+          description: All history through today, or 1 through 3660 calendar days ending today.
+          example: all
+        from: { type: string, format: date, description: "First aggregate day, inclusive; requires to" }
+        to: { type: string, format: date, description: "Last aggregate day, inclusive; not before from" }
+        candidates:
+          type: array
+          maxItems: 10000
+          description: Original native sessions; session ids must be unique within this request.
+          items: { $ref: "#/components/schemas/InsightsCandidate" }
+        local_active_days:
+          type: array
+          maxItems: 10000
+          description: |
+            All-history account-local days with positive captured local
+            activity, including outside the aggregate window. Future dates
+            after server today are refused. Used only for combined streak.
+          items: { type: string, format: date }
+        calendar_from:
+          type: string
+          format: date
+          description: |
+            First daily-output day; requires calendar_to. At most 4000
+            inclusive days, within the aggregate window when bounded.
+            Without explicit calendar bounds, bounded requests use the
+            aggregate window. For all history, start at earliest positive
+            server activity, clipped to the latest 4000 days (today alone
+            when no positive activity exists).
+        calendar_to:
+          type: string
+          format: date
+          description: |
+            Last daily-output day, inclusive; requires calendar_from and
+            must not precede it. Defaults to aggregate end, or today for all.
+            Calendar bounds do not narrow summary, works or streaks.
+    InsightsOverlap:
+      type: object
+      required: [total_active_minutes, sessions, works, days]
+      description: |
+        Contributions of matching original candidates actually present in
+        this snapshot, including exact v2 archive proof. Absent candidates
+        contribute zero. There is no top-level total_pages; pages are in
+        works/days. Merge only additive metrics, not position or ETA fields.
+      properties:
+        total_active_minutes: { type: number }
+        sessions: { type: integer }
+        works:
+          type: array
+          description: |
+            Same row shape as server works, but current_progression is 0
+            and eta_seconds is null because overlap has no positions.
+          items: { $ref: "#/components/schemas/InsightsWork" }
+        days:
+          type: array
+          description: Daily overlap within the echoed calendar bounds, ordered by date.
+          items: { $ref: "#/components/schemas/InsightsDay" }
+    InsightsSnapshot:
+      allOf:
+        - { $ref: "#/components/schemas/InsightsWindow" }
+        - { $ref: "#/components/schemas/InsightsRevision" }
+        - type: object
+          required: [version, account_id, snapshot_id, complete, first_activity_day, today, calendar_from, calendar_to, summary, works, days, combined_streak_days, overlap]
+          properties:
+            version: { type: integer, const: 1 }
+            account_id: { type: string, description: Stable account id of the authenticated caller }
+            snapshot_id: { type: string, description: Echoed client-local capture identifier }
+            complete:
+              type: boolean
+              description: |
+                False when legacy or timezone-incompatible rollups, a
+                candidate payload mismatch, or unknown archived proof
+                prevent an exact union. Check this before using overlap.
+            incomplete_reason:
+              type: string
+              description: Present only when complete is false; unknown reasons also require fallback.
+              enum:
+                - legacy_or_different_timezone_rollups
+                - candidate_payload_mismatch
+                - unknown_archived_contribution
+                - archived_timezone_mismatch
+                - archived_work_missing
+            first_activity_day: { $ref: "#/components/schemas/InsightsFirstActivityDay" }
+            today: { type: string, format: date, description: Today in the account timezone }
+            calendar_from: { type: string, format: date }
+            calendar_to: { type: string, format: date }
+            summary: { $ref: "#/components/schemas/InsightsSummary" }
+            works:
+              type: array
+              description: |
+                Server works with contributions in the aggregate window,
+                including works the client does not hold. Sorted by active
+                minutes descending, then work id.
+              items: { $ref: "#/components/schemas/InsightsWork" }
+            days:
+              type: array
+              description: |
+                Server daily contributions within the echoed calendar
+                bounds, ordered by date. Missing dates contribute zero.
+              items: { $ref: "#/components/schemas/InsightsDay" }
+            combined_streak_days:
+              type: integer
+              description: |
+                All-history streak over server positive-activity days
+                unioned with local_active_days, ending today or yesterday.
+                Independent of aggregate and calendar bounds.
+            overlap: { $ref: "#/components/schemas/InsightsOverlap" }
     SessionInput:
       type: object
       required: [session_id, work_id, started_at, ended_at, start_progression, end_progression]
@@ -2882,12 +3213,33 @@ components:
             hour that never happened. Send only sessions that have
             ended, so the payload behind the id can never change.
         work_id: { type: string }
-        edition_sha: { type: string }
+        edition_sha: { type: [string, "null"] }
         started_at: { type: string, format: date-time }
-        ended_at: { type: string, format: date-time }
+        ended_at: { type: string, format: date-time, description: Must not precede started_at }
         start_progression: { type: number, minimum: 0, maximum: 1 }
         end_progression: { type: number, minimum: 0, maximum: 1 }
-        idle_ms: { type: integer, minimum: 0, description: "Reader-visible idle time, excluded from speed" }
+        idle_ms:
+          type: integer
+          format: int64
+          minimum: 0
+          default: 0
+          description: |
+            Idle milliseconds; must not exceed the wall-clock span even
+            when active_ms is supplied. Subtracted only when active_ms
+            is absent or null.
+        active_ms:
+          type: [integer, "null"]
+          format: int64
+          minimum: 0
+          maximum: 9007199254740991
+          description: |
+            Optional monotonic measured duration. Explicit 0 is zero
+            active time; absent or null uses wall-clock span minus idle.
+            Authoritative independently of the span and idle_ms, never
+            capped to the span or reduced by idle again. Negotiate support
+            through insights capabilities (active_ms) or token introspection
+            (session_active_ms). Presence/value participates in immutable
+            payload identity; do not change it on retries.
     AnnotationInput:
       type: object
       required: [id, base_rev, work_id, kind, client_ts]

--- a/internal/adapter/koplugin/koplugin.go
+++ b/internal/adapter/koplugin/koplugin.go
@@ -151,16 +151,18 @@ func (s *Server) HandleUpload(w http.ResponseWriter, r *http.Request) {
 		// payload yields a new session (supersession) and an identical
 		// re-upload is a duplicate.
 		payloadHash := sha256hex(fmt.Sprintf("%d|%d|%d|%d", rw.StartTime, rw.Duration, rw.Page, rw.TotalPages))
+		reportedPages := 1.0
 		ses := store.Session{
-			SessionID:   sessionIDFor(key, payloadHash),
-			DeviceID:    d.DeviceID,
-			StartedAt:   time.Unix(rw.StartTime, 0),
-			EndedAt:     time.Unix(rw.StartTime+rw.Duration, 0),
-			StartProg:   float64(rw.Page-1) / float64(rw.TotalPages),
-			EndProg:     float64(rw.Page) / float64(rw.TotalPages),
-			Origin:      store.OriginKoplugin,
-			OriginAlias: strPtr("partial-md5:" + md5v),
-			SourceKey:   strPtr(key),
+			SessionID:     sessionIDFor(key, payloadHash),
+			DeviceID:      d.DeviceID,
+			StartedAt:     time.Unix(rw.StartTime, 0),
+			EndedAt:       time.Unix(rw.StartTime+rw.Duration, 0),
+			StartProg:     float64(rw.Page-1) / float64(rw.TotalPages),
+			EndProg:       float64(rw.Page) / float64(rw.TotalPages),
+			ReportedPages: &reportedPages,
+			Origin:        store.OriginKoplugin,
+			OriginAlias:   strPtr("partial-md5:" + md5v),
+			SourceKey:     strPtr(key),
 		}
 		status, err := s.St.UpsertKopluginSessionByAlias(ctx, d.UserID, md5v, ses)
 		if err != nil {

--- a/internal/adapter/koplugin/koplugin_test.go
+++ b/internal/adapter/koplugin/koplugin_test.go
@@ -113,13 +113,24 @@ func TestUploadInsertDuplicateSupersede(t *testing.T) {
 	if len(ss) != 2 { // both revisions stored, append-only
 		t.Fatalf("want 2 session rows, got %d", len(ss))
 	}
-	// Progression conversion: page 42/300 -> [41/300, 42/300].
+	// Progression conversion: page 42/300 -> [41/300, 42/300],
+	// with exactly one reported page from the actual row.
 	for _, s := range ss {
 		wantStart := 41.0 / 300.0
 		wantEnd := 42.0 / 300.0
 		if s.StartProg != wantStart || s.EndProg != wantEnd {
 			t.Fatalf("bad progression: %v %v", s.StartProg, s.EndProg)
 		}
+		if s.ReportedPages == nil || *s.ReportedPages != 1 {
+			t.Fatalf("reported pages should be exactly the uploaded page row: %+v", s.ReportedPages)
+		}
+	}
+	snap, err := st.StatisticsSnapshot(t.Context(), "u1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Editions) != 0 {
+		t.Fatalf("koplugin must not synthesize editions: %+v", snap.Editions)
 	}
 }
 

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -4,6 +4,7 @@ package api
 import (
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -193,7 +194,11 @@ func writeBatchTooLarge(w http.ResponseWriter, limit int) {
 // A body over the bound is 413, like the annotations route; anything
 // else that fails to decode is 400. Reports whether it answered.
 func decodeBatch(w http.ResponseWriter, r *http.Request, maxBytes int64, into any) bool {
-	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxBytes)).Decode(into); err != nil {
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxBytes))
+	if err == nil {
+		err = json.Unmarshal(body, into)
+	}
+	if err != nil {
 		var tooBig *http.MaxBytesError
 		if errors.As(err, &tooBig) {
 			writeError(w, http.StatusRequestEntityTooLarge, "request body too large")

--- a/internal/api/insights.go
+++ b/internal/api/insights.go
@@ -1,10 +1,8 @@
 package api
 
 import (
-	"context"
-	"errors"
 	"net/http"
-	"sort"
+	"strconv"
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/auth"
@@ -12,628 +10,154 @@ import (
 	"github.com/chmouel/liseur-sync/internal/store"
 )
 
-// Insights semantics (design §6, plan):
-// - pages read = max(0, end-start progression delta) x edition page
-//   count when known; negative deltas (rereads) count time but zero
-//   pages — never fabricated, never negative.
-//
-//   "When known" is the common case for it not to be. Only the KOReader
-//   statistics adapter reports a page count, because only a paginated
-//   reader has one to report: a reflowable EPUB has no inherent number
-//   of pages, and inventing one from whichever device happened to sync
-//   first would make the figure depend on that device's font size. So
-//   total_pages is legitimately 0 for a native client, and the web UI
-//   hides the tile rather than showing a zero that looks like a fault.
-// - day boundaries use the user's configured IANA timezone; sessions
-//   crossing midnight split across tz-local days.
-// - speed = progression delta / active duration (duration - idle).
-// - ETA = remaining progression / rolling speed.
+const maxCalendarDays = 4000
 
-type dayStat struct {
-	Date    string  `json:"date"`
-	Minutes float64 `json:"minutes"`
-	Pages   float64 `json:"pages"`
-}
-
-// workInsight is one work's aggregate.
-//
-// Title and Author are here so that a client can name a book it has
-// never seen. A reader's dashboard lists what it can put a local file
-// against, and a work read only on another device falls out of that
-// list while still counting towards the total above it — a list that is
-// smaller than its own headline and gives no reason. The name is the
-// only thing needed to show the row; both are omitted when the server
-// has nothing to say rather than sent empty.
-type workInsight struct {
-	WorkID             string     `json:"work_id"`
-	Title              string     `json:"title,omitempty"`
-	Author             string     `json:"author,omitempty"`
-	Sessions           int        `json:"sessions"`
-	TotalActiveMinutes float64    `json:"total_active_minutes"`
-	TotalPages         float64    `json:"total_pages"`
-	CurrentProgression float64    `json:"current_progression"`
-	ETASeconds         *float64   `json:"eta_seconds"`
-	LastReadAt         *time.Time `json:"last_read_at"`
-}
-
-// describe adds the window to a response so a client can tell what was
-// actually counted from what it asked for. `range_days` is always
-// written — nought for an unbounded window — because "everything on
-// record" needs checking as much as any other span does: a server too
-// old to know the word answers with a horizon of its own and nothing in
-// the totals says which it was.
-//
-// This is what makes a new client safe against an old server. The
-// aggregates themselves look identical either way, so without an echo a
-// client cannot tell a range that was honoured from one that was
-// silently ignored — and would label a lifetime total as a fortnight.
-//
-// It lives here rather than in the insights package because it is the
-// shape of a JSON answer, not a fact about a span.
-func describe(w insights.Window, answer map[string]any) {
-	answer["range_days"] = w.Days()
-	if w.Unbounded() {
-		return
+func describe(win insights.Window, answer map[string]any) {
+	answer["range_days"] = win.Days()
+	if !win.Unbounded() {
+		answer["from"] = win.FromDay()
+		answer["to"] = win.ToDay()
 	}
-	answer["from"] = w.FromDay()
-	answer["to"] = w.ToDay()
 }
 
-// userLocation loads the user's configured timezone.
-func (s *Server) userLocation(r *http.Request, userID string) *time.Location {
-	u, err := s.St.UserByID(r.Context(), userID)
+func describeSnapshot(snap store.StatsSnapshot, answer map[string]any) {
+	answer["timezone"] = snap.Timezone
+	answer["stats_revision"] = strconv.FormatInt(snap.Revision, 10)
+	answer["attribution_version"] = 2
+}
+
+func (s *Server) insightInput(w http.ResponseWriter, r *http.Request, ids []string) (store.StatsSnapshot, *time.Location, bool) {
+	tok, _ := auth.TokenFrom(r)
+	snap, err := s.St.StatisticsSnapshot(r.Context(), tok.UserID, ids)
 	if err != nil {
-		return time.UTC
+		writeError(w, http.StatusInternalServerError, "statistics read failed")
+		return snap, nil, false
 	}
-	loc, err := time.LoadLocation(u.Timezone)
+	loc, err := time.LoadLocation(snap.Timezone)
 	if err != nil {
-		return time.UTC
+		writeError(w, http.StatusInternalServerError, "invalid account timezone")
+		return snap, nil, false
 	}
-	return loc
+	return snap, loc, true
 }
 
-// activeDays returns the set of tz-local days with reading on them,
-// across all of history rather than a requested window.
-//
-// The set the caller already built for its own range is reused as a
-// starting point, and an unbounded range has nothing left to add, so
-// the extra queries are skipped. Raw sessions only survive the
-// retention horizon, so the long tail here is rollups, which are one
-// row per work per day and cheap to walk.
-func (s *Server) activeDays(
-	ctx context.Context,
-	userID string,
-	loc *time.Location,
-	now time.Time,
-	known map[string]bool,
-	win insights.Window,
-) (map[string]bool, error) {
-	if win.Unbounded() {
-		return known, nil
-	}
-	all := make(map[string]bool, len(known))
-	for day := range known {
-		all[day] = true
-	}
-	from := now.AddDate(0, 0, -insights.StreakLookbackDays)
-	sessions, err := s.St.SessionsInRange(ctx, userID, from, now)
+func buildInsights(w http.ResponseWriter, snap store.StatsSnapshot, win insights.Window, now time.Time) (insights.Result, bool) {
+	result, err := insights.Build(snap, win, now)
 	if err != nil {
-		return nil, err
+		writeError(w, http.StatusInternalServerError, "statistics aggregation failed")
+		return result, false
 	}
-	for _, ses := range sessions {
-		for _, day := range splitDays(ses, loc) {
-			all[day.date] = true
-		}
-	}
-	rollups, err := s.St.RollupsInRange(ctx, userID,
-		from.In(loc).Format("2006-01-02"), now.In(loc).Format("2006-01-02"))
-	if err != nil {
-		return nil, err
-	}
-	for _, ru := range rollups {
-		if ru.ActiveSeconds > 0 {
-			all[ru.Day] = true
-		}
-	}
-	return all, nil
+	return result, true
 }
 
-// pagesRead converts a progression delta to pages using the session's
-// edition page count; negative deltas yield zero.
-func (s *Server) pagesRead(ctx context.Context, ses store.Session) float64 {
-	delta := ses.EndProg - ses.StartProg
-	if delta <= 0 || ses.EditionSHA == nil {
-		return 0
-	}
-	ed, err := s.St.EditionBySHA(ctx, ses.UserID, *ses.EditionSHA)
-	if err != nil || ed.PageCount == nil {
-		return 0
-	}
-	return delta * float64(*ed.PageCount)
-}
-
-// HandleInsightsSummary implements GET /v1/insights/summary. The span
-// is either `from=2026-01-01&to=2026-03-31` or the older `range=30d`,
-// and defaults to the last thirty days when neither is given.
 func (s *Server) HandleInsightsSummary(w http.ResponseWriter, r *http.Request) {
-	tok, _ := auth.TokenFrom(r)
 	now := time.Now()
-	loc := s.userLocation(r, tok.UserID)
+	snap, loc, ok := s.insightInput(w, r, nil)
+	if !ok {
+		return
+	}
 	win := requestWindow(r, loc, now, insights.DefaultSummaryRange)
-	from, to := win.SessionBounds(now, loc)
-	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "summary failed")
+	result, ok := buildInsights(w, snap, win, now)
+	if !ok {
 		return
 	}
-
-	var totalActive float64
-	var totalPages float64
-	sessionCount := 0
-	daySet := map[string]bool{}
-	// Rolling speed: progression delta per active second over range.
-	var progDelta float64
-	for _, ses := range sessions {
-		// A query by overlap returns a session that began before the
-		// window and ran into it. Where it counts is settled the same
-		// way here as for one book — by where it ended — so that the
-		// headline and the rows beneath it cannot disagree about a
-		// stretch of reading that straddles the first morning.
-		if !win.HoldsSession(ses) {
-			continue
-		}
-		sessionCount++
-		a := insights.ActiveSeconds(ses)
-		totalActive += a
-		totalPages += s.pagesRead(r.Context(), ses)
-		if d := ses.EndProg - ses.StartProg; d > 0 {
-			progDelta += d
-		}
-		for _, day := range splitDays(ses, loc) {
-			daySet[day.date] = true
-		}
-	}
-	// Aged sessions live as daily rollups; merge them in so ranges
-	// wider than the retention window stay correct.
-	fromDay, toDay := win.DayBounds(now, loc)
-	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID, fromDay, toDay)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "summary failed")
-		return
-	}
-	for _, ru := range rollups {
-		totalActive += ru.ActiveSeconds
-		totalPages += ru.Pages
-		progDelta += ru.ProgDelta
-		sessionCount += int(ru.SessionCount)
-		if ru.ActiveSeconds > 0 {
-			daySet[ru.Day] = true
-		}
-	}
-	// A streak is a fact about the reader, not about the window they
-	// asked to look through. Counted from every day on record, so that
-	// asking for the last week cannot report a hundred-day run as seven.
-	streakSet, err := s.activeDays(r.Context(), tok.UserID, loc, now, daySet, win)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "summary failed")
-		return
-	}
-	streak := insights.StreakDays(streakSet, loc, now)
-
-	speed := 0.0
-	if totalActive > 0 {
-		speed = progDelta / totalActive // progression fraction per second
-	}
+	sum := result.Summary
 	answer := map[string]any{
-		"total_active_minutes": totalActive / 60,
-		"total_pages":          totalPages,
-		"sessions":             sessionCount,
-		"streak_days":          streak,
-		"speed_prog_per_hour":  speed * 3600,
+		"total_active_minutes": sum.TotalActiveMinutes, "total_pages": sum.TotalPages,
+		"sessions": sum.Sessions, "streak_days": sum.StreakDays,
+		"speed_prog_per_hour": sum.SpeedProgPerHour, "first_activity_day": result.FirstActivityDay,
 	}
 	describe(win, answer)
+	describeSnapshot(snap, answer)
 	writeJSON(w, http.StatusOK, answer)
 }
 
-func (s *Server) workInsight(ctx context.Context, userID, workID string, loc *time.Location, win insights.Window) (workInsight, error) {
-	sessions, err := s.St.CurrentSessionsForWork(ctx, userID, workID, sessionsPerWork)
-	if err != nil {
-		return workInsight{}, err
-	}
-	return s.workInsightFrom(ctx, userID, workID, loc, win, sessions)
-}
-
-// workInsightFrom builds one work's aggregate from sessions already in
-// hand.
-//
-// The collection endpoint fetches the whole window once and groups it,
-// rather than asking per work: that is one query instead of one per
-// book, and it is not subject to the row limit a per-work fetch needs —
-// which, applied newest-first to a narrow window deep in the past,
-// could otherwise drop the very sessions being asked about.
-func (s *Server) workInsightFrom(
-	ctx context.Context,
-	userID, workID string,
-	loc *time.Location,
-	win insights.Window,
-	sessions []store.Session,
-) (workInsight, error) {
-	var totalActive, totalPages, progDelta float64
-	sessionCount := 0
-	var lastReadAt *time.Time
-	for _, ses := range sessions {
-		if !win.HoldsSession(ses) {
-			continue
-		}
-		sessionCount++
-		totalActive += insights.ActiveSeconds(ses)
-		totalPages += s.pagesRead(ctx, ses)
-		if d := ses.EndProg - ses.StartProg; d > 0 {
-			progDelta += d
-		}
-		if lastReadAt == nil || ses.EndedAt.After(*lastReadAt) {
-			ended := ses.EndedAt
-			lastReadAt = &ended
-		}
-	}
-	// Aged sessions live as daily rollups.
-	rollups, err := s.St.RollupsForWork(ctx, userID, workID)
-	if err != nil {
-		return workInsight{}, err
-	}
-	for _, ru := range rollups {
-		if !win.HoldsDay(ru.Day) {
-			continue
-		}
-		totalActive += ru.ActiveSeconds
-		totalPages += ru.Pages
-		progDelta += ru.ProgDelta
-		sessionCount += int(ru.SessionCount)
-		if day, err := time.ParseInLocation("2006-01-02", ru.Day, loc); err == nil &&
-			(lastReadAt == nil || day.After(*lastReadAt)) {
-			lastReadAt = &day
-		}
-	}
-	// Current position: newest op. Never windowed — where the reader is
-	// in a book is true now, whatever span the totals beside it cover,
-	// and an estimate of what is left must be measured from there.
-	var currentProg float64
-	var etaSeconds *float64
-	if ops, err := s.St.Positions(ctx, userID, workID, 1); err == nil && len(ops) > 0 {
-		currentProg = ops[0].Progression
-		if totalActive > 0 && progDelta > 0 {
-			speed := progDelta / totalActive
-			remaining := 1 - currentProg
-			if remaining > 0 && speed > 0 {
-				eta := remaining / speed
-				etaSeconds = &eta
-			}
-		}
-	}
-	// The name, when the server has one. A missing work is not an error
-	// here: the aggregate is built from sessions and rollups that name
-	// the work themselves, so a record that has gone stays a row with
-	// figures on it and no title, rather than failing the whole request.
-	// Any other failure is a real store problem and must propagate,
-	// rather than being swallowed into the same silent blank.
-	title, author := "", ""
-	work, err := s.St.WorkByID(ctx, userID, workID)
-	switch {
-	case err == nil:
-		title, author = work.Title, work.Author
-	case errors.Is(err, store.ErrNotFound):
-		// Nothing to do: title and author stay empty.
-	default:
-		return workInsight{}, err
-	}
-	return workInsight{
-		WorkID:             workID,
-		Title:              title,
-		Author:             author,
-		Sessions:           sessionCount,
-		TotalActiveMinutes: totalActive / 60,
-		TotalPages:         totalPages,
-		CurrentProgression: currentProg,
-		ETASeconds:         etaSeconds,
-		LastReadAt:         lastReadAt,
-	}, nil
-}
-
-// HandleInsightsWorks implements GET /v1/insights/works. It returns one
-// aggregate per work with reading history, so a client can render its
-// per-book dashboard without issuing one request for every catalog item.
-//
-// An optional span narrows every aggregate to the same window the
-// summary uses, so that a dashboard's headline and its per-book rows
-// add up to each other instead of describing two different spans. It is
-// echoed back for the same reason the calendar's is: a client must be
-// able to tell a narrowed answer from a lifetime one, because the two
-// are indistinguishable from the aggregates alone.
 func (s *Server) HandleInsightsWorks(w http.ResponseWriter, r *http.Request) {
-	tok, _ := auth.TokenFrom(r)
-	workIDs, err := s.St.WorkIDsWithInsights(r.Context(), tok.UserID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "work insights failed")
-		return
-	}
-	loc := s.userLocation(r, tok.UserID)
 	now := time.Now()
-	win := requestWindow(r, loc, now, "")
-	from, to := win.SessionBounds(now, loc)
-	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "work insights failed")
+	snap, loc, ok := s.insightInput(w, r, nil)
+	if !ok {
 		return
 	}
-	byWork := map[string][]store.Session{}
-	for _, ses := range sessions {
-		byWork[ses.WorkID] = append(byWork[ses.WorkID], ses)
+	win := requestWindow(r, loc, now, "")
+	result, ok := buildInsights(w, snap, win, now)
+	if !ok {
+		return
 	}
-	works := make([]workInsight, 0, len(workIDs))
-	for _, workID := range workIDs {
-		insight, err := s.workInsightFrom(
-			r.Context(), tok.UserID, workID, loc, win, byWork[workID])
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, "work insights failed")
-			return
-		}
-		if insight.Sessions > 0 || insight.TotalActiveMinutes > 0 {
-			works = append(works, insight)
-		}
-	}
-	sort.Slice(works, func(i, j int) bool {
-		return works[i].TotalActiveMinutes > works[j].TotalActiveMinutes
-	})
-	answer := map[string]any{"works": works}
+	answer := map[string]any{"works": result.Works}
 	describe(win, answer)
+	describeSnapshot(snap, answer)
 	writeJSON(w, http.StatusOK, answer)
 }
 
-// workInsightAnswer is one work's aggregate with the span it covers.
-// The embedded type's fields are promoted, so this stays the flat object
-// it has always been rather than growing a nested envelope.
-type workInsightAnswer struct {
-	workInsight
-	RangeDays int    `json:"range_days"`
-	From      string `json:"from,omitempty"`
-	To        string `json:"to,omitempty"`
-}
-
-// HandleInsightsWork implements GET /v1/insights/works/{id}.
 func (s *Server) HandleInsightsWork(w http.ResponseWriter, r *http.Request) {
-	tok, _ := auth.TokenFrom(r)
-	workID := r.PathValue("id")
-	if _, err := s.St.WorkByID(r.Context(), tok.UserID, workID); err != nil {
+	now := time.Now()
+	snap, loc, ok := s.insightInput(w, r, nil)
+	if !ok {
+		return
+	}
+	win := requestWindow(r, loc, now, "")
+	result, ok := buildInsights(w, snap, win, now)
+	if !ok {
+		return
+	}
+	work, found := result.ByWork[r.PathValue("id")]
+	if !found {
 		writeError(w, http.StatusNotFound, "work not found")
 		return
 	}
-	loc := s.userLocation(r, tok.UserID)
-	win := requestWindow(r, loc, time.Now(), "")
-	insight, err := s.workInsight(r.Context(), tok.UserID, workID, loc, win)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "work insights failed")
-		return
-	}
-	writeJSON(w, http.StatusOK, workInsightAnswer{
-		workInsight: insight,
-		RangeDays:   win.Days(),
-		From:        win.FromDay(),
-		To:          win.ToDay(),
-	})
+	writeJSON(w, http.StatusOK, struct {
+		insights.Work
+		RangeDays int    `json:"range_days"`
+		From      string `json:"from,omitempty"`
+		To        string `json:"to,omitempty"`
+		Timezone  string `json:"timezone"`
+	}{work, win.Days(), win.FromDay(), win.ToDay(), snap.Timezone})
 }
 
-// HandleInsightsCalendar implements GET /v1/insights/calendar — daily
-// minutes for heatmaps, days in the user's timezone.
-//
-// Either `year=2026` or `from=2025-04-01&to=2026-03-31`. The bounded
-// form exists so a rolling window costs one request rather than one per
-// calendar year it happens to straddle, and both bounds are echoed back
-// so a client can tell a server that understood them from one that
-// ignored them and answered with this year.
 func (s *Server) HandleInsightsCalendar(w http.ResponseWriter, r *http.Request) {
-	tok, _ := auth.TokenFrom(r)
-	loc := s.userLocation(r, tok.UserID)
+	now := time.Now()
+	snap, loc, ok := s.insightInput(w, r, nil)
+	if !ok {
+		return
+	}
 	win, bounded, ok := calendarBounds(r, loc)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "calendar span too long")
 		return
 	}
-	from, to := win.SessionBounds(time.Now(), loc)
-	sessions, err := s.St.SessionsInRange(r.Context(), tok.UserID, from, to)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "calendar failed")
+	result, ok := buildInsights(w, snap, win, now)
+	if !ok {
 		return
 	}
-	byDay := map[string]*dayStat{}
-	for _, ses := range sessions {
-		for _, part := range s.splitDaysFull(r.Context(), ses, loc) {
-			d := byDay[part.date]
-			if d == nil {
-				d = &dayStat{Date: part.date}
-				byDay[part.date] = d
-			}
-			d.Minutes += part.activeSec / 60
-			d.Pages += part.pages
-		}
-	}
-	rollups, err := s.St.RollupsInRange(r.Context(), tok.UserID, win.FromDay(), win.ToDay())
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "calendar failed")
-		return
-	}
-	for _, ru := range rollups {
-		d := byDay[ru.Day]
-		if d == nil {
-			d = &dayStat{Date: ru.Day}
-			byDay[ru.Day] = d
-		}
-		d.Minutes += ru.ActiveSeconds / 60
-		d.Pages += ru.Pages
-	}
-	out := []dayStat{}
-	for _, d := range byDay {
-		out = append(out, *d)
-	}
-	sort.Slice(out, func(i, j int) bool { return out[i].Date < out[j].Date })
-	answer := map[string]any{"year": calendarYear(win, loc), "days": out}
+	first, _ := time.Parse(insights.DayFormat, win.FromDay())
+	answer := map[string]any{"year": first.Year(), "days": result.Days}
 	if bounded {
 		describe(win, answer)
 	}
+	describeSnapshot(snap, answer)
 	writeJSON(w, http.StatusOK, answer)
 }
 
-// calendarBounds resolves the requested span. It reports whether an
-// explicit from/to pair was honoured, which is what the response echo is
-// derived from: a client must not be able to mistake an ignored
-// parameter for an obeyed one. A span longer than any reader can have
-// is refused rather than served, so that one authenticated request
-// cannot ask the store to walk an unbounded history.
 func calendarBounds(r *http.Request, loc *time.Location) (insights.Window, bool, bool) {
 	q := r.URL.Query()
 	rawFrom, rawTo := q.Get("from"), q.Get("to")
 	if rawFrom != "" && rawTo != "" {
-		from, errFrom := time.ParseInLocation("2006-01-02", rawFrom, loc)
-		to, errTo := time.ParseInLocation("2006-01-02", rawTo, loc)
+		from, errFrom := time.ParseInLocation(insights.DayFormat, rawFrom, loc)
+		to, errTo := time.ParseInLocation(insights.DayFormat, rawTo, loc)
 		if errFrom == nil && errTo == nil && !to.Before(from) {
 			win := insights.DayWindow(from, to, loc)
-			if win.Days() > maxCalendarDays {
-				return insights.Window{}, true, false
-			}
-			return win, true, true
+			return win, true, win.Days() <= maxCalendarDays
 		}
 	}
 	year := time.Now().In(loc).Year()
-	if y := q.Get("year"); y != "" {
-		var v int
-		if _, err := parseInt(y, &v); err == nil && v > 1970 && v < 3000 {
-			year = v
-		}
+	if v, err := strconv.Atoi(q.Get("year")); err == nil && v > 1970 && v < 3000 {
+		year = v
 	}
 	first := time.Date(year, 1, 1, 0, 0, 0, 0, loc)
 	return insights.DayWindow(first, first.AddDate(1, 0, -1), loc), false, true
 }
 
-type dayPart struct {
-	date      string
-	activeSec float64
-	pages     float64
-}
-
-// splitDays splits a session into tz-local day parts. Pages attribute
-// pro-rata by active time share (approximation, honest about it).
-func (s *Server) splitDaysFull(ctx context.Context, ses store.Session, loc *time.Location) []dayPart {
-	parts := splitDays(ses, loc)
-	total := 0.0
-	for _, p := range parts {
-		total += p.activeSec
-	}
-	pages := s.pagesRead(ctx, ses)
-	for i := range parts {
-		if total > 0 {
-			parts[i].pages = pages * parts[i].activeSec / total
-		}
-	}
-	return parts
-}
-
-// splitDays divides a session's active seconds across the tz-local days
-// it spans (idle excluded pro-rata is overkill; active = whole segment
-// minus idle attributed to the segment containing the session end).
-func splitDays(ses store.Session, loc *time.Location) []dayPart {
-	var parts []dayPart
-	start := ses.StartedAt.In(loc)
-	end := ses.EndedAt.In(loc)
-	idleSec := float64(ses.IdleMs) / 1000
-	totalDur := ses.EndedAt.Sub(ses.StartedAt).Seconds()
-	if totalDur <= 0 {
-		return nil
-	}
-	for dayStart := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, loc); dayStart.Before(end); dayStart = dayStart.AddDate(0, 0, 1) {
-		dayEnd := dayStart.AddDate(0, 0, 1)
-		segStart := maxTime(start, dayStart)
-		segEnd := minTime(end, dayEnd)
-		if !segEnd.After(segStart) {
-			continue
-		}
-		parts = append(parts, dayPart{
-			date:      dayStart.Format("2006-01-02"),
-			activeSec: segEnd.Sub(segStart).Seconds(),
-		})
-	}
-	// Subtract idle from the end backwards. A pause can exceed the
-	// final day's segment when a session crosses midnight.
-	for i := len(parts) - 1; i >= 0 && idleSec > 0; i-- {
-		if idleSec >= parts[i].activeSec {
-			idleSec -= parts[i].activeSec
-			parts[i].activeSec = 0
-			continue
-		}
-		parts[i].activeSec -= idleSec
-		idleSec = 0
-	}
-	return parts
-}
-
-// sessionsPerWork bounds a single work's raw session fetch. Raw
-// sessions are reduced to daily rollups past the retention horizon, so
-// this is far more sittings than one book can hold; the collection
-// endpoint does not use it at all, fetching the window once and
-// grouping it instead.
-const sessionsPerWork = 10_000
-
-// maxCalendarDays is the longest calendar a single request may ask for.
-// Comfortably more than a client showing a year at a time needs, and
-// short of asking the store to walk an entire history per request.
-const maxCalendarDays = 4000
-
-// requestWindow resolves the span an insights request asks for, from
-// the parameters this API spells them with. The resolving itself lives
-// in the insights package, so that the web UI — which spells them
-// differently and never sees an *http.Request — reaches the same
-// answer.
 func requestWindow(r *http.Request, loc *time.Location, now time.Time, def string) insights.Window {
 	q := r.URL.Query()
 	return insights.ParseWindow(q.Get("from"), q.Get("to"), q.Get("range"), def, loc, now)
-}
-
-// calendarYear is the year the calendar's span opens in, which is the
-// only thing the `year` field in its answer ever meant.
-func calendarYear(win insights.Window, loc *time.Location) int {
-	day, err := time.ParseInLocation(insights.DayFormat, win.FromDay(), loc)
-	if err != nil {
-		return time.Now().In(loc).Year()
-	}
-	return day.Year()
-}
-
-func parseInt(s string, out *int) (int, error) {
-	var v int
-	for _, c := range s {
-		if c < '0' || c > '9' {
-			return 0, errBadInt
-		}
-		v = v*10 + int(c-'0')
-	}
-	*out = v
-	return v, nil
-}
-
-var errBadInt = errString2("bad int")
-
-type errString2 string
-
-func (e errString2) Error() string { return string(e) }
-
-func maxTime(a, b time.Time) time.Time {
-	if a.After(b) {
-		return a
-	}
-	return b
-}
-
-func minTime(a, b time.Time) time.Time {
-	if a.Before(b) {
-		return a
-	}
-	return b
 }

--- a/internal/api/insights_snapshot.go
+++ b/internal/api/insights_snapshot.go
@@ -1,0 +1,237 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/insights"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+const maxInsightCandidates = 10_000
+
+func (s *Server) HandleInsightsCapabilities(w http.ResponseWriter, r *http.Request) {
+	tok, _ := auth.TokenFrom(r)
+	user, err := s.St.UserByID(r.Context(), tok.UserID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "account read failed")
+		return
+	}
+	if _, err := time.LoadLocation(user.Timezone); err != nil {
+		writeError(w, http.StatusInternalServerError, "invalid account timezone")
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"version": 1, "active_ms": true, "attribution_version": 2,
+		"account_id": tok.UserID, "all_time": true,
+		"timezone": user.Timezone, "max_candidates": maxInsightCandidates,
+		"max_calendar_days":     maxCalendarDays,
+		"max_body_bytes":        s.Cfg.Ops.MaxBodyBytes,
+		"max_local_active_days": maxInsightCandidates,
+	})
+}
+
+type insightCandidate struct {
+	sessionReqJSON
+	DeviceID string `json:"device_id"`
+}
+
+type insightSnapshotRequest struct {
+	SnapshotID      string             `json:"snapshot_id"`
+	Timezone        string             `json:"timezone"`
+	Range           string             `json:"range"`
+	From            string             `json:"from"`
+	To              string             `json:"to"`
+	Candidates      []insightCandidate `json:"candidates"`
+	LocalActiveDays []string           `json:"local_active_days"`
+	CalendarFrom    string             `json:"calendar_from"`
+	CalendarTo      string             `json:"calendar_to"`
+}
+
+func snapshotWindow(req insightSnapshotRequest, loc *time.Location, now time.Time) (insights.Window, bool) {
+	if req.From != "" || req.To != "" {
+		from, errFrom := time.ParseInLocation(insights.DayFormat, req.From, loc)
+		to, errTo := time.ParseInLocation(insights.DayFormat, req.To, loc)
+		if errFrom != nil || errTo != nil || to.Before(from) || req.Range != "" {
+			return insights.Window{}, false
+		}
+		return insights.DayWindow(from, to, loc), true
+	}
+	if req.Range == "all" {
+		return insights.Window{}, true
+	}
+	if !strings.HasSuffix(req.Range, "d") {
+		return insights.Window{}, false
+	}
+	days, err := strconv.Atoi(strings.TrimSuffix(req.Range, "d"))
+	if err != nil || days <= 0 || days > insights.MaxRangeDays {
+		return insights.Window{}, false
+	}
+	return insights.ParseWindow("", "", req.Range, "", loc, now), true
+}
+
+// Candidates and aggregates are read together; an upload acknowledgement,
+// a separate receipt query, or an op cursor cannot prove this overlap.
+func (s *Server) HandleInsightsSnapshot(w http.ResponseWriter, r *http.Request) {
+	var req insightSnapshotRequest
+	if decodeBatch(w, r, s.Cfg.Ops.MaxBodyBytes, &req) {
+		return
+	}
+	if req.SnapshotID == "" || len(req.SnapshotID) > 128 ||
+		len(req.Candidates) > maxInsightCandidates || len(req.LocalActiveDays) > maxInsightCandidates {
+		writeError(w, http.StatusBadRequest, "invalid or excessive snapshot evidence")
+		return
+	}
+	tok, _ := auth.TokenFrom(r)
+	candidates := make([]store.Session, 0, len(req.Candidates))
+	ids := make([]string, 0, len(req.Candidates))
+	seen := make(map[string]bool)
+	for _, candidate := range req.Candidates {
+		if candidate.DeviceID == "" || len(candidate.DeviceID) > 64 || seen[candidate.SessionID] {
+			writeError(w, http.StatusBadRequest, "invalid candidate identity")
+			return
+		}
+		ses, err := parseSessionRequest(candidate.sessionReqJSON, candidate.DeviceID)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid candidate payload")
+			return
+		}
+		ses.UserID = tok.UserID
+		seen[ses.SessionID] = true
+		ids = append(ids, ses.SessionID)
+		candidates = append(candidates, ses)
+	}
+	now := time.Now()
+	snap, loc, ok := s.insightInput(w, r, ids)
+	if !ok {
+		return
+	}
+	if req.Timezone != snap.Timezone {
+		writeError(w, http.StatusConflict, "statistics timezone changed")
+		return
+	}
+	win, ok := snapshotWindow(req, loc, now)
+	if !ok {
+		writeError(w, http.StatusBadRequest, "invalid statistics window")
+		return
+	}
+	result, ok := buildInsights(w, snap, win, now)
+	if !ok {
+		return
+	}
+	today := now.In(loc).Format(insights.DayFormat)
+	for _, date := range req.LocalActiveDays {
+		if _, err := time.Parse(insights.DayFormat, date); err != nil || date > today {
+			writeError(w, http.StatusBadRequest, "invalid local activity day")
+			return
+		}
+		result.ActiveDays[date] = true
+	}
+	calendarFrom, calendarTo := win.DayBounds(now, loc)
+	if win.Unbounded() {
+		calendarFrom = today
+		if result.FirstActivityDay != nil {
+			calendarFrom = *result.FirstActivityDay
+		}
+		first := now.In(loc).AddDate(0, 0, -(maxCalendarDays - 1)).Format(insights.DayFormat)
+		if calendarFrom < first {
+			calendarFrom = first
+		}
+	}
+	if req.CalendarFrom != "" || req.CalendarTo != "" {
+		calendarFrom, calendarTo = req.CalendarFrom, req.CalendarTo
+	}
+	first, errFrom := time.ParseInLocation(insights.DayFormat, calendarFrom, loc)
+	last, errTo := time.ParseInLocation(insights.DayFormat, calendarTo, loc)
+	if errFrom != nil || errTo != nil || last.Before(first) {
+		writeError(w, http.StatusBadRequest, "invalid calendar window")
+		return
+	}
+	calendarWin := insights.DayWindow(first, last, loc)
+	if calendarWin.Days() > maxCalendarDays ||
+		(!win.Unbounded() && (!win.HoldsDay(calendarFrom) || !win.HoldsDay(calendarTo))) {
+		writeError(w, http.StatusBadRequest, "calendar window outside supported bounds")
+		return
+	}
+	overlapSnapshot := store.StatsSnapshot{
+		Timezone: snap.Timezone, Works: snap.Works, Editions: snap.Editions,
+	}
+	raw := make(map[string]store.Session, len(snap.Sessions))
+	for _, ses := range snap.Sessions {
+		raw[ses.SessionID] = ses
+	}
+	incomplete := func(reason string) {
+		result.Complete = false
+		result.IncompleteReason = reason
+	}
+	for _, candidate := range candidates {
+		fingerprint := store.SessionFingerprint(candidate)
+		if ses, exists := raw[candidate.SessionID]; exists {
+			if store.SessionFingerprint(ses) != fingerprint {
+				incomplete("candidate_payload_mismatch")
+				continue
+			}
+			overlapSnapshot.Sessions = append(overlapSnapshot.Sessions, ses)
+			continue
+		}
+		proof, archived := snap.Archived[candidate.SessionID]
+		if !archived {
+			continue
+		}
+		if proof.Fingerprint != fingerprint || proof.AttributionVersion != 2 {
+			incomplete("unknown_archived_contribution")
+			continue
+		}
+		if !proof.Present {
+			continue
+		}
+		if proof.Timezone != snap.Timezone {
+			incomplete("archived_timezone_mismatch")
+			continue
+		}
+		if _, exists := result.ByWork[proof.WorkID]; !exists {
+			incomplete("archived_work_missing")
+			continue
+		}
+		overlapSnapshot.Rollups = append(overlapSnapshot.Rollups, store.SessionRollup{
+			WorkID: proof.WorkID, Day: proof.Day, Timezone: proof.Timezone,
+			AttributionVersion: 2, SessionCount: 1, ActiveSeconds: proof.ActiveSeconds,
+			Pages: proof.Pages, ProgDelta: proof.ProgDelta,
+			MeasuredActiveSeconds: proof.MeasuredActiveSeconds, MeasuredProgDelta: proof.MeasuredProgDelta,
+		})
+	}
+	overlap, ok := buildInsights(w, overlapSnapshot, win, now)
+	if !ok {
+		return
+	}
+	answer := map[string]any{
+		"version": 1, "account_id": tok.UserID, "snapshot_id": req.SnapshotID,
+		"complete": result.Complete, "first_activity_day": result.FirstActivityDay,
+		"today": today, "calendar_from": calendarFrom, "calendar_to": calendarTo,
+		"summary": result.Summary, "works": result.Works, "days": calendarDays(result.Days, calendarWin),
+		"combined_streak_days": insights.StreakDays(result.ActiveDays, loc, now),
+		"overlap": map[string]any{
+			"total_active_minutes": overlap.Summary.TotalActiveMinutes, "sessions": overlap.Summary.Sessions,
+			"works": overlap.Works, "days": calendarDays(overlap.Days, calendarWin),
+		},
+	}
+	if !result.Complete {
+		answer["incomplete_reason"] = result.IncompleteReason
+	}
+	describe(win, answer)
+	describeSnapshot(snap, answer)
+	writeJSON(w, http.StatusOK, answer)
+}
+
+func calendarDays(days []insights.Day, win insights.Window) []insights.Day {
+	out := make([]insights.Day, 0)
+	for _, day := range days {
+		if win.HoldsDay(day.Date) {
+			out = append(out, day)
+		}
+	}
+	return out
+}

--- a/internal/api/insights_snapshot_regression_test.go
+++ b/internal/api/insights_snapshot_regression_test.go
@@ -1,0 +1,1008 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/config"
+	"github.com/chmouel/liseur-sync/internal/insights"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+type snapshotFixture struct {
+	ts             *httptest.Server
+	st             store.Store
+	user           store.User
+	work           store.Work
+	reader, writer string
+	originalDevice string
+}
+
+func newSnapshotFixture(t *testing.T) *snapshotFixture {
+	t.Helper()
+	ts, st := testServer(t)
+	t.Cleanup(func() {
+		ts.Close()
+		if err := st.Close(); err != nil {
+			t.Error(err)
+		}
+	})
+	hash, err := auth.HashPassword("hunter2hunter")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := &snapshotFixture{
+		ts: ts, st: st,
+		user: store.User{ID: "snapshot-user", Name: "snapshot-reader", Argon2Hash: hash, Timezone: "UTC", CreatedAt: time.Now()},
+	}
+	if err := st.CreateUser(t.Context(), f.user); err != nil {
+		t.Fatal(err)
+	}
+	f.work = store.Work{ID: "snapshot-work", UserID: f.user.ID, Title: "Test book", Author: "Test author", CreatedAt: time.Now()}
+	if err := st.CreateWork(t.Context(), f.work, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	service := auth.NewService(st)
+	f.reader, _, err = service.MintToken(t.Context(), f.user.ID, "new phone", store.ScopeSet{store.ScopeReadInsights}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tok store.Token
+	f.writer, tok, err = service.MintToken(t.Context(), f.user.ID, "original phone", store.ScopeSet{store.ScopeSync}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.originalDevice = tok.DeviceID
+	return f
+}
+
+func (f *snapshotFixture) session(id string) store.Session {
+	start := time.Date(2024, 1, 2, 12, 0, 0, 0, time.UTC)
+	active := int64(30 * 60 * 1000)
+	return store.Session{
+		UserID: f.user.ID, SessionID: id, WorkID: f.work.ID, DeviceID: f.originalDevice,
+		StartedAt: start, EndedAt: start.Add(10 * time.Minute),
+		StartProg: 0.1, EndProg: 0.2, ActiveMs: &active, Origin: store.OriginNative,
+	}
+}
+
+// Build the wire payload independently of the handler's request types.
+func snapshotCandidate(s store.Session) map[string]any {
+	out := map[string]any{
+		"session_id": s.SessionID, "work_id": s.WorkID, "device_id": s.DeviceID,
+		"started_at": s.StartedAt.Format(time.RFC3339Nano), "ended_at": s.EndedAt.Format(time.RFC3339Nano),
+		"start_progression": s.StartProg, "end_progression": s.EndProg, "idle_ms": s.IdleMs,
+	}
+	if s.ActiveMs != nil {
+		out["active_ms"] = *s.ActiveMs
+	}
+	if s.EditionSHA != nil {
+		out["edition_sha"] = *s.EditionSHA
+	}
+	return out
+}
+
+func snapshotBody(sessions ...store.Session) map[string]any {
+	candidates := make([]map[string]any, 0, len(sessions))
+	for _, s := range sessions {
+		candidates = append(candidates, snapshotCandidate(s))
+	}
+	return map[string]any{
+		"snapshot_id": "local-generation-7", "timezone": "UTC", "range": "all",
+		"candidates": candidates, "local_active_days": []string{},
+		"calendar_from": "2024-01-01", "calendar_to": "2024-01-31",
+	}
+}
+
+type snapshotReply struct {
+	AccountID          string           `json:"account_id"`
+	SnapshotID         string           `json:"snapshot_id"`
+	Timezone           string           `json:"timezone"`
+	Revision           string           `json:"stats_revision"`
+	Complete           bool             `json:"complete"`
+	IncompleteReason   string           `json:"incomplete_reason"`
+	CombinedStreakDays int              `json:"combined_streak_days"`
+	Summary            insights.Summary `json:"summary"`
+	Works              []insights.Work  `json:"works"`
+	Days               []insights.Day   `json:"days"`
+	Overlap            struct {
+		Minutes  float64         `json:"total_active_minutes"`
+		Sessions int             `json:"sessions"`
+		Works    []insights.Work `json:"works"`
+		Days     []insights.Day  `json:"days"`
+	} `json:"overlap"`
+}
+
+func readSnapshot(t *testing.T, url, token string, body map[string]any) snapshotReply {
+	t.Helper()
+	code, out := post(t, url+"/v1/insights/snapshot", token, body)
+	if code != http.StatusOK {
+		t.Fatalf("snapshot: HTTP %d: %v", code, out)
+	}
+	for _, field := range []string{
+		"account_id", "snapshot_id", "timezone", "stats_revision", "complete",
+		"summary", "works", "days", "overlap", "combined_streak_days",
+	} {
+		if _, ok := out[field]; !ok {
+			t.Errorf("snapshot missing %q: %v", field, out)
+		}
+	}
+	if out["version"] != float64(1) || out["attribution_version"] != float64(2) {
+		t.Errorf("protocol versions: %v", out)
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got snapshotReply
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	revision, err := strconv.ParseInt(got.Revision, 10, 64)
+	if err != nil || revision < 0 || strconv.FormatInt(revision, 10) != got.Revision {
+		t.Errorf("revision must be a canonical decimal string: %q", got.Revision)
+	}
+	if got.SnapshotID != body["snapshot_id"] || got.Timezone != body["timezone"] {
+		t.Errorf("snapshot identity not echoed: %+v", got)
+	}
+	return got
+}
+
+func snapshotNear(t *testing.T, label string, got, want float64) {
+	t.Helper()
+	if math.IsNaN(got) || math.IsInf(got, 0) || math.Abs(got-want) > 1e-9 {
+		t.Errorf("%s: got %v, want %v", label, got, want)
+	}
+}
+
+func requireSnapshotError(t *testing.T, code int, out map[string]any, want int) {
+	t.Helper()
+	if code != want {
+		t.Fatalf("got HTTP %d, want %d: %v", code, want, out)
+	}
+	if text, ok := out["error"].(string); !ok || text == "" {
+		t.Errorf("missing JSON error: %v", out)
+	}
+	for _, field := range []string{"summary", "overlap", "stats_revision", "complete"} {
+		if _, ok := out[field]; ok {
+			t.Errorf("failure contains success field %q: %v", field, out)
+		}
+	}
+}
+
+func TestInsightsSnapshotMeasuredOverlapSurvivesReplayAndCompaction(t *testing.T) {
+	f := newSnapshotFixture(t)
+	f.work.ID = "edition-work"
+	sha, pages := "edition-sha", int64(200)
+	if err := f.st.CreateWork(t.Context(), f.work, &store.Edition{
+		UserID: f.user.ID, WorkID: f.work.ID, SHA256: sha, PageCount: &pages,
+	}, nil); err != nil {
+		t.Fatal(err)
+	}
+	local, remote := f.session("local"), f.session("remote")
+	local.EditionSHA, remote.EditionSHA = &sha, &sha
+	local.IdleMs = 5 * 60 * 1000
+	remote.DeviceID = "another-device"
+	remoteActive := int64(20 * 60 * 1000)
+	remote.ActiveMs = &remoteActive
+	if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{local, remote}); err != nil {
+		t.Fatal(err)
+	}
+	body := snapshotBody(local)
+	assertTotals := func(got snapshotReply) {
+		t.Helper()
+		if got.AccountID != f.user.ID || !got.Complete || got.IncompleteReason != "" {
+			t.Errorf("snapshot identity/completeness: %+v", got)
+		}
+		snapshotNear(t, "server minutes", got.Summary.TotalActiveMinutes, 50)
+		snapshotNear(t, "server pages", got.Summary.TotalPages, 40)
+		snapshotNear(t, "overlap minutes", got.Overlap.Minutes, 30)
+		if got.Summary.Sessions != 2 || got.Overlap.Sessions != 1 {
+			t.Errorf("session counts: %+v", got)
+		}
+		if len(got.Works) != 1 || got.Works[0].WorkID != f.work.ID ||
+			got.Works[0].TotalActiveMinutes != 50 || got.Works[0].Sessions != 2 ||
+			got.Works[0].TotalPages != 40 ||
+			len(got.Overlap.Works) != 1 || got.Overlap.Works[0].TotalActiveMinutes != 30 ||
+			got.Overlap.Works[0].Sessions != 1 || got.Overlap.Works[0].TotalPages != 20 {
+			t.Errorf("per-work server/overlap totals: %+v", got)
+		}
+		if want := []insights.Day{{Date: "2024-01-02", Minutes: 50, Pages: 40, Sessions: 2}}; !reflect.DeepEqual(got.Days, want) {
+			t.Errorf("server days: got %+v, want %+v", got.Days, want)
+		}
+		if want := []insights.Day{{Date: "2024-01-02", Minutes: 30, Pages: 20, Sessions: 1}}; !reflect.DeepEqual(got.Overlap.Days, want) {
+			t.Errorf("overlap days: got %+v, want %+v", got.Overlap.Days, want)
+		}
+	}
+	before := readSnapshot(t, f.ts.URL, f.reader, body)
+	assertTotals(before)
+	for _, compact := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compacted=%v", compact), func(t *testing.T) {
+			if compact {
+				(&Server{St: f.st}).rollupSessionsOnce(t.Context(), 24*time.Hour)
+				snap, err := f.st.StatisticsSnapshot(t.Context(), f.user.ID, []string{local.SessionID})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(snap.Sessions) != 0 || !snap.Archived[local.SessionID].Present {
+					t.Fatalf("compaction precondition failed: %+v", snap)
+				}
+			}
+			preReplay := readSnapshot(t, f.ts.URL, f.reader, body)
+			assertTotals(preReplay)
+			code, out := post(t, f.ts.URL+"/v1/sessions", f.writer,
+				map[string]any{"sessions": []map[string]any{snapshotCandidate(local)}})
+			if code != http.StatusOK {
+				t.Fatalf("identical replay: %d %v", code, out)
+			}
+			after := readSnapshot(t, f.ts.URL, f.reader, body)
+			assertTotals(after)
+			if after.Revision != preReplay.Revision {
+				t.Errorf("idempotent replay changed revision: %s -> %s", preReplay.Revision, after.Revision)
+			}
+		})
+	}
+}
+
+func TestInsightsSnapshotLegacyPayloadSubtractsActualServerContribution(t *testing.T) {
+	for _, compact := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compacted=%v", compact), func(t *testing.T) {
+			f := newSnapshotFixture(t)
+			legacy := f.session("legacy-local")
+			legacy.ActiveMs = nil
+			if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{legacy}); err != nil {
+				t.Fatal(err)
+			}
+			if compact {
+				(&Server{St: f.st}).rollupSessionsOnce(t.Context(), 24*time.Hour)
+			}
+			got := readSnapshot(t, f.ts.URL, f.reader, snapshotBody(legacy))
+			if !got.Complete || got.Summary.Sessions != 1 || got.Overlap.Sessions != 1 {
+				t.Fatalf("original legacy payload is exact evidence: %+v", got)
+			}
+			snapshotNear(t, "legacy server minutes", got.Summary.TotalActiveMinutes, 10)
+			snapshotNear(t, "actual overlap, not local measured duration", got.Overlap.Minutes, 10)
+			// The phone has since measured 30 minutes, but must offer the
+			// original payload as evidence for the server's ten-minute row.
+			snapshotNear(t, "local + server - actual overlap", 30+got.Summary.TotalActiveMinutes-got.Overlap.Minutes, 30)
+			if len(got.Overlap.Works) != 1 || got.Overlap.Works[0].TotalActiveMinutes != 10 ||
+				len(got.Overlap.Days) != 1 || got.Overlap.Days[0].Minutes != 10 {
+				t.Errorf("legacy overlap dimensions: %+v", got.Overlap)
+			}
+			changed := legacy
+			active := int64(30 * 60 * 1000)
+			changed.ActiveMs = &active
+			mismatch := readSnapshot(t, f.ts.URL, f.reader, snapshotBody(changed))
+			if mismatch.Complete || mismatch.IncompleteReason == "" || mismatch.Overlap.Minutes != 0 {
+				t.Errorf("new payload cannot prove the old contribution: %+v", mismatch)
+			}
+			snapshotNear(t, "mismatch still exposes server totals", mismatch.Summary.TotalActiveMinutes, 10)
+		})
+	}
+}
+
+func TestInsightsSnapshotLegacyArchiveFallsBackWithoutInventingOverlap(t *testing.T) {
+	f := newSnapshotFixture(t)
+	ses := f.session("legacy-archive")
+	ses.ActiveMs = nil
+	if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.st.ApplyRollups(t.Context(), f.user.ID, []store.SessionRollup{{
+		WorkID: f.work.ID, Day: "2024-01-02", ActiveSeconds: 600, SessionCount: 1,
+	}}, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	for _, candidates := range [][]store.Session{nil, {ses}} {
+		got := readSnapshot(t, f.ts.URL, f.reader, snapshotBody(candidates...))
+		if got.Complete || got.IncompleteReason == "" || got.Summary.Sessions != 1 ||
+			got.Overlap.Sessions != 0 || got.Overlap.Minutes != 0 {
+			t.Errorf("legacy archive must request fallback: %+v", got)
+		}
+		snapshotNear(t, "legacy total retained", got.Summary.TotalActiveMinutes, 10)
+		if len(got.Days) != 1 || got.Days[0].Minutes != 10 || len(got.Works) != 1 {
+			t.Errorf("legacy totals hidden: %+v", got)
+		}
+	}
+}
+
+func TestInsightsSnapshotDeletedContributionsAreNotOverlap(t *testing.T) {
+	for _, compact := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compacted=%v", compact), func(t *testing.T) {
+			f := newSnapshotFixture(t)
+			ses := f.session("deleted")
+			if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{ses}); err != nil {
+				t.Fatal(err)
+			}
+			if compact {
+				(&Server{St: f.st}).rollupSessionsOnce(t.Context(), 24*time.Hour)
+			}
+			before := readSnapshot(t, f.ts.URL, f.reader, snapshotBody(ses))
+			if err := f.st.DeleteWork(t.Context(), f.user.ID, f.work.ID); err != nil {
+				t.Fatal(err)
+			}
+			got := readSnapshot(t, f.ts.URL, f.reader, snapshotBody(ses))
+			if !got.Complete || got.Summary.Sessions != 0 || got.Summary.TotalActiveMinutes != 0 ||
+				got.Overlap.Sessions != 0 || got.Overlap.Minutes != 0 ||
+				len(got.Works) != 0 || len(got.Days) != 0 || len(got.Overlap.Works) != 0 || len(got.Overlap.Days) != 0 {
+				t.Errorf("deleted contribution still counted: %+v", got)
+			}
+			if got.Revision == before.Revision {
+				t.Error("deletion did not invalidate snapshot revision")
+			}
+		})
+	}
+}
+
+func TestInsightsSnapshotAuthScopesAndTenantIsolation(t *testing.T) {
+	f := newSnapshotFixture(t)
+	for _, endpoint := range []string{"capabilities", "snapshot"} {
+		for _, token := range []struct {
+			name, secret string
+			want         int
+		}{
+			{"anonymous", "", http.StatusUnauthorized},
+			{"invalid bearer", "not-a-token", http.StatusUnauthorized},
+			{"sync only", f.writer, http.StatusForbidden},
+			{"read-insights only", f.reader, http.StatusOK},
+		} {
+			t.Run(endpoint+"/"+token.name, func(t *testing.T) {
+				var code int
+				var out map[string]any
+				if endpoint == "capabilities" {
+					code, out = get(t, f.ts.URL+"/v1/insights/capabilities", token.secret)
+				} else {
+					code, out = post(t, f.ts.URL+"/v1/insights/snapshot", token.secret, snapshotBody())
+				}
+				if token.want != http.StatusOK {
+					requireSnapshotError(t, code, out, token.want)
+				} else if code != http.StatusOK {
+					t.Errorf("read-insights route: %d %v", code, out)
+				}
+			})
+		}
+	}
+	code, caps := get(t, f.ts.URL+"/v1/insights/capabilities", f.reader)
+	if code != http.StatusOK || caps["version"] != float64(1) || caps["active_ms"] != true ||
+		caps["attribution_version"] != float64(2) || caps["timezone"] != "UTC" ||
+		caps["account_id"] != f.user.ID || caps["all_time"] != true ||
+		caps["max_candidates"] != float64(10_000) || caps["max_calendar_days"] != float64(4000) ||
+		caps["max_local_active_days"] != float64(10_000) ||
+		caps["max_body_bytes"] != float64(config.Default().Ops.MaxBodyBytes) {
+		t.Errorf("capability contract: %d %v", code, caps)
+	}
+	other := store.User{ID: "other-user", Name: "other-reader", Argon2Hash: f.user.Argon2Hash, Timezone: "Europe/Paris", CreatedAt: time.Now()}
+	if err := f.st.CreateUser(t.Context(), other); err != nil {
+		t.Fatal(err)
+	}
+	otherWork := store.Work{ID: "other-work", UserID: other.ID, CreatedAt: time.Now()}
+	if err := f.st.CreateWork(t.Context(), otherWork, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	ses := f.session("other-session")
+	ses.UserID, ses.WorkID = other.ID, otherWork.ID
+	if err := f.st.AppendSessions(t.Context(), other.ID, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	otherToken, _, err := auth.NewService(f.st).MintToken(t.Context(), other.ID, "other phone", store.ScopeSet{store.ScopeReadInsights}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	code, caps = get(t, f.ts.URL+"/v1/insights/capabilities", otherToken)
+	if code != http.StatusOK || caps["timezone"] != "Europe/Paris" || caps["account_id"] != other.ID {
+		t.Errorf("capabilities use token's account timezone: %d %v", code, caps)
+	}
+	for _, compact := range []bool{false, true} {
+		if compact {
+			(&Server{St: f.st}).rollupSessionsOnce(t.Context(), 24*time.Hour)
+		}
+		got := readSnapshot(t, f.ts.URL, f.reader, snapshotBody(ses))
+		if got.AccountID != f.user.ID || !got.Complete || got.Summary.Sessions != 0 ||
+			got.Overlap.Sessions != 0 || len(got.Works) != 0 || len(got.Days) != 0 {
+			t.Errorf("foreign candidate leaked tenant data (compacted=%v): %+v", compact, got)
+		}
+		body := snapshotBody(ses)
+		body["timezone"] = "Europe/Paris"
+		own := readSnapshot(t, f.ts.URL, otherToken, body)
+		if own.AccountID != other.ID || own.Summary.TotalActiveMinutes != 30 || own.Overlap.Minutes != 30 {
+			t.Errorf("other tenant's own reading missing: %+v", own)
+		}
+	}
+}
+
+func TestInsightsSnapshotWindowAndCalendarClipBothAggregates(t *testing.T) {
+	for _, compact := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compacted=%v", compact), func(t *testing.T) {
+			f := newSnapshotFixture(t)
+			loc, err := time.LoadLocation("Europe/Paris")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := f.st.UpdateUserSettings(t.Context(), f.user.ID, "Europe/Paris", false, false); err != nil {
+				t.Fatal(err)
+			}
+			midnight := time.Date(2024, 1, 2, 0, 0, 0, 0, loc)
+			before, cross, zero, next := f.session("before"), f.session("cross"), f.session("zero"), f.session("next")
+			before.StartedAt, before.EndedAt = midnight.Add(-time.Hour), midnight.Add(-time.Minute)
+			cross.StartedAt, cross.EndedAt = midnight.Add(-10*time.Minute), midnight
+			zero.StartedAt, zero.EndedAt = midnight, midnight
+			z := int64(0)
+			zero.ActiveMs = &z
+			next.StartedAt, next.EndedAt = midnight.AddDate(0, 0, 1).Add(-time.Minute), midnight.AddDate(0, 0, 1)
+			sessions := []store.Session{before, cross, zero, next}
+			if err := f.st.AppendSessions(t.Context(), f.user.ID, sessions); err != nil {
+				t.Fatal(err)
+			}
+			if compact {
+				(&Server{St: f.st}).rollupSessionsOnce(t.Context(), 24*time.Hour)
+			}
+			body := snapshotBody(sessions...)
+			delete(body, "range")
+			body["timezone"], body["from"], body["to"] = "Europe/Paris", "2024-01-02", "2024-01-02"
+			body["calendar_from"], body["calendar_to"] = "2024-01-02", "2024-01-02"
+			got := readSnapshot(t, f.ts.URL, f.reader, body)
+			if !got.Complete || got.Summary.TotalActiveMinutes != 30 || got.Overlap.Minutes != 30 ||
+				got.Summary.Sessions != 2 || got.Overlap.Sessions != 2 {
+				t.Errorf("end-day range clipped duration or lost zero-duration sitting: %+v", got)
+			}
+			want := []insights.Day{{Date: "2024-01-02", Minutes: 30, Sessions: 2}}
+			if !reflect.DeepEqual(got.Days, want) || !reflect.DeepEqual(got.Overlap.Days, want) {
+				t.Errorf("end-day calendars: server=%+v overlap=%+v", got.Days, got.Overlap.Days)
+			}
+		})
+	}
+}
+
+func TestInsightsSnapshotStreakUnionsAllHistoryNotDisplayedDays(t *testing.T) {
+	f := newSnapshotFixture(t)
+	today := time.Now().UTC()
+	today = time.Date(today.Year(), today.Month(), today.Day(), 0, 0, 0, 0, time.UTC)
+	var sessions []store.Session
+	for _, offset := range []int{-4, -3, -1} {
+		ses := f.session(fmt.Sprintf("day%d", offset))
+		ses.StartedAt = today.AddDate(0, 0, offset).Add(time.Hour)
+		ses.EndedAt = ses.StartedAt.Add(10 * time.Minute)
+		sessions = append(sessions, ses)
+	}
+	if err := f.st.AppendSessions(t.Context(), f.user.ID, sessions); err != nil {
+		t.Fatal(err)
+	}
+	body := snapshotBody()
+	body["local_active_days"] = []string{
+		today.Format(insights.DayFormat), today.AddDate(0, 0, -2).Format(insights.DayFormat),
+		today.AddDate(0, 0, -2).Format(insights.DayFormat),
+	}
+	got := readSnapshot(t, f.ts.URL, f.reader, body)
+	if got.CombinedStreakDays != 5 || got.Summary.StreakDays != 1 ||
+		got.Summary.TotalActiveMinutes != 90 || len(got.Days) != 0 {
+		t.Errorf("all-history streak union must not change server totals: %+v", got)
+	}
+	delete(body, "range")
+	body["from"], body["to"] = "2024-01-01", "2024-01-31"
+	got = readSnapshot(t, f.ts.URL, f.reader, body)
+	if got.CombinedStreakDays != 5 || got.Summary.Sessions != 0 || got.Summary.TotalActiveMinutes != 0 {
+		t.Errorf("display range must not truncate combined streak: %+v", got)
+	}
+}
+
+func TestInsightsSnapshotCalendarChunksRetainRevisionIdentity(t *testing.T) {
+	f := newSnapshotFixture(t)
+	first, second := f.session("first"), f.session("second")
+	second.StartedAt = second.StartedAt.AddDate(0, 1, 0)
+	second.EndedAt = second.EndedAt.AddDate(0, 1, 0)
+	if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{first, second}); err != nil {
+		t.Fatal(err)
+	}
+	body := snapshotBody(first, second)
+	january := readSnapshot(t, f.ts.URL, f.reader, body)
+	body["calendar_from"], body["calendar_to"] = "2024-02-01", "2024-02-29"
+	february := readSnapshot(t, f.ts.URL, f.reader, body)
+	if january.Revision != february.Revision || january.AccountID != february.AccountID ||
+		january.SnapshotID != february.SnapshotID || !reflect.DeepEqual(january.Summary, february.Summary) ||
+		!reflect.DeepEqual(january.Works, february.Works) || january.Overlap.Minutes != february.Overlap.Minutes {
+		t.Errorf("calendar chunk changed snapshot identity/totals: January=%+v February=%+v", january, february)
+	}
+	if january.Summary.TotalActiveMinutes != 60 || january.Overlap.Minutes != 60 ||
+		len(january.Days) != 1 || january.Days[0].Date != "2024-01-02" ||
+		len(february.Days) != 1 || february.Days[0].Date != "2024-02-02" ||
+		len(january.Overlap.Days) != 1 || january.Overlap.Days[0].Date != "2024-01-02" ||
+		len(february.Overlap.Days) != 1 || february.Overlap.Days[0].Date != "2024-02-02" {
+		t.Errorf("chunks not independently clipped: January=%+v February=%+v", january, february)
+	}
+	if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{f.session("new-reading")}); err != nil {
+		t.Fatal(err)
+	}
+	changed := readSnapshot(t, f.ts.URL, f.reader, body)
+	if changed.Revision == february.Revision || changed.Summary.TotalActiveMinutes != 90 {
+		t.Errorf("new reading must invalidate assembled chunks: %+v", changed)
+	}
+}
+
+func TestInsightsSnapshotRejectsInvalidEvidenceAndWindows(t *testing.T) {
+	f := newSnapshotFixture(t)
+	for _, tc := range []struct {
+		name string
+		edit func(map[string]any)
+		want int
+	}{
+		{"missing snapshot id", func(b map[string]any) { delete(b, "snapshot_id") }, 400},
+		{"long snapshot id", func(b map[string]any) { b["snapshot_id"] = strings.Repeat("s", 129) }, 400},
+		{"missing timezone", func(b map[string]any) { delete(b, "timezone") }, 409},
+		{"invalid timezone", func(b map[string]any) { b["timezone"] = "Not/A_Timezone" }, 409},
+		{"stale timezone", func(b map[string]any) { b["timezone"] = "Europe/Paris" }, 409},
+		{"missing range", func(b map[string]any) { delete(b, "range") }, 400},
+		{"unknown range", func(b map[string]any) { b["range"] = "everything" }, 400},
+		{"zero days", func(b map[string]any) { b["range"] = "0d" }, 400},
+		{"negative days", func(b map[string]any) { b["range"] = "-1d" }, 400},
+		{"excessive days", func(b map[string]any) { b["range"] = "3661d" }, 400},
+		{"partial from to", func(b map[string]any) { delete(b, "range"); b["from"] = "2024-01-01" }, 400},
+		{"impossible date", func(b map[string]any) {
+			delete(b, "range")
+			b["from"], b["to"] = "2024-02-30", "2024-03-01"
+		}, 400},
+		{"non padded date", func(b map[string]any) {
+			delete(b, "range")
+			b["from"], b["to"] = "2024-1-1", "2024-01-31"
+		}, 400},
+		{"reversed dates", func(b map[string]any) {
+			delete(b, "range")
+			b["from"], b["to"] = "2024-02-01", "2024-01-01"
+		}, 400},
+		{"range and dates", func(b map[string]any) { b["from"], b["to"] = "2024-01-01", "2024-01-31" }, 400},
+		{"bad local day", func(b map[string]any) { b["local_active_days"] = []string{"2024-02-30"} }, 400},
+		{"non padded local day", func(b map[string]any) { b["local_active_days"] = []string{"2024-1-2"} }, 400},
+		{"local day timestamp", func(b map[string]any) { b["local_active_days"] = []string{"2024-01-02T00:00:00Z"} }, 400},
+		{"local day whitespace", func(b map[string]any) { b["local_active_days"] = []string{" 2024-01-02"} }, 400},
+		{"empty local day", func(b map[string]any) { b["local_active_days"] = []string{""} }, 400},
+		{"future local day", func(b map[string]any) {
+			b["local_active_days"] = []string{time.Now().UTC().AddDate(0, 0, 2).Format(insights.DayFormat)}
+		}, 400},
+		{"too many local days", func(b map[string]any) { b["local_active_days"] = make([]string, 10_001) }, 400},
+		{"too many candidates", func(b map[string]any) { b["candidates"] = make([]map[string]any, 10_001) }, 400},
+		{"duplicate candidates", func(b map[string]any) {
+			b["candidates"] = []map[string]any{snapshotCandidate(f.session("same")), snapshotCandidate(f.session("same"))}
+		}, 400},
+		{"partial calendar", func(b map[string]any) { delete(b, "calendar_to") }, 400},
+		{"invalid calendar day", func(b map[string]any) { b["calendar_from"] = "2024-02-30" }, 400},
+		{"reversed calendar", func(b map[string]any) { b["calendar_to"] = "2023-12-31" }, 400},
+		{"excessive calendar", func(b map[string]any) { b["calendar_from"], b["calendar_to"] = "2000-01-01", "2024-01-31" }, 400},
+		{"calendar outside range", func(b map[string]any) {
+			delete(b, "range")
+			b["from"], b["to"] = "2024-01-02", "2024-01-31"
+		}, 400},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := snapshotBody()
+			tc.edit(body)
+			code, out := post(t, f.ts.URL+"/v1/insights/snapshot", f.reader, body)
+			requireSnapshotError(t, code, out, tc.want)
+		})
+	}
+	for _, tc := range []struct {
+		name, field string
+		value       any
+	}{
+		{"missing device", "device_id", nil},
+		{"empty device", "device_id", ""},
+		{"long device", "device_id", strings.Repeat("d", 65)},
+		{"empty session", "session_id", ""},
+		{"long session", "session_id", strings.Repeat("s", 65)},
+		{"empty work", "work_id", ""},
+		{"bad start", "started_at", "yesterday"},
+		{"backwards times", "ended_at", "2024-01-01T00:00:00Z"},
+		{"missing progression", "start_progression", nil},
+		{"out of range progression", "end_progression", 1.01},
+		{"negative progression", "start_progression", -0.1},
+		{"negative idle", "idle_ms", -1},
+		{"excess idle", "idle_ms", 600_001},
+		{"negative active", "active_ms", -1},
+		{"excess active", "active_ms", int64(9007199254740992)},
+		{"fractional active", "active_ms", 0.5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := snapshotCandidate(f.session("invalid"))
+			candidate[tc.field] = tc.value
+			body := snapshotBody()
+			body["candidates"] = []map[string]any{candidate}
+			code, out := post(t, f.ts.URL+"/v1/insights/snapshot", f.reader, body)
+			requireSnapshotError(t, code, out, http.StatusBadRequest)
+		})
+	}
+}
+
+type snapshotReadStore struct {
+	store.Store
+	read func(context.Context, string, []string) (store.StatsSnapshot, error)
+}
+
+func (s *snapshotReadStore) StatisticsSnapshot(ctx context.Context, userID string, ids []string) (store.StatsSnapshot, error) {
+	return s.read(ctx, userID, ids)
+}
+
+func snapshotTestServer(t *testing.T, f *snapshotFixture, st store.Store, maxBody int64) *httptest.Server {
+	t.Helper()
+	cfg := config.Default()
+	cfg.InsecureHTTP = true
+	if maxBody != 0 {
+		cfg.Ops.MaxBodyBytes = maxBody
+	}
+	srv := &Server{St: st, Auth: auth.NewService(f.st), Cfg: cfg}
+	ts := httptest.NewServer(srv.Routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestInsightsSnapshotRejectsMalformedAndOversizedBodies(t *testing.T) {
+	f := newSnapshotFixture(t)
+	ts := snapshotTestServer(t, f, f.st, 1024)
+	valid, err := json.Marshal(snapshotBody())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, body string
+		want       int
+	}{
+		{"empty", "", 400},
+		{"malformed", `{"snapshot_id":`, 400},
+		{"wrong shape", `[]`, 400},
+		{"trailing JSON", string(valid) + `{}`, 400},
+		{"trailing garbage", string(valid) + `garbage`, 400},
+		{"oversized trailing body", string(valid) + strings.Repeat(" ", 2048) + `{}`, 413},
+		{"oversized", `{"snapshot_id":"` + strings.Repeat("x", 2048) + `"}`, 413},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/insights/snapshot", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Authorization", "Bearer "+f.reader)
+			req.Header.Set("Content-Type", "application/json")
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer res.Body.Close()
+			var out map[string]any
+			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+				t.Fatal(err)
+			}
+			requireSnapshotError(t, res.StatusCode, out, tc.want)
+		})
+	}
+}
+
+func TestInsightsSnapshotUsesOneCoherentReadAndExactRevision(t *testing.T) {
+	f := newSnapshotFixture(t)
+	ses := f.session("coherent")
+	sha, pageCount := "snapshot-edition", int64(200)
+	ses.EditionSHA = &sha
+	snap := store.StatsSnapshot{
+		Timezone: "UTC", Revision: 9007199254740993,
+		Works: []store.Work{f.work}, Sessions: []store.Session{ses},
+		Editions: map[string]store.Edition{sha: {PageCount: &pageCount}},
+	}
+	var calls atomic.Int32
+	st := &snapshotReadStore{
+		Store: f.st,
+		read: func(_ context.Context, userID string, ids []string) (store.StatsSnapshot, error) {
+			calls.Add(1)
+			if userID != f.user.ID || !reflect.DeepEqual(ids, []string{ses.SessionID}) {
+				t.Errorf("snapshot evidence read under wrong account or IDs: %q %v", userID, ids)
+			}
+			return snap, nil
+		},
+	}
+	ts := snapshotTestServer(t, f, st, 0)
+	got := readSnapshot(t, ts.URL, f.reader, snapshotBody(ses))
+	if calls.Load() != 1 || got.Revision != "9007199254740993" || got.Summary.TotalActiveMinutes != 30 ||
+		got.Overlap.Minutes != 30 || !got.Complete {
+		t.Errorf("one snapshot must supply totals, evidence and lossless revision: calls=%d reply=%+v", calls.Load(), got)
+	}
+	snapshotNear(t, "pages from coherent edition metadata", got.Summary.TotalPages, 20)
+	if len(got.Works) != 1 || got.Works[0].TotalPages != 20 ||
+		len(got.Overlap.Works) != 1 || got.Overlap.Works[0].TotalPages != 20 ||
+		len(got.Days) != 1 || got.Days[0].Pages != 20 ||
+		len(got.Overlap.Days) != 1 || got.Overlap.Days[0].Pages != 20 {
+		t.Errorf("pages must use the same snapshot in every dimension: %+v", got)
+	}
+}
+
+func TestInsightsSnapshotCoherentFailuresNeverBecomePartialSuccess(t *testing.T) {
+	f := newSnapshotFixture(t)
+	for _, tc := range []struct {
+		name string
+		edit func(*store.StatsSnapshot) error
+	}{
+		{"snapshot read failure", func(*store.StatsSnapshot) error { return errors.New("injected snapshot failure") }},
+		{"invalid account timezone", func(s *store.StatsSnapshot) error { s.Timezone = "Not/A_Timezone"; return nil }},
+		{"missing edition metadata", func(s *store.StatsSnapshot) error {
+			sha := "missing"
+			s.Sessions[0].EditionSHA = &sha
+			return nil
+		}},
+		{"corrupt rollup day", func(s *store.StatsSnapshot) error {
+			s.Rollups = []store.SessionRollup{{WorkID: f.work.ID, Day: "2024-02-30"}}
+			return nil
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := store.StatsSnapshot{
+				Timezone: "UTC", Revision: 17, Works: []store.Work{f.work},
+				Sessions: []store.Session{f.session("incoherent")},
+			}
+			failure := tc.edit(&snap)
+			st := &snapshotReadStore{Store: f.st, read: func(context.Context, string, []string) (store.StatsSnapshot, error) {
+				return snap, failure
+			}}
+			ts := snapshotTestServer(t, f, st, 0)
+			code, out := post(t, ts.URL+"/v1/insights/snapshot", f.reader, snapshotBody())
+			requireSnapshotError(t, code, out, http.StatusInternalServerError)
+		})
+	}
+}
+
+func TestInsightsSnapshotMismatchedArchivedProofCannotCertifyOverlap(t *testing.T) {
+	f := newSnapshotFixture(t)
+	ses := f.session("archived")
+	for _, tc := range []struct {
+		name string
+		edit func(*store.ArchivedSession)
+	}{
+		{"payload", func(p *store.ArchivedSession) { p.Fingerprint = "different" }},
+		{"legacy proof", func(p *store.ArchivedSession) { p.AttributionVersion = 0 }},
+		{"timezone", func(p *store.ArchivedSession) { p.Timezone = "Europe/Paris" }},
+		{"missing work", func(p *store.ArchivedSession) { p.WorkID = "gone" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			proof := store.ArchivedSession{
+				Fingerprint: store.SessionFingerprint(ses), WorkID: f.work.ID, Day: "2024-01-02",
+				Timezone: "UTC", AttributionVersion: 2, Present: true, ActiveSeconds: 1800,
+			}
+			tc.edit(&proof)
+			st := &snapshotReadStore{Store: f.st, read: func(context.Context, string, []string) (store.StatsSnapshot, error) {
+				return store.StatsSnapshot{
+					Timezone: "UTC", Revision: 11, Works: []store.Work{f.work},
+					Rollups: []store.SessionRollup{{
+						WorkID: f.work.ID, Day: "2024-01-02", Timezone: "UTC",
+						AttributionVersion: 2, ActiveSeconds: 1800, SessionCount: 1,
+					}},
+					Archived: map[string]store.ArchivedSession{ses.SessionID: proof},
+				}, nil
+			}}
+			ts := snapshotTestServer(t, f, st, 0)
+			got := readSnapshot(t, ts.URL, f.reader, snapshotBody(ses))
+			if got.Complete || got.IncompleteReason == "" || got.Overlap.Minutes != 0 ||
+				got.Overlap.Sessions != 0 || got.Summary.TotalActiveMinutes != 30 {
+				t.Errorf("unverifiable archived contribution must fall back: %+v", got)
+			}
+		})
+	}
+}
+
+func TestInsightsSnapshotRawEvidenceRequiresOriginalDeviceAndFullPayload(t *testing.T) {
+	f := newSnapshotFixture(t)
+	ses := f.session("original")
+	if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name, field string
+		value       any
+	}{
+		{"device", "device_id", "replacement-phone"},
+		{"work", "work_id", "another-work"},
+		{"edition", "edition_sha", "another-edition"},
+		{"start", "started_at", ses.StartedAt.Add(-time.Minute).Format(time.RFC3339Nano)},
+		{"end", "ended_at", ses.EndedAt.Add(time.Minute).Format(time.RFC3339Nano)},
+		{"start progression", "start_progression", 0.05},
+		{"end progression", "end_progression", 0.25},
+		{"idle", "idle_ms", 1},
+		{"absent active", "active_ms", nil},
+		{"zero active", "active_ms", 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := snapshotBody(ses)
+			body["candidates"].([]map[string]any)[0][tc.field] = tc.value
+			got := readSnapshot(t, f.ts.URL, f.reader, body)
+			if got.Complete || got.IncompleteReason == "" || got.Overlap.Minutes != 0 ||
+				got.Overlap.Sessions != 0 || got.Summary.TotalActiveMinutes != 30 ||
+				got.Summary.Sessions != 1 {
+				t.Errorf("partial evidence was trusted or changed server totals: %+v", got)
+			}
+		})
+	}
+}
+
+func TestInsightsSnapshotEmptyAndCalendarLimitBoundaries(t *testing.T) {
+	f := newSnapshotFixture(t)
+	body := snapshotBody()
+	delete(body, "calendar_from")
+	delete(body, "calendar_to")
+	code, out := post(t, f.ts.URL+"/v1/insights/snapshot", f.reader, body)
+	if code != http.StatusOK || out["calendar_from"] != out["today"] || out["calendar_to"] != out["today"] ||
+		out["first_activity_day"] != nil {
+		t.Fatalf("empty snapshot's optional calendar: %d %v", code, out)
+	}
+	got := readSnapshot(t, f.ts.URL, f.reader, body)
+	if !got.Complete || got.Summary.Sessions != 0 || got.Overlap.Sessions != 0 ||
+		got.Works == nil || got.Days == nil || got.Overlap.Works == nil || got.Overlap.Days == nil {
+		t.Errorf("empty successful snapshot must carry empty arrays: %+v", got)
+	}
+	start := time.Date(2010, 1, 1, 0, 0, 0, 0, time.UTC)
+	body["calendar_from"] = start.Format(insights.DayFormat)
+	body["calendar_to"] = start.AddDate(0, 0, 3999).Format(insights.DayFormat)
+	readSnapshot(t, f.ts.URL, f.reader, body)
+	body["calendar_to"] = start.AddDate(0, 0, 4000).Format(insights.DayFormat)
+	code, out = post(t, f.ts.URL+"/v1/insights/snapshot", f.reader, body)
+	requireSnapshotError(t, code, out, http.StatusBadRequest)
+}
+
+type capabilitiesReadStore struct {
+	store.Store
+	user store.User
+	err  error
+}
+
+func (s *capabilitiesReadStore) UserByID(context.Context, string) (store.User, error) {
+	return s.user, s.err
+}
+
+func TestInsightsSnapshotCapabilitiesReadFailuresAreExplicit(t *testing.T) {
+	f := newSnapshotFixture(t)
+	for _, tc := range []struct {
+		name string
+		user store.User
+		err  error
+	}{
+		{"account unavailable", store.User{}, errors.New("injected account read failure")},
+		{"invalid account timezone", store.User{Timezone: "Not/A_Timezone"}, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			st := &capabilitiesReadStore{Store: f.st, user: tc.user, err: tc.err}
+			ts := snapshotTestServer(t, f, st, 0)
+			code, out := get(t, ts.URL+"/v1/insights/capabilities", f.reader)
+			requireSnapshotError(t, code, out, http.StatusInternalServerError)
+			if _, ok := out["active_ms"]; ok {
+				t.Errorf("failed account read advertised capabilities: %v", out)
+			}
+		})
+	}
+}
+
+func TestInsightsSnapshotCapabilitiesAdvertiseConfiguredBodyLimit(t *testing.T) {
+	f := newSnapshotFixture(t)
+	ts := snapshotTestServer(t, f, f.st, 1024)
+	code, caps := get(t, ts.URL+"/v1/insights/capabilities", f.reader)
+	if code != http.StatusOK || caps["max_body_bytes"] != float64(1024) {
+		t.Fatalf("capabilities must advertise the enforced configuration: %d %v", code, caps)
+	}
+}
+
+func TestInsightsSnapshotTokenAdvertisesMeasuredSessionsWithoutInsightsScope(t *testing.T) {
+	f := newSnapshotFixture(t)
+	for _, tc := range []struct {
+		name, token string
+		scope       store.Scope
+	}{
+		{"sync only", f.writer, store.ScopeSync},
+		{"read-insights only", f.reader, store.ScopeReadInsights},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			code, out := get(t, f.ts.URL+"/v1/token", tc.token)
+			if code != http.StatusOK || out["session_active_ms"] != true || out["account_id"] != f.user.ID {
+				t.Fatalf("token must advertise measured-session support as a boolean: %d %v", code, out)
+			}
+			if !reflect.DeepEqual(out["scopes"], []any{string(tc.scope)}) {
+				t.Errorf("advertising a wire capability must not expand token scopes: %v", out)
+			}
+		})
+	}
+	ses := f.session("browser-measured")
+	code, out := post(t, f.ts.URL+"/v1/sessions", f.writer,
+		map[string]any{"sessions": []map[string]any{snapshotCandidate(ses)}})
+	if code != http.StatusOK {
+		t.Fatalf("sync-only client cannot use advertised active_ms support: %d %v", code, out)
+	}
+	got := readSnapshot(t, f.ts.URL, f.reader, snapshotBody(ses))
+	if !got.Complete || got.Summary.TotalActiveMinutes != 30 || got.Overlap.Minutes != 30 {
+		t.Errorf("advertised measured session was not preserved: %+v", got)
+	}
+}
+
+func TestInsightsSnapshotWireFixture(t *testing.T) {
+	f := newSnapshotFixture(t)
+	ses := f.session("wire-measured-30-minutes")
+	ses.EndedAt = time.Now().UTC().Truncate(time.Second)
+	ses.StartedAt = ses.EndedAt.Add(-10 * time.Minute)
+	today := ses.EndedAt.Format(insights.DayFormat)
+	code, out := post(t, f.ts.URL+"/v1/sessions", f.writer,
+		map[string]any{"sessions": []map[string]any{snapshotCandidate(ses)}})
+	if code != http.StatusOK {
+		t.Fatalf("upload wire fixture session: %d %v", code, out)
+	}
+	body := snapshotBody(ses)
+	body["calendar_from"], body["calendar_to"] = today, today
+	request, err := json.MarshalIndent(body, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	capture := func(method, path string, body []byte) []byte {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), method, f.ts.URL+path, bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Authorization", "Bearer "+f.reader)
+		if body != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer res.Body.Close()
+		raw, err := io.ReadAll(res.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.StatusCode != http.StatusOK {
+			t.Fatalf("%s %s: HTTP %d: %s", method, path, res.StatusCode, raw)
+		}
+		return raw
+	}
+	capabilities := capture(http.MethodGet, "/v1/insights/capabilities", nil)
+	response := capture(http.MethodPost, "/v1/insights/snapshot", request)
+	var caps map[string]any
+	if err := json.Unmarshal(capabilities, &caps); err != nil {
+		t.Fatal(err)
+	}
+	var got snapshotReply
+	if err := json.Unmarshal(response, &got); err != nil {
+		t.Fatal(err)
+	}
+	if caps["active_ms"] != true || caps["account_id"] != got.AccountID || caps["timezone"] != got.Timezone ||
+		got.AccountID != f.user.ID || got.SnapshotID != "local-generation-7" || !got.Complete ||
+		got.Summary.TotalActiveMinutes != 30 || got.Summary.Sessions != 1 ||
+		got.Overlap.Minutes != 30 || got.Overlap.Sessions != 1 ||
+		len(got.Works) != 1 || got.Works[0].TotalActiveMinutes != 30 ||
+		len(got.Overlap.Works) != 1 || got.Overlap.Works[0].TotalActiveMinutes != 30 ||
+		len(got.Days) != 1 || got.Days[0].Minutes != 30 || got.Days[0].Date != today ||
+		len(got.Overlap.Days) != 1 || got.Overlap.Days[0].Minutes != 30 || got.Overlap.Days[0].Date != today {
+		t.Fatalf("wire fixture must represent one exact measured overlap: capabilities=%s response=%s", capabilities, response)
+	}
+	// Opt-in artifacts carry the exact HTTP bodies for downstream client
+	// parser tests, not a hand-written approximation of the Go wire format.
+	if dir := os.Getenv("LISEUR_STATS_WIRE_DIR"); dir != "" {
+		for _, artifact := range []struct {
+			name string
+			body []byte
+		}{
+			{"stats-wire-capabilities.json", capabilities},
+			{"stats-wire-request.json", request},
+			{"stats-wire-response.json", response},
+		} {
+			path := filepath.Join(dir, artifact.name)
+			if err := os.WriteFile(path, artifact.body, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("wrote actual wire fixture: %s", path)
+		}
+	}
+}

--- a/internal/api/materializer.go
+++ b/internal/api/materializer.go
@@ -124,15 +124,6 @@ func (s *Server) rollupSessionsOnce(ctx context.Context, retention time.Duration
 	}
 	cutoff := time.Now().Add(-retention)
 	for _, userID := range users {
-		u, err := s.St.UserByID(ctx, userID)
-		if err != nil {
-			slog.Warn("session rollup: user", "user", userID, "err", err)
-			continue
-		}
-		loc, err := time.LoadLocation(u.Timezone)
-		if err != nil {
-			loc = time.UTC
-		}
 		sessions, err := s.St.SessionsEndedBefore(ctx, userID, cutoff)
 		if err != nil {
 			slog.Warn("session rollup: sessions", "user", userID, "err", err)
@@ -141,38 +132,59 @@ func (s *Server) rollupSessionsOnce(ctx context.Context, retention time.Duration
 		if len(sessions) == 0 {
 			continue
 		}
+		ids := make([]string, 0, len(sessions))
+		var aggregateErr error
+		for _, ses := range sessions {
+			ids = append(ids, ses.SessionID)
+		}
+		snap, err := s.St.StatisticsSnapshot(ctx, userID, ids)
+		if err != nil {
+			slog.Warn("session rollup: snapshot", "user", userID, "err", err)
+			continue
+		}
+		timezone := snap.Timezone
+		loc, err := time.LoadLocation(timezone)
+		if err != nil {
+			slog.Warn("session rollup: timezone", "user", userID, "err", err)
+			continue
+		}
 
 		type key struct{ workID, day string }
 		byDay := make(map[key]*store.SessionRollup)
 		for _, ses := range sessions {
-			parts := s.splitDaysFull(ctx, ses, loc)
-			activeTotal := insights.ActiveSeconds(ses)
-			progDelta := ses.EndProg - ses.StartProg
-			if progDelta < 0 {
-				progDelta = 0
+			day := ses.EndedAt.In(loc).Format(insights.DayFormat)
+			k := key{ses.WorkID, day}
+			ru := byDay[k]
+			if ru == nil {
+				ru = &store.SessionRollup{
+					UserID:             userID,
+					WorkID:             ses.WorkID,
+					Day:                day,
+					Timezone:           timezone,
+					AttributionVersion: 2,
+				}
+				byDay[k] = ru
 			}
-			for i, part := range parts {
-				k := key{ses.WorkID, part.date}
-				ru := byDay[k]
-				if ru == nil {
-					ru = &store.SessionRollup{
-						UserID: userID,
-						WorkID: ses.WorkID,
-						Day:    part.date,
-					}
-					byDay[k] = ru
-				}
-				ru.ActiveSeconds += part.activeSec
-				ru.Pages += part.pages
-				if activeTotal > 0 {
-					ru.ProgDelta += progDelta * part.activeSec / activeTotal
-				} else if i == 0 {
-					ru.ProgDelta += progDelta
-				}
-				if i == 0 {
-					ru.SessionCount++
-				}
+
+			active := insights.ActiveSeconds(ses)
+			progDelta := positiveProgDelta(ses)
+			pages, err := insights.Pages(ses, snap.Editions)
+			if err != nil {
+				aggregateErr = err
+				break
 			}
+			ru.ActiveSeconds += active
+			ru.Pages += pages
+			ru.ProgDelta += progDelta
+			ru.SessionCount++
+			if ses.Origin != store.OriginInferred {
+				ru.MeasuredActiveSeconds += active
+				ru.MeasuredProgDelta += progDelta
+			}
+		}
+		if aggregateErr != nil {
+			slog.Warn("session rollup: aggregate", "user", userID, "err", aggregateErr)
+			continue
 		}
 		rollups := make([]store.SessionRollup, 0, len(byDay))
 		for _, ru := range byDay {
@@ -182,4 +194,12 @@ func (s *Server) rollupSessionsOnce(ctx context.Context, retention time.Duration
 			slog.Warn("session rollup", "user", userID, "err", err)
 		}
 	}
+}
+
+func positiveProgDelta(ses store.Session) float64 {
+	delta := ses.EndProg - ses.StartProg
+	if delta < 0 {
+		return 0
+	}
+	return delta
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -185,15 +185,17 @@ func (s *Server) HandleToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, struct {
-		ID        string         `json:"id"`
-		AccountID string         `json:"account_id"`
-		DeviceID  string         `json:"device_id"`
-		Name      string         `json:"name"`
-		Scope     *store.Scope   `json:"scope,omitempty"`
-		Scopes    store.ScopeSet `json:"scopes"`
+		ID              string         `json:"id"`
+		AccountID       string         `json:"account_id"`
+		SessionActiveMs bool           `json:"session_active_ms"`
+		DeviceID        string         `json:"device_id"`
+		Name            string         `json:"name"`
+		Scope           *store.Scope   `json:"scope,omitempty"`
+		Scopes          store.ScopeSet `json:"scopes"`
 	}{
 		ID: tok.ID, AccountID: tok.UserID, DeviceID: tok.DeviceID, Name: tok.Name,
-		Scope: legacyScope(tok.Scopes), Scopes: tok.Scopes,
+		SessionActiveMs: true,
+		Scope:           legacyScope(tok.Scopes), Scopes: tok.Scopes,
 	})
 }
 
@@ -371,6 +373,8 @@ func (s *Server) Routes() *http.ServeMux {
 	mux.Handle("GET /v1/insights/works", insH(s.HandleInsightsWorks))
 	mux.Handle("GET /v1/insights/works/{id}", insH(s.HandleInsightsWork))
 	mux.Handle("GET /v1/insights/calendar", insH(s.HandleInsightsCalendar))
+	mux.Handle("GET /v1/insights/capabilities", insH(s.HandleInsightsCapabilities))
+	mux.Handle("POST /v1/insights/snapshot", insH(s.HandleInsightsSnapshot))
 
 	// library-read scope: the catalog. Folder grants select the shared
 	// catalog rows this account may see (ADR-0027), while reading state

--- a/internal/api/sessions.go
+++ b/internal/api/sessions.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"errors"
+	"math"
 	"net/http"
 	"time"
 
@@ -22,6 +24,77 @@ type sessionReqJSON struct {
 	StartProg  *float64 `json:"start_progression"`
 	EndProg    *float64 `json:"end_progression"`
 	IdleMs     int64    `json:"idle_ms"`
+	ActiveMs   *int64   `json:"active_ms"`
+}
+
+// MaxSessionActiveMs is the largest explicit active_ms the native
+// sessions endpoint accepts. It is the largest JavaScript-safe integer,
+// comfortably below int64's bound and therefore safe for downstream
+// millisecond-to-second conversions.
+const MaxSessionActiveMs int64 = 9007199254740991
+
+const errCodeActiveOutOfRange = "active_out_of_range"
+
+type sessionRequestError struct {
+	code      string
+	what      string
+	sessionID string
+}
+
+func (e sessionRequestError) Error() string { return e.what }
+
+func parseSessionRequest(in sessionReqJSON, deviceID string) (store.Session, error) {
+	refuse := func(code, what string) (store.Session, error) {
+		return store.Session{}, sessionRequestError{code: code, what: what, sessionID: in.SessionID}
+	}
+	if in.SessionID == "" || len(in.SessionID) > 64 {
+		return store.Session{}, sessionRequestError{
+			code: errCodeMissingField, what: "session_id required",
+		}
+	}
+	if in.WorkID == "" {
+		return refuse(errCodeMissingField, "work_id required")
+	}
+	started, err := time.Parse(time.RFC3339Nano, in.StartedAt)
+	if err != nil {
+		return refuse(errCodeBadTime, "bad started_at")
+	}
+	ended, err := time.Parse(time.RFC3339Nano, in.EndedAt)
+	if err != nil {
+		return refuse(errCodeBadTime, "bad ended_at")
+	}
+	if ended.Before(started) {
+		return refuse(errCodeBadTime, "ended_at before started_at")
+	}
+	if in.StartProg == nil || in.EndProg == nil {
+		return refuse(errCodeMissingField, "progression required")
+	}
+	sp, ep := *in.StartProg, *in.EndProg
+	if math.IsNaN(sp) || math.IsInf(sp, 0) ||
+		math.IsNaN(ep) || math.IsInf(ep, 0) ||
+		!(sp >= 0 && sp <= 1) || !(ep >= 0 && ep <= 1) {
+		return refuse(errCodeProgression, "progression out of range [0,1]")
+	}
+	durMs := ended.Sub(started).Milliseconds()
+	if in.IdleMs < 0 || in.IdleMs > durMs {
+		return refuse(errCodeIdleOutOfRange, "idle_ms out of range")
+	}
+	if in.ActiveMs != nil && (*in.ActiveMs < 0 || *in.ActiveMs > MaxSessionActiveMs) {
+		return refuse(errCodeActiveOutOfRange, "active_ms out of range")
+	}
+	return store.Session{
+		SessionID:  in.SessionID,
+		WorkID:     in.WorkID,
+		EditionSHA: in.EditionSHA,
+		DeviceID:   deviceID,
+		StartedAt:  started,
+		EndedAt:    ended,
+		StartProg:  sp,
+		EndProg:    ep,
+		IdleMs:     in.IdleMs,
+		ActiveMs:   in.ActiveMs,
+		Origin:     store.OriginNative,
+	}, nil
 }
 
 // HandlePushSessions implements POST /v1/sessions — batch, idempotent
@@ -49,60 +122,18 @@ func (s *Server) HandlePushSessions(w http.ResponseWriter, r *http.Request) {
 
 	sessions := make([]store.Session, len(body.Sessions))
 	for i, in := range body.Sessions {
-		refuse := func(code, what string) {
-			writeItemRefusal(w, code, "session", "session_id", in.SessionID, i, what, 0)
-		}
-		if in.SessionID == "" || len(in.SessionID) > 64 {
-			in.SessionID = ""
-			refuse(errCodeMissingField, "session_id required")
-			return
-		}
-		if in.WorkID == "" {
-			refuse(errCodeMissingField, "work_id required")
-			return
-		}
-		started, err := time.Parse(time.RFC3339Nano, in.StartedAt)
+		ses, err := parseSessionRequest(in, tok.DeviceID)
 		if err != nil {
-			refuse(errCodeBadTime, "bad started_at")
+			var reqErr sessionRequestError
+			if errors.As(err, &reqErr) {
+				writeItemRefusal(w, reqErr.code, "session", "session_id",
+					reqErr.sessionID, i, reqErr.what, 0)
+				return
+			}
+			writeError(w, http.StatusInternalServerError, "append failed")
 			return
 		}
-		ended, err := time.Parse(time.RFC3339Nano, in.EndedAt)
-		if err != nil {
-			refuse(errCodeBadTime, "bad ended_at")
-			return
-		}
-		if ended.Before(started) {
-			refuse(errCodeBadTime, "ended_at before started_at")
-			return
-		}
-		if in.StartProg == nil || in.EndProg == nil {
-			refuse(errCodeMissingField, "progression required")
-			return
-		}
-		// Negation of the in-range test so a NaN (both comparisons
-		// false) is rejected rather than let through.
-		sp, ep := *in.StartProg, *in.EndProg
-		if !(sp >= 0 && sp <= 1) || !(ep >= 0 && ep <= 1) {
-			refuse(errCodeProgression, "progression out of range [0,1]")
-			return
-		}
-		durMs := ended.Sub(started).Milliseconds()
-		if in.IdleMs < 0 || in.IdleMs > durMs {
-			refuse(errCodeIdleOutOfRange, "idle_ms out of range")
-			return
-		}
-		sessions[i] = store.Session{
-			SessionID:  in.SessionID,
-			WorkID:     in.WorkID,
-			EditionSHA: in.EditionSHA,
-			DeviceID:   tok.DeviceID,
-			StartedAt:  started,
-			EndedAt:    ended,
-			StartProg:  sp,
-			EndProg:    ep,
-			IdleMs:     in.IdleMs,
-			Origin:     store.OriginNative,
-		}
+		sessions[i] = ses
 	}
 
 	if err := s.St.AppendSessions(r.Context(), tok.UserID, sessions); err != nil {

--- a/internal/api/stats_ingestion_test.go
+++ b/internal/api/stats_ingestion_test.go
@@ -1,0 +1,157 @@
+package api
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/insights"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func TestNativeSessionActiveMsOptionalZeroAndBounded(t *testing.T) {
+	ts, st := testServer(t)
+	ctx := t.Context()
+	hash, _ := auth.HashPassword("hunter2hunter")
+	u := store.User{ID: "u1", Name: "alice", Argon2Hash: hash, Timezone: "UTC", CreatedAt: time.Now()}
+	if err := st.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	secret, _, err := auth.NewService(st).MintToken(ctx, u.ID, "phone", store.ScopeSet{store.ScopeSync}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := store.Work{ID: "w1", UserID: u.ID, CreatedAt: time.Now()}
+	if err := st.CreateWork(ctx, w, nil, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	session := func(id string, active any) map[string]any {
+		m := map[string]any{
+			"session_id": id, "work_id": w.ID,
+			"started_at":        start.Format(time.RFC3339Nano),
+			"ended_at":          start.Add(time.Minute).Format(time.RFC3339Nano),
+			"start_progression": 0.1, "end_progression": 0.2,
+		}
+		if active != nil {
+			m["active_ms"] = active
+		}
+		return m
+	}
+	code, out := post(t, ts.URL+"/v1/sessions", secret, map[string]any{"sessions": []map[string]any{
+		session("absent", nil), session("zero", 0),
+	}})
+	if code != 200 {
+		t.Fatalf("push: %d %v", code, out)
+	}
+	got, err := st.SessionsForWork(ctx, u.ID, w.ID, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[string]store.Session{}
+	for _, ses := range got {
+		byID[ses.SessionID] = ses
+	}
+	if byID["absent"].ActiveMs != nil {
+		t.Fatalf("absent active_ms became present: %+v", byID["absent"].ActiveMs)
+	}
+	if byID["zero"].ActiveMs == nil || *byID["zero"].ActiveMs != 0 {
+		t.Fatalf("zero active_ms not preserved: %+v", byID["zero"].ActiveMs)
+	}
+
+	if code, out := post(t, ts.URL+"/v1/sessions", secret, map[string]any{"sessions": []map[string]any{
+		session("too-active", MaxSessionActiveMs+1),
+	}}); code != 400 || out["code"] != errCodeActiveOutOfRange || out["session_id"] != "too-active" {
+		t.Fatalf("active_ms bound: %d %v", code, out)
+	}
+}
+
+func TestParseSessionRequestRejectsPositiveNonfiniteProgression(t *testing.T) {
+	start := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	sp, ep := 0.1, math.Inf(1)
+	_, err := parseSessionRequest(sessionReqJSON{
+		SessionID: "s-inf", WorkID: "w1",
+		StartedAt: start.Format(time.RFC3339Nano), EndedAt: start.Add(time.Minute).Format(time.RFC3339Nano),
+		StartProg: &sp, EndProg: &ep,
+	}, "device")
+	if reqErr, ok := err.(sessionRequestError); !ok || reqErr.code != errCodeProgression {
+		t.Fatalf("want progression refusal, got %#v", err)
+	}
+}
+
+func TestMaterializerUsesExplicitActiveAndEndDayV2Archive(t *testing.T) {
+	_, st := testServer(t)
+	ctx := t.Context()
+	u := store.User{ID: "rollup-active", Name: "reader", Argon2Hash: "x", Timezone: "Europe/Paris", CreatedAt: time.Now()}
+	if err := st.CreateUser(ctx, u); err != nil {
+		t.Fatal(err)
+	}
+	w := store.Work{ID: "w-active", UserID: u.ID, CreatedAt: time.Now()}
+	ed := &store.Edition{UserID: u.ID, SHA256: "ed-active", WorkID: w.ID, PageCount: ptrI64(100)}
+	if err := st.CreateWork(ctx, w, ed, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	paris, err := time.LoadLocation("Europe/Paris")
+	if err != nil {
+		t.Fatal(err)
+	}
+	active := int64(2 * time.Hour / time.Millisecond)
+	zero := int64(0)
+	crossStart := time.Date(2024, 1, 1, 23, 50, 0, 0, paris)
+	zeroAt := time.Date(2024, 1, 2, 1, 0, 0, 0, paris)
+	sessions := []store.Session{
+		{
+			SessionID: "measured-cross", WorkID: w.ID, EditionSHA: &ed.SHA256, DeviceID: "phone",
+			StartedAt: crossStart, EndedAt: crossStart.Add(20 * time.Minute),
+			StartProg: 0.1, EndProg: 0.2, ActiveMs: &active, Origin: store.OriginNative,
+		},
+		{
+			SessionID: "zero-wall", WorkID: w.ID, EditionSHA: &ed.SHA256, DeviceID: "phone",
+			StartedAt: zeroAt, EndedAt: zeroAt,
+			StartProg: 0.2, EndProg: 0.3, ActiveMs: &zero, Origin: store.OriginNative,
+		},
+	}
+	if err := st.AppendSessions(ctx, u.ID, sessions); err != nil {
+		t.Fatal(err)
+	}
+
+	(&Server{St: st}).rollupSessionsOnce(ctx, 24*time.Hour)
+	rollups, err := st.RollupsForWork(ctx, u.ID, w.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rollups) != 1 {
+		t.Fatalf("want one end-day rollup, got %+v", rollups)
+	}
+	ru := rollups[0]
+	if ru.Day != "2024-01-02" || ru.Timezone != "Europe/Paris" || ru.AttributionVersion != 2 {
+		t.Fatalf("wrong v2 end day: %+v", ru)
+	}
+	if ru.SessionCount != 2 || ru.ActiveSeconds != 7200 || ru.MeasuredActiveSeconds != 7200 {
+		t.Fatalf("wrong active/count: %+v", ru)
+	}
+	if math.Abs(ru.ProgDelta-0.2) > 0.000001 || math.Abs(ru.MeasuredProgDelta-0.2) > 0.000001 {
+		t.Fatalf("wrong measured progression: %+v", ru)
+	}
+	if math.Abs(ru.Pages-20) > 0.000001 {
+		t.Fatalf("wrong pages: %+v", ru)
+	}
+
+	snap, err := st.StatisticsSnapshot(ctx, u.ID, []string{"zero-wall", "measured-cross"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch, ok := snap.Archived["zero-wall"]
+	if !ok || !arch.Present || arch.Day != "2024-01-02" || arch.AttributionVersion != 2 {
+		t.Fatalf("zero-wall archive: %+v present=%v", arch, ok)
+	}
+	if arch.MeasuredActiveSeconds != 0 || math.Abs(arch.MeasuredProgDelta-0.1) > 0.000001 {
+		t.Fatalf("zero-wall measured archive: %+v", arch)
+	}
+	if got := insights.ActiveSeconds(sessions[0]); got != 7200 {
+		t.Fatalf("explicit active should exceed wall without cap, got %v", got)
+	}
+}

--- a/internal/api/token_scope_test.go
+++ b/internal/api/token_scope_test.go
@@ -169,10 +169,12 @@ var registeredRouteGates = map[string]routeGate{
 	"DELETE /v1/annotations/{id}":    gateSync,
 	"GET /v1/works/{id}/annotations": gateSync,
 
-	"GET /v1/insights/summary":    gateInsights,
-	"GET /v1/insights/works":      gateInsights,
-	"GET /v1/insights/works/{id}": gateInsights,
-	"GET /v1/insights/calendar":   gateInsights,
+	"GET /v1/insights/summary":      gateInsights,
+	"GET /v1/insights/works":        gateInsights,
+	"GET /v1/insights/works/{id}":   gateInsights,
+	"GET /v1/insights/calendar":     gateInsights,
+	"GET /v1/insights/capabilities": gateInsights,
+	"POST /v1/insights/snapshot":    gateInsights,
 
 	"GET /v1/folders":                        gateLibraryRead,
 	"GET /v1/folders/{folder}/books":         gateLibraryRead,

--- a/internal/insights/aggregate.go
+++ b/internal/insights/aggregate.go
@@ -1,0 +1,201 @@
+package insights
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+type Summary struct {
+	TotalActiveMinutes float64 `json:"total_active_minutes"`
+	TotalPages         float64 `json:"total_pages"`
+	Sessions           int     `json:"sessions"`
+	StreakDays         int     `json:"streak_days"`
+	SpeedProgPerHour   float64 `json:"speed_prog_per_hour"`
+}
+
+type Work struct {
+	WorkID             string     `json:"work_id"`
+	Title              string     `json:"title,omitempty"`
+	Author             string     `json:"author,omitempty"`
+	Sessions           int        `json:"sessions"`
+	TotalActiveMinutes float64    `json:"total_active_minutes"`
+	TotalPages         float64    `json:"total_pages"`
+	CurrentProgression float64    `json:"current_progression"`
+	ETASeconds         *float64   `json:"eta_seconds"`
+	LastReadAt         *time.Time `json:"last_read_at"`
+}
+
+type Day struct {
+	Date     string  `json:"date"`
+	Minutes  float64 `json:"minutes"`
+	Pages    float64 `json:"pages"`
+	Sessions int     `json:"sessions"`
+}
+
+type Result struct {
+	Summary          Summary
+	Works            []Work
+	ByWork           map[string]Work
+	Days             []Day
+	ActiveDays       map[string]bool
+	FirstActivityDay *string
+	Complete         bool
+	IncompleteReason string
+}
+
+// Pages reads only metadata captured with the sessions. A failed metadata
+// query must not become a zero-page rollup that replaces the original record.
+func Pages(ses store.Session, editions map[string]store.Edition) (float64, error) {
+	if ses.ReportedPages != nil {
+		if *ses.ReportedPages < 0 || math.IsNaN(*ses.ReportedPages) || math.IsInf(*ses.ReportedPages, 0) {
+			return 0, fmt.Errorf("invalid reported pages for session %s", ses.SessionID)
+		}
+		return *ses.ReportedPages, nil
+	}
+	delta := math.Max(0, ses.EndProg-ses.StartProg)
+	if delta == 0 || ses.EditionSHA == nil {
+		return 0, nil
+	}
+	edition, ok := editions[*ses.EditionSHA]
+	if !ok {
+		return 0, fmt.Errorf("missing edition for session %s", ses.SessionID)
+	}
+	if edition.PageCount == nil {
+		return 0, nil
+	}
+	return delta * float64(*edition.PageCount), nil
+}
+
+// Build aggregates one coherent store snapshot without performing further reads.
+// Legacy buckets remain visible, but cannot certify exact cross-device overlap.
+func Build(snap store.StatsSnapshot, win Window, now time.Time) (Result, error) {
+	out := Result{
+		Works: []Work{}, Days: []Day{}, ByWork: make(map[string]Work),
+		ActiveDays: make(map[string]bool), Complete: true,
+	}
+	loc, err := time.LoadLocation(snap.Timezone)
+	if err != nil {
+		return out, err
+	}
+	from, to := win.DayBounds(now, loc)
+	today := now.In(loc).Format(DayFormat)
+	byDay := make(map[string]*Day)
+	type pace struct {
+		seconds, progression float64
+		unknown              bool
+	}
+	paces := make(map[string]pace)
+	for _, w := range snap.Works {
+		out.ByWork[w.ID] = Work{WorkID: w.ID, Title: w.Title, Author: w.Author}
+	}
+	add := func(workID, day string, seconds, pages float64, count int, last time.Time, measuredSeconds, delta float64, legacy bool) {
+		if seconds > 0 && day <= today {
+			out.ActiveDays[day] = true
+			if out.FirstActivityDay == nil || day < *out.FirstActivityDay {
+				date := day
+				out.FirstActivityDay = &date
+			}
+		}
+		if day < from || day > to {
+			return
+		}
+		work := out.ByWork[workID]
+		work.WorkID = workID
+		work.TotalActiveMinutes += seconds / 60
+		work.TotalPages += pages
+		work.Sessions += count
+		if work.LastReadAt == nil || last.After(*work.LastReadAt) {
+			at := last
+			work.LastReadAt = &at
+		}
+		out.ByWork[workID] = work
+		p := paces[workID]
+		p.seconds += measuredSeconds
+		p.progression += delta
+		p.unknown = p.unknown || legacy
+		paces[workID] = p
+		d := byDay[day]
+		if d == nil {
+			d = &Day{Date: day}
+			byDay[day] = d
+		}
+		d.Minutes += seconds / 60
+		d.Pages += pages
+		d.Sessions += count
+	}
+	for _, ses := range snap.Sessions {
+		pages, err := Pages(ses, snap.Editions)
+		if err != nil {
+			return out, err
+		}
+		active := ActiveSeconds(ses)
+		var measured, delta float64
+		if ses.Origin != store.OriginInferred {
+			measured = active
+			delta = math.Max(0, ses.EndProg-ses.StartProg)
+		}
+		add(ses.WorkID, ses.EndedAt.In(loc).Format(DayFormat), active, pages, 1,
+			ses.EndedAt, measured, delta, false)
+	}
+	for _, ru := range snap.Rollups {
+		day, err := time.ParseInLocation(DayFormat, ru.Day, loc)
+		if err != nil {
+			return out, err
+		}
+		if ru.AttributionVersion != 2 || ru.Timezone != snap.Timezone {
+			out.Complete = false
+			out.IncompleteReason = "legacy_or_different_timezone_rollups"
+		}
+		add(ru.WorkID, ru.Day, ru.ActiveSeconds, ru.Pages, int(ru.SessionCount), day,
+			ru.MeasuredActiveSeconds, ru.MeasuredProgDelta, ru.AttributionVersion != 2)
+	}
+	var totalPace pace
+	workIDs := make([]string, 0, len(out.ByWork))
+	for id := range out.ByWork {
+		workIDs = append(workIDs, id)
+	}
+	sort.Strings(workIDs)
+	// Calendar chunks must reproduce the same floating-point totals at one
+	// revision, regardless of Go's map iteration order.
+	for _, id := range workIDs {
+		work := out.ByWork[id]
+		p := paces[id]
+		if position, ok := snap.Positions[id]; ok {
+			work.CurrentProgression = position.Progression
+			if !p.unknown && p.seconds > 0 && p.progression > 0 && position.Progression < 1 {
+				eta := (1 - position.Progression) * p.seconds / p.progression
+				work.ETASeconds = &eta
+			}
+		}
+		out.ByWork[id] = work
+		if work.Sessions == 0 && work.TotalActiveMinutes == 0 && work.TotalPages == 0 {
+			continue
+		}
+		out.Works = append(out.Works, work)
+		out.Summary.TotalActiveMinutes += work.TotalActiveMinutes
+		out.Summary.TotalPages += work.TotalPages
+		out.Summary.Sessions += work.Sessions
+		totalPace.seconds += p.seconds
+		totalPace.progression += p.progression
+		totalPace.unknown = totalPace.unknown || p.unknown
+	}
+	if !totalPace.unknown && totalPace.seconds > 0 {
+		out.Summary.SpeedProgPerHour = totalPace.progression / totalPace.seconds * 3600
+	}
+	out.Summary.StreakDays = StreakDays(out.ActiveDays, loc, now)
+	for _, day := range byDay {
+		out.Days = append(out.Days, *day)
+	}
+	sort.Slice(out.Days, func(i, j int) bool { return out.Days[i].Date < out.Days[j].Date })
+	sort.Slice(out.Works, func(i, j int) bool {
+		if out.Works[i].TotalActiveMinutes == out.Works[j].TotalActiveMinutes {
+			return out.Works[i].WorkID < out.Works[j].WorkID
+		}
+		return out.Works[i].TotalActiveMinutes > out.Works[j].TotalActiveMinutes
+	})
+	return out, nil
+}

--- a/internal/insights/aggregate_regression_test.go
+++ b/internal/insights/aggregate_regression_test.go
@@ -1,0 +1,240 @@
+package insights
+
+import (
+	"math"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func aggregateNear(t *testing.T, label string, got, want float64) {
+	t.Helper()
+	if math.IsNaN(got) || math.IsInf(got, 0) || math.Abs(got-want) > 1e-9 {
+		t.Errorf("%s: got %v, want %v", label, got, want)
+	}
+}
+
+func TestAggregateMeasuredTimeIsNotCappedToWallTime(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+	active, zero, pages := int64(30*60*1000), int64(0), int64(200)
+	sha := "edition"
+	snap := store.StatsSnapshot{
+		Timezone: "UTC",
+		Works: []store.Work{
+			{ID: "measured", Title: "Measured book", Author: "Writer"},
+			{ID: "inferred"}, {ID: "unread"},
+		},
+		Editions:  map[string]store.Edition{sha: {PageCount: &pages}},
+		Positions: map[string]store.Op{"measured": {Progression: 0.5}},
+		Sessions: []store.Session{
+			{
+				SessionID: "measured", WorkID: "measured", EditionSHA: &sha,
+				StartedAt: now.Add(-10 * time.Minute), EndedAt: now,
+				IdleMs: 5 * 60 * 1000, ActiveMs: &active,
+				StartProg: 0.1, EndProg: 0.2, Origin: store.OriginNative,
+			},
+			{
+				SessionID: "zero", WorkID: "measured",
+				StartedAt: now.Add(-time.Hour), EndedAt: now, ActiveMs: &zero,
+				Origin: store.OriginNative,
+			},
+			{
+				SessionID: "inferred", WorkID: "inferred",
+				StartedAt: now.Add(-time.Hour), EndedAt: now,
+				StartProg: 0, EndProg: 0.8, Origin: store.OriginInferred,
+			},
+		},
+	}
+	got, err := Build(snap, Window{}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Complete || got.Summary.Sessions != 3 || len(got.Works) != 2 {
+		t.Fatalf("unexpected aggregate: %+v", got)
+	}
+	aggregateNear(t, "total minutes", got.Summary.TotalActiveMinutes, 90)
+	aggregateNear(t, "pages", got.Summary.TotalPages, 20)
+	aggregateNear(t, "measured-only pace", got.Summary.SpeedProgPerHour, 0.2)
+	work := got.ByWork["measured"]
+	aggregateNear(t, "measured minutes", work.TotalActiveMinutes, 30)
+	if work.ETASeconds == nil {
+		t.Fatal("measured progression must yield an ETA")
+	}
+	aggregateNear(t, "ETA seconds", *work.ETASeconds, 9000)
+	if work.Sessions != 2 || work.Title != "Measured book" || work.Author != "Writer" ||
+		work.LastReadAt == nil || !work.LastReadAt.Equal(now) {
+		t.Errorf("work metadata/count: %+v", work)
+	}
+	if got.Works[0].WorkID != "inferred" || got.Works[1].WorkID != "measured" {
+		t.Errorf("works not ordered by active time: %+v", got.Works)
+	}
+	if want := []Day{{Date: "2026-03-30", Minutes: 90, Pages: 20, Sessions: 3}}; !reflect.DeepEqual(got.Days, want) {
+		t.Errorf("days: got %+v, want %+v", got.Days, want)
+	}
+}
+
+func TestAggregateEndDayClippingMidnightAndZeroDuration(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, paris)
+	midnight := time.Date(2026, 3, 29, 0, 0, 0, 0, paris)
+	next := midnight.AddDate(0, 0, 1) // This day is only 23 hours long.
+	active, zero := int64(30*60*1000), int64(0)
+	snap := store.StatsSnapshot{
+		Timezone: "Europe/Paris", Works: []store.Work{{ID: "book"}},
+		Sessions: []store.Session{
+			{SessionID: "before", WorkID: "book", StartedAt: midnight.Add(-time.Hour), EndedAt: midnight.Add(-time.Nanosecond), ActiveMs: &active},
+			{SessionID: "ends-at-midnight", WorkID: "book", StartedAt: midnight.Add(-10 * time.Minute), EndedAt: midnight, ActiveMs: &active},
+			{SessionID: "zero-at-midnight", WorkID: "book", StartedAt: midnight, EndedAt: midnight, ActiveMs: &zero},
+			{SessionID: "ends-next-midnight", WorkID: "book", StartedAt: next.Add(-time.Hour), EndedAt: next, ActiveMs: &active},
+		},
+		Rollups: []store.SessionRollup{
+			{WorkID: "book", Day: "2026-03-27", ActiveSeconds: 60, SessionCount: 1, Timezone: "Europe/Paris", AttributionVersion: 2},
+			{WorkID: "book", Day: "2026-03-29", ActiveSeconds: 600, SessionCount: 2, Timezone: "Europe/Paris", AttributionVersion: 2},
+		},
+	}
+	got, err := Build(snap, DayWindow(midnight, midnight, paris), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aggregateNear(t, "end-day minutes, without proportional clipping", got.Summary.TotalActiveMinutes, 40)
+	if got.Summary.Sessions != 4 || len(got.Days) != 1 || got.Days[0].Date != "2026-03-29" ||
+		got.Days[0].Sessions != 4 || got.Days[0].Minutes != 40 {
+		t.Errorf("midnight/zero-duration counts: %+v", got)
+	}
+	if got.Summary.StreakDays != 4 || got.FirstActivityDay == nil || *got.FirstActivityDay != "2026-03-27" {
+		t.Errorf("all-history streak and first day must ignore display window: %+v", got)
+	}
+}
+
+func TestAggregateZeroActivityDoesNotCreateAStreak(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+	zero := int64(0)
+	snap := store.StatsSnapshot{
+		Timezone: "UTC", Works: []store.Work{{ID: "book"}},
+		Sessions: []store.Session{
+			{WorkID: "book", StartedAt: now, EndedAt: now, ActiveMs: &zero},
+			{WorkID: "book", StartedAt: now.Add(-time.Minute), EndedAt: now, IdleMs: 60_000},
+		},
+	}
+	got, err := Build(snap, Window{}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Summary.Sessions != 2 || got.Summary.TotalActiveMinutes != 0 ||
+		got.Summary.StreakDays != 0 || len(got.ActiveDays) != 0 || got.FirstActivityDay != nil {
+		t.Fatalf("zero-active sessions count, but are not active days: %+v", got)
+	}
+}
+
+func TestAggregateLegacyAndForeignTimezoneRollupsRemainVisible(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name    string
+		version int
+		zone    string
+	}{
+		{name: "legacy"},
+		{name: "different timezone", version: 2, zone: "Europe/Paris"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := store.StatsSnapshot{
+				Timezone: "UTC", Works: []store.Work{{ID: "book"}},
+				Positions: map[string]store.Op{"book": {Progression: 0.5}},
+				Rollups: []store.SessionRollup{{
+					WorkID: "book", Day: "2026-03-29", ActiveSeconds: 600, Pages: 12,
+					SessionCount: 2, ProgDelta: 0.2, Timezone: tc.zone, AttributionVersion: tc.version,
+				}},
+			}
+			got, err := Build(snap, Window{}, now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got.Complete || got.IncompleteReason == "" {
+				t.Errorf("unverifiable attribution claimed complete: %+v", got)
+			}
+			aggregateNear(t, "fallback minutes", got.Summary.TotalActiveMinutes, 10)
+			aggregateNear(t, "fallback pages", got.Summary.TotalPages, 12)
+			if got.Summary.Sessions != 2 || got.Summary.StreakDays != 1 ||
+				len(got.Days) != 1 || got.Days[0].Date != "2026-03-29" ||
+				got.ByWork["book"].ETASeconds != nil || got.Summary.SpeedProgPerHour != 0 {
+				t.Errorf("fallback loses totals or fabricates pace: %+v", got)
+			}
+		})
+	}
+}
+
+func TestAggregateV2RollupsPreserveMeasuredPaceAndStableOrder(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+	snap := store.StatsSnapshot{
+		Timezone: "UTC", Works: []store.Work{{ID: "b"}, {ID: "a"}},
+		Positions: map[string]store.Op{"a": {Progression: 0.5}},
+		Rollups: []store.SessionRollup{
+			{WorkID: "b", Day: "2026-03-30", ActiveSeconds: 1800, SessionCount: 1, Timezone: "UTC", AttributionVersion: 2},
+			{WorkID: "a", Day: "2026-03-29", ActiveSeconds: 1800, Pages: 20, SessionCount: 2,
+				Timezone: "UTC", AttributionVersion: 2, MeasuredActiveSeconds: 600, MeasuredProgDelta: 0.1},
+		},
+	}
+	got, err := Build(snap, Window{}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Complete || len(got.Works) != 2 || got.Works[0].WorkID != "a" ||
+		got.Works[1].WorkID != "b" || len(got.Days) != 2 || got.Days[0].Date != "2026-03-29" {
+		t.Fatalf("v2 aggregate/order: %+v", got)
+	}
+	aggregateNear(t, "measured rollup pace", got.Summary.SpeedProgPerHour, 0.6)
+	if got.ByWork["a"].ETASeconds == nil {
+		t.Fatal("v2 measured rollup lost ETA")
+	}
+	aggregateNear(t, "rollup ETA", *got.ByWork["a"].ETASeconds, 3000)
+}
+
+func TestAggregateRejectsIncoherentMetadata(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+	sha := "missing-edition"
+	for _, tc := range []struct {
+		name string
+		edit func(*store.StatsSnapshot)
+	}{
+		{"missing edition", func(s *store.StatsSnapshot) { s.Sessions[0].EditionSHA = &sha }},
+		{"invalid timezone", func(s *store.StatsSnapshot) { s.Timezone = "Not/A_Timezone" }},
+		{"invalid rollup day", func(s *store.StatsSnapshot) {
+			s.Rollups = []store.SessionRollup{{WorkID: "book", Day: "2026-02-30"}}
+		}},
+		{"negative pages", func(s *store.StatsSnapshot) { p := -1.0; s.Sessions[0].ReportedPages = &p }},
+		{"NaN pages", func(s *store.StatsSnapshot) { p := math.NaN(); s.Sessions[0].ReportedPages = &p }},
+		{"infinite pages", func(s *store.StatsSnapshot) { p := math.Inf(1); s.Sessions[0].ReportedPages = &p }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := store.StatsSnapshot{
+				Timezone: "UTC", Works: []store.Work{{ID: "book"}},
+				Sessions: []store.Session{{SessionID: "session", WorkID: "book", StartedAt: now.Add(-time.Minute), EndedAt: now, EndProg: 0.2}},
+			}
+			tc.edit(&snap)
+			if _, err := Build(snap, Window{}, now); err == nil {
+				t.Fatal("incoherent metadata must fail, not return a plausible zero-page total")
+			}
+		})
+	}
+}
+
+func TestAggregateReportedPagesAndUnknownPageCounts(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+	sha, reported := "edition", 7.0
+	snap := store.StatsSnapshot{
+		Timezone: "UTC", Works: []store.Work{{ID: "book"}},
+		Editions: map[string]store.Edition{sha: {}},
+		Sessions: []store.Session{
+			{WorkID: "book", StartedAt: now.Add(-time.Minute), EndedAt: now, EndProg: 0.2, EditionSHA: &sha},
+			{WorkID: "book", StartedAt: now.Add(-time.Minute), EndedAt: now, EndProg: 0.2, ReportedPages: &reported},
+			{WorkID: "book", StartedAt: now.Add(-time.Minute), EndedAt: now, StartProg: 0.8, EndProg: 0.2},
+		},
+	}
+	got, err := Build(snap, Window{}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aggregateNear(t, "only reported pages are known", got.Summary.TotalPages, 7)
+	aggregateNear(t, "backwards progression does not subtract pace", got.Summary.SpeedProgPerHour, 8)
+}

--- a/internal/insights/aggregate_revision_test.go
+++ b/internal/insights/aggregate_revision_test.go
@@ -1,0 +1,39 @@
+package insights_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/insights"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func TestStatisticsRevisionHasStableFloatingPointTotals(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	snapshot := store.StatsSnapshot{Timezone: "UTC"}
+	var expected float64
+	for i := range 32 {
+		active := int64(1)
+		if i == 0 {
+			active = 9_000_000_000_000_000
+		}
+		id := fmt.Sprintf("work-%02d", i)
+		snapshot.Works = append(snapshot.Works, store.Work{ID: id})
+		snapshot.Sessions = append(snapshot.Sessions, store.Session{
+			SessionID: id, WorkID: id, StartedAt: now.Add(-time.Second),
+			EndedAt: now, ActiveMs: &active, Origin: store.OriginNative,
+		})
+		expected += float64(active) / 1000 / 60
+	}
+	for range 100 {
+		result, err := insights.Build(snapshot, insights.Window{}, now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Summary.TotalActiveMinutes != expected {
+			t.Fatalf("unchanged snapshot changed numeric identity: got %.17g, want %.17g",
+				result.Summary.TotalActiveMinutes, expected)
+		}
+	}
+}

--- a/internal/insights/statistics_benchmark_test.go
+++ b/internal/insights/statistics_benchmark_test.go
@@ -1,0 +1,522 @@
+package insights_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/insights"
+	"github.com/chmouel/liseur-sync/internal/store"
+	"github.com/chmouel/liseur-sync/internal/store/postgres"
+	"github.com/chmouel/liseur-sync/internal/store/sqlite"
+)
+
+// Run with:
+// go test ./internal/insights -run '^TestStatisticsReadRegression$' -bench '^BenchmarkStatisticsReads$' -benchmem -benchtime=3x -timeout=300s
+//
+// Set LISEUR_STATS_BENCH_POSTGRES_DSN explicitly to additionally test PostgreSQL.
+// It must point to a dedicated disposable database created for this harness:
+// the harness migrates and seeds it. Without it, only SQLite runs. This does
+// not consult the application's or store suite's DSN. Remove the disposable
+// database after use.
+//
+// The baseline follows summary + works in internal/api/insights.go at
+// 2fe346a9ddf218a788129aac6bde991e0d6c6cd6, without HTTP/JSON overhead.
+// It does NOT invent a per-work session query: that handler already grouped one
+// SessionsInRange result. For E eligible sessions and W historical works, its
+// reads are 6 + 2*E + 3*W, plus 2 for a bounded window's lifetime streak.
+// Every counted old helper executes one SELECT in both current stores.
+//
+// StatisticsSnapshot executes 6 SELECTs (timezone/revision, sessions, rollups,
+// works, positions, editions), then ceil(candidateIDs/500) archived reads.
+// Build executes no reads. Transaction control is excluded from these counts;
+// snapshot-reads/op is source-derived, not SQL tracing.
+//
+// These warm, local, synthetic measurements are not a production latency
+// promise. Build also produces calendar/coverage data absent from the compared
+// old summary + works outputs. Seeds, equivalence checks and cleanup are untimed.
+
+const statisticsSessionCount = 12_000
+const statisticsWorkCount = 24
+
+var statisticsNow = time.Date(2026, 9, 5, 20, 0, 0, 0, time.UTC)
+
+type statisticsFixture struct {
+	st       store.Store
+	userID   string
+	sessions []store.Session
+	loc      *time.Location
+}
+
+func statisticsBackends() []string {
+	backends := []string{"sqlite"}
+	if os.Getenv("LISEUR_STATS_BENCH_POSTGRES_DSN") != "" {
+		backends = append(backends, "postgres")
+	}
+	return backends
+}
+
+func seedStatistics(tb testing.TB, backend string) statisticsFixture {
+	tb.Helper()
+	var st store.Store
+	var err error
+	switch backend {
+	case "sqlite":
+		st, err = sqlite.Open(filepath.Join(tb.TempDir(), "statistics.db"))
+	case "postgres":
+		dsn := os.Getenv("LISEUR_STATS_BENCH_POSTGRES_DSN")
+		if dsn == "" {
+			tb.Fatal("PostgreSQL requires LISEUR_STATS_BENCH_POSTGRES_DSN for a dedicated disposable database")
+		}
+		st, err = postgres.Open(dsn)
+	default:
+		tb.Fatalf("unknown benchmark backend %q", backend)
+	}
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() {
+		if err := st.Close(); err != nil {
+			tb.Error(err)
+		}
+	})
+	ctx := tb.Context()
+	if err := st.Migrate(ctx); err != nil {
+		tb.Fatal(err)
+	}
+	loc, err := time.LoadLocation("Europe/Paris")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	hash, err := auth.HashPassword("statistics-benchmark-only")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	userID := store.NewID()
+	if err := st.CreateUser(ctx, store.User{
+		ID: userID, Name: "statistics-" + userID, Argon2Hash: hash,
+		Timezone: loc.String(), CreatedAt: statisticsNow,
+	}); err != nil {
+		tb.Fatal(err)
+	}
+	works := make([]store.Work, statisticsWorkCount)
+	editions := make([]string, statisticsWorkCount)
+	var ops []store.Op
+	for i := range works {
+		works[i] = store.Work{
+			ID: fmt.Sprintf("%s-work-%02d", userID, i), UserID: userID,
+			Title: fmt.Sprintf("Synthetic work %02d", i), Author: "Benchmark reader",
+			CreatedAt: statisticsNow,
+		}
+		editions[i] = fmt.Sprintf("%064x", i+1)
+		pages := int64(256 + i*64)
+		edition := store.Edition{
+			UserID: userID, WorkID: works[i].ID, SHA256: editions[i],
+			PageCount: &pages, MetaJSON: []byte("{}"),
+		}
+		if err := st.CreateWork(ctx, works[i], &edition, nil); err != nil {
+			tb.Fatal(err)
+		}
+		// Two heads ensure "latest position" is exercised, not just metadata.
+		for j := range 2 {
+			ops = append(ops, store.Op{
+				OpID: fmt.Sprintf("position-%d-%d", i, j), WorkID: works[i].ID,
+				EditionSHA: &editions[i], ClientTS: statisticsNow.Add(time.Duration(j-2) * time.Hour),
+				Progression: float64(j+1) / 4, Origin: store.OriginNative,
+				LocatorJSON: []byte("{}"),
+			})
+		}
+	}
+	if _, err := st.AppendOps(ctx, userID, "statistics-device", ops); err != nil {
+		tb.Fatal(err)
+	}
+	f := statisticsFixture{st: st, userID: userID, loc: loc}
+	// Eight non-overlapping sittings per day across 1,500 days, including DST
+	// and leap years. Each work's 500 sessions share its edition. Raw native
+	// sessions without ActiveMs/ReportedPages/source keys keep old and v2
+	// semantics comparable; no crossing midnight, inference or legacy rollups.
+	first := time.Date(2026, 9, 5, 10, 0, 0, 0, loc).AddDate(0, 0, -1499)
+	for i := range statisticsSessionCount {
+		work := i % statisticsWorkCount
+		start := first.AddDate(0, 0, i/8).Add(time.Duration(i%8) * time.Hour)
+		ses := store.Session{
+			UserID: userID, SessionID: fmt.Sprintf("session-%05d", i),
+			WorkID: works[work].ID, EditionSHA: &editions[work], DeviceID: "statistics-device",
+			StartedAt: start, EndedAt: start.Add(time.Duration(20+work%5) * time.Minute),
+			StartProg: 0.25, EndProg: 0.25 + 1.0/64, IdleMs: 120_000,
+			Origin: store.OriginNative,
+		}
+		if i%11 == 0 {
+			ses.EndProg = 0.125 // Rereading adds time, not negative pages.
+		}
+		if i%13 == 0 {
+			ses.EditionSHA = nil // Unknown pages are not fabricated.
+		}
+		f.sessions = append(f.sessions, ses)
+	}
+	for start := 0; start < len(f.sessions); start += 500 {
+		if err := st.AppendSessions(ctx, userID, f.sessions[start:min(start+500, len(f.sessions))]); err != nil {
+			tb.Fatal(err)
+		}
+	}
+	return f
+}
+
+func statisticsWindows(loc *time.Location) []struct {
+	name string
+	win  insights.Window
+} {
+	return []struct {
+		name string
+		win  insights.Window
+	}{
+		{"all", insights.Window{}},
+		{"30d", insights.ParseWindow("", "", "30d", "", loc, statisticsNow)},
+		{"historical-year", insights.ParseWindow("2023-07-01", "2024-06-30", "", "", loc, statisticsNow)},
+	}
+}
+
+func TestStatisticsReadRegression(t *testing.T) {
+	for _, backend := range statisticsBackends() {
+		t.Run(backend, func(t *testing.T) {
+			f := seedStatistics(t, backend)
+			for _, window := range statisticsWindows(f.loc) {
+				t.Run(window.name, func(t *testing.T) {
+					checkStatistics(t, f, window.win, nil)
+				})
+			}
+			// Exercise the archive loader's 500-ID boundary. These live IDs
+			// have no tombstones; candidate lookups must not change aggregates.
+			plain, err := f.st.StatisticsSnapshot(t.Context(), f.userID, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, n := range []int{500, 501, 1001} {
+				t.Run(fmt.Sprintf("candidates-%d", n), func(t *testing.T) {
+					got, err := f.st.StatisticsSnapshot(t.Context(), f.userID, statisticsCandidates(f, n))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !reflect.DeepEqual(got, plain) {
+						t.Fatal("live candidate IDs changed the snapshot")
+					}
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkStatisticsReads(b *testing.B) {
+	for _, backend := range statisticsBackends() {
+		b.Run(backend, func(b *testing.B) {
+			b.StopTimer()
+			f := seedStatistics(b, backend)
+			for _, window := range statisticsWindows(f.loc) {
+				b.Run(window.name, func(b *testing.B) {
+					b.StopTimer()
+					reads := checkStatistics(b, f, window.win, nil)
+					b.Run("former-summary-works", func(b *testing.B) {
+						b.ReportAllocs()
+						b.ResetTimer()
+						b.StartTimer()
+						for i := 0; i < b.N; i++ {
+							if _, _, err := formerStatistics(b.Context(), f.st, f.userID, window.win); err != nil {
+								b.Fatal(err)
+							}
+						}
+						b.StopTimer()
+						b.ReportMetric(float64(reads), "helper-reads/op")
+					})
+					b.Run("snapshot-build", func(b *testing.B) {
+						benchmarkSnapshot(b, f, window.win, nil)
+					})
+				})
+			}
+			b.Run("all-candidates-1001/snapshot-build", func(b *testing.B) {
+				b.StopTimer()
+				ids := statisticsCandidates(f, 1001)
+				checkStatistics(b, f, insights.Window{}, ids)
+				benchmarkSnapshot(b, f, insights.Window{}, ids)
+			})
+		})
+	}
+}
+
+func statisticsCandidates(f statisticsFixture, n int) []string {
+	ids := make([]string, n)
+	for i := range ids {
+		ids[i] = f.sessions[i].SessionID
+	}
+	return ids
+}
+
+func benchmarkSnapshot(b *testing.B, f statisticsFixture, win insights.Window, ids []string) {
+	b.Helper()
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		snap, err := f.st.StatisticsSnapshot(b.Context(), f.userID, ids)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := insights.Build(snap, win, statisticsNow); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	b.ReportMetric(float64(6+(len(ids)+499)/500), "snapshot-reads/op")
+}
+
+func checkStatistics(tb testing.TB, f statisticsFixture, win insights.Window, ids []string) int {
+	tb.Helper()
+	old, reads, err := formerStatistics(tb.Context(), f.st, f.userID, win)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	snap, err := f.st.StatisticsSnapshot(tb.Context(), f.userID, ids)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if len(snap.Sessions) != statisticsSessionCount || len(snap.Works) != statisticsWorkCount ||
+		len(snap.Editions) != statisticsWorkCount || len(snap.Positions) != statisticsWorkCount ||
+		len(snap.Rollups) != 0 || len(snap.Archived) != 0 {
+		tb.Fatal("fixture is not the expected raw, multi-work history")
+	}
+	got, err := insights.Build(snap, win, statisticsNow)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	var sessions, eligible int
+	var active, pages float64
+	for _, ses := range f.sessions {
+		if ses.ActiveMs != nil || ses.ReportedPages != nil || ses.SourceKey != nil ||
+			ses.Origin != store.OriginNative ||
+			ses.StartedAt.In(f.loc).Format(insights.DayFormat) != ses.EndedAt.In(f.loc).Format(insights.DayFormat) {
+			tb.Fatalf("non-legacy benchmark session %s", ses.SessionID)
+		}
+		if !win.HoldsSession(ses) {
+			continue
+		}
+		sessions++
+		active += ses.EndedAt.Sub(ses.StartedAt).Seconds() - float64(ses.IdleMs)/1000
+		if ses.EndProg > ses.StartProg && ses.EditionSHA != nil {
+			eligible++
+			pages += (ses.EndProg - ses.StartProg) * float64(*snap.Editions[*ses.EditionSHA].PageCount)
+		}
+	}
+	wantReads := 6 + 2*eligible + 3*statisticsWorkCount
+	if !win.Unbounded() {
+		wantReads += 2
+	}
+	if reads != wantReads || got.Summary.Sessions != sessions || old.Summary.Sessions != sessions {
+		tb.Fatalf("reads=%d want=%d; session totals old=%d new=%d want=%d",
+			reads, wantReads, old.Summary.Sessions, got.Summary.Sessions, sessions)
+	}
+	statisticsNear(tb, "fixture minutes", got.Summary.TotalActiveMinutes, active/60)
+	statisticsNear(tb, "fixture pages", got.Summary.TotalPages, pages)
+	statisticsNear(tb, "summary minutes", got.Summary.TotalActiveMinutes, old.Summary.TotalActiveMinutes)
+	statisticsNear(tb, "summary pages", got.Summary.TotalPages, old.Summary.TotalPages)
+	statisticsNear(tb, "summary speed", got.Summary.SpeedProgPerHour, old.Summary.SpeedProgPerHour)
+	if got.Summary.StreakDays != old.Summary.StreakDays || got.Summary.StreakDays != 1500 {
+		tb.Fatalf("streak old=%d new=%d want=1500", old.Summary.StreakDays, got.Summary.StreakDays)
+	}
+	if len(got.Works) != len(old.Works) {
+		tb.Fatalf("work count old=%d new=%d", len(old.Works), len(got.Works))
+	}
+	for _, want := range old.Works {
+		work, ok := got.ByWork[want.WorkID]
+		if !ok || work.Title != want.Title || work.Author != want.Author || work.Sessions != want.Sessions ||
+			work.LastReadAt == nil || want.LastReadAt == nil || !work.LastReadAt.Equal(*want.LastReadAt) {
+			tb.Fatalf("work metadata differs: old=%+v new=%+v", want, work)
+		}
+		statisticsNear(tb, "work minutes", work.TotalActiveMinutes, want.TotalActiveMinutes)
+		statisticsNear(tb, "work pages", work.TotalPages, want.TotalPages)
+		statisticsNear(tb, "work progression", work.CurrentProgression, want.CurrentProgression)
+		if (work.ETASeconds == nil) != (want.ETASeconds == nil) {
+			tb.Fatalf("ETA availability differs for %s", want.WorkID)
+		}
+		if work.ETASeconds != nil {
+			statisticsNear(tb, "work ETA", *work.ETASeconds, *want.ETASeconds)
+		}
+	}
+	return reads
+}
+
+func statisticsNear(tb testing.TB, field string, got, want float64) {
+	tb.Helper()
+	if math.IsNaN(got) || math.IsInf(got, 0) || math.Abs(got-want) > 1e-9*math.Max(1, math.Abs(want)) {
+		tb.Fatalf("%s: got %.12g want %.12g", field, got, want)
+	}
+}
+
+// formerStatistics preserves the old successful read path for summary + works.
+// checkStatistics enforces a legacy-compatible fixture outside timing. For
+// these same-day sessions, the old splitDays result is simply the ending day.
+// Errors are surfaced, not timed as the old metadata/position fallback.
+func formerStatistics(ctx context.Context, st store.Store, userID string, win insights.Window) (insights.Result, int, error) {
+	var out insights.Result
+	reads := 0
+	location := func() (*time.Location, error) {
+		reads++
+		u, err := st.UserByID(ctx, userID)
+		if err != nil {
+			return nil, err
+		}
+		return time.LoadLocation(u.Timezone)
+	}
+	pageCount := func(ses store.Session) (float64, error) {
+		delta := ses.EndProg - ses.StartProg
+		if delta <= 0 || ses.EditionSHA == nil {
+			return 0, nil
+		}
+		reads++
+		ed, err := st.EditionBySHA(ctx, userID, *ses.EditionSHA)
+		if err != nil || ed.PageCount == nil {
+			return 0, err
+		}
+		return delta * float64(*ed.PageCount), nil
+	}
+	loc, err := location()
+	if err != nil {
+		return out, reads, err
+	}
+	from, to := win.SessionBounds(statisticsNow, loc)
+	reads++
+	sessions, err := st.SessionsInRange(ctx, userID, from, to)
+	if err != nil {
+		return out, reads, err
+	}
+	days := make(map[string]bool)
+	var active, delta float64
+	for _, ses := range sessions {
+		if !win.HoldsSession(ses) {
+			continue
+		}
+		pages, err := pageCount(ses)
+		if err != nil {
+			return out, reads, err
+		}
+		out.Summary.Sessions++
+		out.Summary.TotalPages += pages
+		active += insights.ActiveSeconds(ses)
+		delta += math.Max(0, ses.EndProg-ses.StartProg)
+		days[ses.EndedAt.In(loc).Format(insights.DayFormat)] = true
+	}
+	first, last := win.DayBounds(statisticsNow, loc)
+	reads++
+	rollups, err := st.RollupsInRange(ctx, userID, first, last)
+	if err != nil {
+		return out, reads, err
+	}
+	if len(rollups) != 0 {
+		return out, reads, fmt.Errorf("legacy comparison requires raw sessions, not rollups")
+	}
+	if !win.Unbounded() {
+		from := statisticsNow.AddDate(0, 0, -insights.StreakLookbackDays)
+		reads++
+		all, err := st.SessionsInRange(ctx, userID, from, statisticsNow)
+		if err != nil {
+			return out, reads, err
+		}
+		for _, ses := range all {
+			days[ses.EndedAt.In(loc).Format(insights.DayFormat)] = true
+		}
+		reads++
+		rollups, err := st.RollupsInRange(ctx, userID,
+			from.In(loc).Format(insights.DayFormat), statisticsNow.In(loc).Format(insights.DayFormat))
+		if err != nil {
+			return out, reads, err
+		}
+		if len(rollups) != 0 {
+			return out, reads, fmt.Errorf("legacy streak comparison requires raw sessions")
+		}
+	}
+	out.Summary.TotalActiveMinutes = active / 60
+	if active > 0 {
+		out.Summary.SpeedProgPerHour = delta / active * 3600
+	}
+	out.Summary.StreakDays = insights.StreakDays(days, loc, statisticsNow)
+
+	reads++
+	workIDs, err := st.WorkIDsWithInsights(ctx, userID)
+	if err != nil {
+		return out, reads, err
+	}
+	loc, err = location()
+	if err != nil {
+		return out, reads, err
+	}
+	from, to = win.SessionBounds(statisticsNow, loc)
+	reads++
+	sessions, err = st.SessionsInRange(ctx, userID, from, to)
+	if err != nil {
+		return out, reads, err
+	}
+	byWork := make(map[string][]store.Session)
+	for _, ses := range sessions {
+		byWork[ses.WorkID] = append(byWork[ses.WorkID], ses)
+	}
+	for _, id := range workIDs {
+		work := insights.Work{WorkID: id}
+		var active, delta float64
+		for _, ses := range byWork[id] {
+			if !win.HoldsSession(ses) {
+				continue
+			}
+			pages, err := pageCount(ses)
+			if err != nil {
+				return out, reads, err
+			}
+			work.Sessions++
+			active += insights.ActiveSeconds(ses)
+			work.TotalPages += pages
+			delta += math.Max(0, ses.EndProg-ses.StartProg)
+			if work.LastReadAt == nil || ses.EndedAt.After(*work.LastReadAt) {
+				at := ses.EndedAt
+				work.LastReadAt = &at
+			}
+		}
+		reads++
+		rollups, err := st.RollupsForWork(ctx, userID, id)
+		if err != nil {
+			return out, reads, err
+		}
+		if len(rollups) != 0 {
+			return out, reads, fmt.Errorf("legacy work comparison requires raw sessions")
+		}
+		reads++
+		ops, err := st.Positions(ctx, userID, id, 1)
+		if err != nil {
+			return out, reads, err
+		}
+		if len(ops) > 0 {
+			work.CurrentProgression = ops[0].Progression
+			if active > 0 && delta > 0 && work.CurrentProgression < 1 {
+				eta := (1 - work.CurrentProgression) / (delta / active)
+				work.ETASeconds = &eta
+			}
+		}
+		reads++
+		meta, err := st.WorkByID(ctx, userID, id)
+		if err != nil {
+			return out, reads, err
+		}
+		work.Title, work.Author = meta.Title, meta.Author
+		work.TotalActiveMinutes = active / 60
+		if work.Sessions > 0 || work.TotalActiveMinutes > 0 {
+			out.Works = append(out.Works, work)
+		}
+	}
+	sort.Slice(out.Works, func(i, j int) bool {
+		return out.Works[i].TotalActiveMinutes > out.Works[j].TotalActiveMinutes
+	})
+	return out, reads, nil
+}

--- a/internal/insights/window.go
+++ b/internal/insights/window.go
@@ -252,12 +252,18 @@ type errString string
 
 func (e errString) Error() string { return string(e) }
 
-// ActiveSeconds returns a session's length minus its idle time, clamped
-// at nought. The device counts reading off a monotonic clock that stops
-// when the app leaves the foreground and reports the difference, so a
-// book left open while the reader answered the door spans more time
-// than it counted.
+// ActiveSeconds returns a session's explicit active time when the
+// device supplied it, otherwise the wall-clock length minus idle time,
+// clamped at nought. Explicit active time is already foreground reading
+// time, so idle is not subtracted from it again and it is not capped to
+// the wall span.
 func ActiveSeconds(ses store.Session) float64 {
+	if ses.ActiveMs != nil {
+		if *ses.ActiveMs < 0 {
+			return 0
+		}
+		return float64(*ses.ActiveMs) / 1000
+	}
 	d := ses.EndedAt.Sub(ses.StartedAt).Seconds() - float64(ses.IdleMs)/1000
 	if d < 0 {
 		return 0

--- a/internal/store/postgres/delete.go
+++ b/internal/store/postgres/delete.go
@@ -53,6 +53,13 @@ func deleteWorkTx(ctx context.Context, tx *sql.Tx, userID, workID string) error 
 	if mapped {
 		return errWorkStillMapped
 	}
+	if _, err := tx.ExecContext(ctx, q(
+		`UPDATE session_tombstones
+		   SET present = FALSE
+		 WHERE user_id = ? AND work_id = ? AND attribution_version = 2 AND present IS TRUE`),
+		userID, workID); err != nil {
+		return err
+	}
 	res, err := tx.ExecContext(ctx, q(
 		`DELETE FROM works WHERE user_id = ? AND id = ?`), userID, workID)
 	if err != nil {

--- a/internal/store/postgres/koplugin.go
+++ b/internal/store/postgres/koplugin.go
@@ -79,6 +79,10 @@ func (s *Store) UpsertKopluginSessionByAlias(ctx context.Context, userID, partia
 }
 
 func upsertKopluginSessionTx(ctx context.Context, tx *sql.Tx, userID string, ses store.Session) (string, error) {
+	if ses.ReportedPages == nil {
+		one := 1.0
+		ses.ReportedPages = &one
+	}
 	now := time.Now().UTC()
 
 	var cnt int
@@ -121,13 +125,13 @@ func upsertKopluginSessionTx(ctx context.Context, tx *sql.Tx, userID string, ses
 func insertSessionTx(ctx context.Context, tx *sql.Tx, userID string, ses store.Session, now time.Time) error {
 	_, err := tx.ExecContext(ctx, q(
 		`INSERT INTO sessions (user_id, session_id, work_id, edition_sha, device_id,
-		                       started_at, ended_at, start_prog, end_prog, idle_ms,
+		                       started_at, ended_at, start_prog, end_prog, idle_ms, active_ms, reported_pages,
 		                       origin, origin_alias, source_key, received_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON CONFLICT (user_id, session_id) DO NOTHING`),
 		userID, ses.SessionID, ses.WorkID, ses.EditionSHA, ses.DeviceID,
 		ses.StartedAt.UTC(), ses.EndedAt.UTC(),
-		ses.StartProg, ses.EndProg, ses.IdleMs,
+		ses.StartProg, ses.EndProg, ses.IdleMs, ses.ActiveMs, ses.ReportedPages,
 		string(ses.Origin), ses.OriginAlias, ses.SourceKey, now)
 	return err
 }

--- a/internal/store/postgres/migrate_test.go
+++ b/internal/store/postgres/migrate_test.go
@@ -112,7 +112,7 @@ func TestBackfillLeavesAConfiguredServerAlone(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reset(t, s)
-			for i, m := range migrations[:len(migrations)-1] {
+			for i, m := range migrations[:len(migrations)-2] {
 				if _, err := s.db.ExecContext(ctx, m); err != nil {
 					t.Fatal(err)
 				}

--- a/internal/store/postgres/reconcile.go
+++ b/internal/store/postgres/reconcile.go
@@ -556,6 +556,8 @@ func collectEmptyWorksTx(ctx context.Context, tx *sql.Tx) error {
 		    AND NOT EXISTS (SELECT 1 FROM sessions s
 		                     WHERE s.user_id = works.user_id AND s.work_id = works.id)
 		    AND NOT EXISTS (SELECT 1 FROM session_rollups r
+		                     WHERE r.user_id = works.user_id AND r.work_id = works.id)
+		    AND NOT EXISTS (SELECT 1 FROM session_rollups_v2 r
 		                     WHERE r.user_id = works.user_id AND r.work_id = works.id)`))
 	return err
 }

--- a/internal/store/postgres/rollups.go
+++ b/internal/store/postgres/rollups.go
@@ -14,7 +14,7 @@ import (
 func (s *Store) SessionsEndedBefore(ctx context.Context, userID string, before time.Time) ([]store.Session, error) {
 	rows, err := s.db.QueryContext(ctx, q(
 		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 		 FROM sessions s WHERE user_id = ? AND ended_at < ? AND source_key IS NULL
 		 ORDER BY started_at`), userID, before.UTC())
 	if err != nil {
@@ -24,7 +24,10 @@ func (s *Store) SessionsEndedBefore(ctx context.Context, userID string, before t
 	return scanSessions(rows)
 }
 
-// ApplyRollups: see the SQLite implementation's doc comment.
+// ApplyRollups additively upserts daily aggregates and deletes the
+// rolled-up raw session rows in one transaction. Supersession rows
+// referencing deleted sessions cascade. Version 2 rollups are kept in
+// their own table and write exact per-session proof to tombstones.
 func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store.SessionRollup, deleteSessions []store.Session) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -34,10 +37,18 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 	if err := lockWorkGraph(ctx, tx, userID); err != nil {
 		return err
 	}
+	v2 := rollupsV2(rollups)
+	for _, r := range v2 {
+		if r.Timezone == "" {
+			return store.ErrInvalidInput
+		}
+	}
+	proofs := make([]store.ArchivedSession, 0, len(deleteSessions))
+	pageCounts := make(map[string]sql.NullInt64)
 	for _, expected := range deleteSessions {
 		current, err := scanSession(tx.QueryRowContext(ctx, q(
 			`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-			        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+			        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 			 FROM sessions WHERE user_id = ? AND session_id = ?`),
 			userID, expected.SessionID))
 		if err != nil {
@@ -49,12 +60,43 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 		if store.SessionFingerprint(current) != store.SessionFingerprint(expected) {
 			return store.ErrConflict
 		}
+		if len(v2) > 0 {
+			proof, err := archivedContribution(ctx, tx, userID, current, v2, pageCounts)
+			if err != nil {
+				return err
+			}
+			proofs = append(proofs, proof)
+		}
+	}
+	if len(v2) > 0 {
+		if err := store.ValidateRollupContributions(v2, proofs); err != nil {
+			return err
+		}
 	}
 	for _, r := range rollups {
+		if rollupAttributionVersion(r) == 2 {
+			if _, err := tx.ExecContext(ctx, q(
+				`INSERT INTO session_rollups_v2 (user_id, work_id, day, timezone, attribution_version,
+				                              active_seconds, pages, prog_delta, session_count,
+				                              measured_active_seconds, measured_prog_delta)
+				 VALUES (?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(user_id, work_id, day, timezone) DO UPDATE SET
+				     active_seconds          = session_rollups_v2.active_seconds + excluded.active_seconds,
+				     pages                   = session_rollups_v2.pages + excluded.pages,
+				     prog_delta              = session_rollups_v2.prog_delta + excluded.prog_delta,
+				     session_count           = session_rollups_v2.session_count + excluded.session_count,
+				     measured_active_seconds = session_rollups_v2.measured_active_seconds + excluded.measured_active_seconds,
+				     measured_prog_delta     = session_rollups_v2.measured_prog_delta + excluded.measured_prog_delta`),
+				userID, r.WorkID, r.Day, r.Timezone, r.ActiveSeconds, r.Pages, r.ProgDelta,
+				r.SessionCount, r.MeasuredActiveSeconds, r.MeasuredProgDelta); err != nil {
+				return err
+			}
+			continue
+		}
 		if _, err := tx.ExecContext(ctx, q(
 			`INSERT INTO session_rollups (user_id, work_id, day, active_seconds, pages, prog_delta, session_count)
 			 VALUES (?, ?, ?, ?, ?, ?, ?)
-			 ON CONFLICT (user_id, work_id, day) DO UPDATE SET
+			 ON CONFLICT(user_id, work_id, day) DO UPDATE SET
 			     active_seconds = session_rollups.active_seconds + excluded.active_seconds,
 			     pages          = session_rollups.pages + excluded.pages,
 			     prog_delta     = session_rollups.prog_delta + excluded.prog_delta,
@@ -63,12 +105,27 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 			return err
 		}
 	}
-	for _, ses := range deleteSessions {
-		if _, err := tx.ExecContext(ctx, q(
-			`INSERT INTO session_tombstones (user_id, session_id, fingerprint) VALUES (?, ?, ?)
-			 ON CONFLICT (user_id, session_id) DO NOTHING`),
-			userID, ses.SessionID, store.SessionFingerprint(ses)); err != nil {
-			return err
+	for i, ses := range deleteSessions {
+		if len(v2) > 0 {
+			archived := proofs[i]
+			if _, err := tx.ExecContext(ctx, q(
+				`INSERT INTO session_tombstones (user_id, session_id, fingerprint, work_id, day, timezone,
+				                                attribution_version, present, active_seconds, pages,
+				                                prog_delta, measured_active_seconds, measured_prog_delta)
+				 VALUES (?, ?, ?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(user_id, session_id) DO NOTHING`),
+				userID, ses.SessionID, store.SessionFingerprint(ses), archived.WorkID, archived.Day,
+				archived.Timezone, archived.Present, archived.ActiveSeconds, archived.Pages,
+				archived.ProgDelta, archived.MeasuredActiveSeconds, archived.MeasuredProgDelta); err != nil {
+				return err
+			}
+		} else {
+			if _, err := tx.ExecContext(ctx, q(
+				`INSERT INTO session_tombstones (user_id, session_id, fingerprint) VALUES (?, ?, ?)
+				 ON CONFLICT(user_id, session_id) DO NOTHING`),
+				userID, ses.SessionID, store.SessionFingerprint(ses)); err != nil {
+				return err
+			}
 		}
 		result, err := tx.ExecContext(ctx, q(
 			`DELETE FROM sessions WHERE user_id = ? AND session_id = ?`),
@@ -87,39 +144,146 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 	return tx.Commit()
 }
 
+func rollupAttributionVersion(r store.SessionRollup) int {
+	if r.AttributionVersion == 2 || r.Timezone != "" {
+		return 2
+	}
+	return 0
+}
+
+func rollupsV2(rollups []store.SessionRollup) []store.SessionRollup {
+	out := make([]store.SessionRollup, 0, len(rollups))
+	for _, r := range rollups {
+		if rollupAttributionVersion(r) == 2 {
+			r.AttributionVersion = 2
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func archivedContribution(ctx context.Context, tx *sql.Tx, userID string, ses store.Session, rollups []store.SessionRollup, pageCounts map[string]sql.NullInt64) (store.ArchivedSession, error) {
+	for _, r := range rollups {
+		if r.WorkID != ses.WorkID || r.Timezone == "" {
+			continue
+		}
+		loc, err := time.LoadLocation(r.Timezone)
+		if err != nil {
+			return store.ArchivedSession{}, err
+		}
+		if ses.EndedAt.In(loc).Format("2006-01-02") != r.Day {
+			continue
+		}
+		proof := store.ArchivedSession{
+			Fingerprint:        store.SessionFingerprint(ses),
+			WorkID:             ses.WorkID,
+			Day:                r.Day,
+			Timezone:           r.Timezone,
+			AttributionVersion: 2,
+			Present:            true,
+			ActiveSeconds:      sessionActiveSeconds(ses),
+			ProgDelta:          sessionProgDelta(ses),
+		}
+		pages, err := sessionPages(ctx, tx, userID, ses, proof.ProgDelta, pageCounts)
+		if err != nil {
+			return store.ArchivedSession{}, err
+		}
+		proof.Pages = pages
+		if ses.Origin != store.OriginInferred {
+			proof.MeasuredActiveSeconds = proof.ActiveSeconds
+			proof.MeasuredProgDelta = proof.ProgDelta
+		}
+		return proof, nil
+	}
+	return store.ArchivedSession{}, store.ErrConflict
+}
+
+func sessionActiveSeconds(ses store.Session) float64 {
+	if ses.ActiveMs != nil {
+		if *ses.ActiveMs < 0 {
+			return 0
+		}
+		return float64(*ses.ActiveMs) / 1000
+	}
+	active := ses.EndedAt.Sub(ses.StartedAt).Seconds() - float64(ses.IdleMs)/1000
+	if active <= 0 {
+		return 0
+	}
+	return active
+}
+
+func sessionProgDelta(ses store.Session) float64 {
+	delta := ses.EndProg - ses.StartProg
+	if delta < 0 {
+		return 0
+	}
+	return delta
+}
+
+func sessionPages(ctx context.Context, tx *sql.Tx, userID string, ses store.Session, progDelta float64, pageCounts map[string]sql.NullInt64) (float64, error) {
+	if ses.ReportedPages != nil {
+		return *ses.ReportedPages, nil
+	}
+	if ses.EditionSHA == nil || progDelta <= 0 {
+		return 0, nil
+	}
+	pages, cached := pageCounts[*ses.EditionSHA]
+	if !cached {
+		err := tx.QueryRowContext(ctx, q(
+			`SELECT page_count FROM editions WHERE user_id = ? AND sha256 = ?`),
+			userID, *ses.EditionSHA).Scan(&pages)
+		if err != nil {
+			return 0, err
+		}
+		pageCounts[*ses.EditionSHA] = pages
+	}
+	if !pages.Valid {
+		return 0, nil
+	}
+	return float64(pages.Int64) * progDelta, nil
+}
+
 func (s *Store) RollupsInRange(ctx context.Context, userID, fromDay, toDay string) ([]store.SessionRollup, error) {
 	rows, err := s.db.QueryContext(ctx, q(
-		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count
+		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
 		 FROM session_rollups WHERE user_id = ? AND day >= ? AND day <= ?
-		 ORDER BY day`), userID, fromDay, toDay)
+		 UNION ALL
+		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		 FROM session_rollups_v2 WHERE user_id = ? AND day >= ? AND day <= ?
+		 ORDER BY day, work_id, attribution_version`), userID, fromDay, toDay, userID, fromDay, toDay)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var out []store.SessionRollup
-	for rows.Next() {
-		var r store.SessionRollup
-		if err := rows.Scan(&r.UserID, &r.WorkID, &r.Day, &r.ActiveSeconds, &r.Pages, &r.ProgDelta, &r.SessionCount); err != nil {
-			return nil, err
-		}
-		out = append(out, r)
-	}
-	return out, rows.Err()
+	return scanRollups(rows)
 }
 
 func (s *Store) RollupsForWork(ctx context.Context, userID, workID string) ([]store.SessionRollup, error) {
 	rows, err := s.db.QueryContext(ctx, q(
-		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count
+		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
 		 FROM session_rollups WHERE user_id = ? AND work_id = ?
-		 ORDER BY day`), userID, workID)
+		 UNION ALL
+		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		 FROM session_rollups_v2 WHERE user_id = ? AND work_id = ?
+		 ORDER BY day, attribution_version`), userID, workID, userID, workID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
+	return scanRollups(rows)
+}
+
+func scanRollups(rows *sql.Rows) ([]store.SessionRollup, error) {
 	var out []store.SessionRollup
 	for rows.Next() {
 		var r store.SessionRollup
-		if err := rows.Scan(&r.UserID, &r.WorkID, &r.Day, &r.ActiveSeconds, &r.Pages, &r.ProgDelta, &r.SessionCount); err != nil {
+		if err := rows.Scan(&r.UserID, &r.WorkID, &r.Day, &r.ActiveSeconds, &r.Pages, &r.ProgDelta,
+			&r.SessionCount, &r.Timezone, &r.AttributionVersion, &r.MeasuredActiveSeconds,
+			&r.MeasuredProgDelta); err != nil {
 			return nil, err
 		}
 		out = append(out, r)

--- a/internal/store/postgres/rollups_test.go
+++ b/internal/store/postgres/rollups_test.go
@@ -1,0 +1,94 @@
+package postgres
+
+import (
+	"database/sql"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+	"github.com/chmouel/liseur-sync/internal/store/storetest"
+)
+
+func openRollupStore(t *testing.T) *Store {
+	t.Helper()
+	dsn := os.Getenv("LISEUR_PG_TEST_DSN")
+	if dsn == "" {
+		t.Skip("LISEUR_PG_TEST_DSN not set")
+	}
+	s, err := Open(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { s.Close() })
+	reset(t, s)
+	if err := s.Migrate(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func TestRollupsRejectStaleEditionPageCount(t *testing.T) {
+	s := openRollupStore(t)
+	storetest.RollupsRejectStaleEditionPageCount(t, s, func(userID, sha string, pages *int64) error {
+		_, err := s.db.ExecContext(t.Context(), q(`UPDATE editions SET page_count = ? WHERE user_id = ? AND sha256 = ?`),
+			pages, userID, sha)
+		return err
+	})
+}
+
+func TestSessionPagesCachesNullableCountsAndPropagatesErrors(t *testing.T) {
+	s := openRollupStore(t)
+	ctx := t.Context()
+	user := storetest.MkUser(t, s, "page-cache")
+	storetest.MkWork(t, s, user, "page-cache-work", "page-cache-sha")
+	for _, tc := range []struct {
+		name  string
+		pages *int64
+		want  float64
+	}{
+		{"known-page-count", storetest.Ptr(int64(100)), 25},
+		{"null-page-count", nil, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, err := s.db.BeginTx(ctx, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tx.Rollback()
+			if _, err := tx.ExecContext(ctx, q(`UPDATE editions SET page_count = ? WHERE user_id = ? AND sha256 = ?`),
+				tc.pages, user.ID, "page-cache-sha"); err != nil {
+				t.Fatal(err)
+			}
+			cache := make(map[string]sql.NullInt64)
+			ses := store.Session{EditionSHA: storetest.Ptr("page-cache-sha")}
+			got, err := sessionPages(ctx, tx, user.ID, ses, 0.25, cache)
+			if err != nil || got != tc.want || len(cache) != 1 {
+				t.Fatalf("initial contribution: pages=%v cache=%v err=%v", got, cache, err)
+			}
+			if err := tx.Rollback(); err != nil {
+				t.Fatal(err)
+			}
+			got, err = sessionPages(ctx, tx, user.ID, ses, 0.5, cache)
+			if err != nil || got != 2*tc.want {
+				t.Fatalf("cached contribution queried the closed transaction: pages=%v err=%v", got, err)
+			}
+			if _, err := sessionPages(ctx, tx, user.ID, ses, 0.25, make(map[string]sql.NullInt64)); !errors.Is(err, sql.ErrTxDone) {
+				t.Fatalf("query failure was swallowed: %v", err)
+			}
+		})
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	cache := make(map[string]sql.NullInt64)
+	ses := store.Session{EditionSHA: storetest.Ptr("missing-edition")}
+	if _, err := sessionPages(ctx, tx, user.ID, ses, 0.25, cache); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("missing edition was silently treated as zero pages: %v", err)
+	}
+	if len(cache) != 0 {
+		t.Fatalf("failed lookup was cached: %v", cache)
+	}
+}

--- a/internal/store/postgres/schema.go
+++ b/internal/store/postgres/schema.go
@@ -525,8 +525,134 @@ SELECT u.id, f.id FROM users u CROSS JOIN folders f
 WHERE NOT EXISTS (SELECT 1 FROM user_folders);
 `
 
+const statisticsStorage = `
+ALTER TABLE sessions ADD COLUMN active_ms BIGINT;
+ALTER TABLE sessions ADD COLUMN reported_pages DOUBLE PRECISION;
+
+CREATE TABLE stats_revisions (
+    user_id  TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    revision BIGINT NOT NULL DEFAULT 0
+);
+INSERT INTO stats_revisions (user_id, revision)
+SELECT id, 0 FROM users
+ON CONFLICT (user_id) DO NOTHING;
+
+CREATE TABLE session_rollups_v2 (
+    user_id                 TEXT NOT NULL,
+    work_id                 TEXT NOT NULL,
+    day                     TEXT NOT NULL,
+    timezone                TEXT NOT NULL,
+    attribution_version     BIGINT NOT NULL DEFAULT 2 CHECK (attribution_version = 2),
+    active_seconds          DOUBLE PRECISION NOT NULL DEFAULT 0,
+    pages                   DOUBLE PRECISION NOT NULL DEFAULT 0,
+    prog_delta              DOUBLE PRECISION NOT NULL DEFAULT 0,
+    session_count           BIGINT NOT NULL DEFAULT 0,
+    measured_active_seconds DOUBLE PRECISION NOT NULL DEFAULT 0,
+    measured_prog_delta     DOUBLE PRECISION NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, work_id, day, timezone),
+    FOREIGN KEY (user_id, work_id) REFERENCES works(user_id, id) ON DELETE CASCADE
+);
+CREATE INDEX session_rollups_v2_user_day ON session_rollups_v2(user_id, day);
+
+ALTER TABLE session_tombstones ADD COLUMN work_id TEXT;
+ALTER TABLE session_tombstones ADD COLUMN day TEXT;
+ALTER TABLE session_tombstones ADD COLUMN timezone TEXT;
+ALTER TABLE session_tombstones ADD COLUMN attribution_version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN present BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE session_tombstones ADD COLUMN active_seconds DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN pages DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN prog_delta DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN measured_active_seconds DOUBLE PRECISION NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN measured_prog_delta DOUBLE PRECISION NOT NULL DEFAULT 0;
+CREATE INDEX session_tombstones_user_work ON session_tombstones(user_id, work_id);
+
+CREATE OR REPLACE FUNCTION ensure_stats_revision_row()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO stats_revisions (user_id, revision) VALUES (NEW.id, 0)
+    ON CONFLICT (user_id) DO NOTHING;
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION bump_stats_revision(p_user_id TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    INSERT INTO stats_revisions (user_id, revision)
+    SELECT p_user_id, 1 WHERE EXISTS (SELECT 1 FROM users WHERE id = p_user_id)
+    ON CONFLICT (user_id) DO UPDATE SET revision = stats_revisions.revision + 1;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION bump_stats_revision_new()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM bump_stats_revision(NEW.user_id);
+    RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION bump_stats_revision_old()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM bump_stats_revision(OLD.user_id);
+    RETURN OLD;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION bump_stats_revision_user_timezone()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    PERFORM bump_stats_revision(NEW.id);
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER stats_revisions_users_insert
+AFTER INSERT ON users
+FOR EACH ROW EXECUTE FUNCTION ensure_stats_revision_row();
+CREATE TRIGGER stats_revisions_users_timezone_update
+AFTER UPDATE OF timezone ON users
+FOR EACH ROW WHEN (OLD.timezone IS DISTINCT FROM NEW.timezone)
+EXECUTE FUNCTION bump_stats_revision_user_timezone();
+
+CREATE TRIGGER stats_revisions_sessions_insert AFTER INSERT ON sessions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_sessions_update AFTER UPDATE ON sessions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_sessions_delete AFTER DELETE ON sessions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
+CREATE TRIGGER stats_revisions_supersessions_insert AFTER INSERT ON session_supersessions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_supersessions_delete AFTER DELETE ON session_supersessions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
+CREATE TRIGGER stats_revisions_rollups_insert AFTER INSERT ON session_rollups FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_rollups_update AFTER UPDATE ON session_rollups FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_rollups_delete AFTER DELETE ON session_rollups FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
+CREATE TRIGGER stats_revisions_rollups_v2_insert AFTER INSERT ON session_rollups_v2 FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_rollups_v2_update AFTER UPDATE ON session_rollups_v2 FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_rollups_v2_delete AFTER DELETE ON session_rollups_v2 FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
+CREATE TRIGGER stats_revisions_tombstones_insert AFTER INSERT ON session_tombstones FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_tombstones_update AFTER UPDATE ON session_tombstones FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_tombstones_delete AFTER DELETE ON session_tombstones FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
+CREATE TRIGGER stats_revisions_ops_insert AFTER INSERT ON ops FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_ops_update AFTER UPDATE ON ops FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_ops_delete AFTER DELETE ON ops FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
+CREATE TRIGGER stats_revisions_works_insert AFTER INSERT ON works FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_works_update AFTER UPDATE ON works FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_works_delete AFTER DELETE ON works FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
+CREATE TRIGGER stats_revisions_editions_insert AFTER INSERT ON editions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_editions_update AFTER UPDATE ON editions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_new();
+CREATE TRIGGER stats_revisions_editions_delete AFTER DELETE ON editions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
+`
+
 // migrations is append-only, for the reason the SQLite copy gives.
 var migrations = []string{
 	schema, claimRevisions, folderUploads, folderAccess, annotationSync,
-	folderBackfill,
+	folderBackfill, statisticsStorage,
 }

--- a/internal/store/postgres/sessions.go
+++ b/internal/store/postgres/sessions.go
@@ -77,12 +77,12 @@ func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store
 		}
 		_, err = tx.ExecContext(ctx, q(
 			`INSERT INTO sessions (user_id, session_id, work_id, edition_sha, device_id,
-			                       started_at, ended_at, start_prog, end_prog, idle_ms,
+			                       started_at, ended_at, start_prog, end_prog, idle_ms, active_ms, reported_pages,
 			                       origin, origin_alias, source_key, received_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`),
 			userID, ses.SessionID, ses.WorkID, ses.EditionSHA, ses.DeviceID,
 			ses.StartedAt.UTC(), ses.EndedAt.UTC(),
-			ses.StartProg, ses.EndProg, ses.IdleMs,
+			ses.StartProg, ses.EndProg, ses.IdleMs, ses.ActiveMs, ses.ReportedPages,
 			string(ses.Origin), ses.OriginAlias, ses.SourceKey, now)
 		if err != nil {
 			return inserted, err
@@ -150,19 +150,23 @@ func sameSession(ctx context.Context, tx *sql.Tx, userID string, ses store.Sessi
 		started, ended        time.Time
 		sp, ep                float64
 		idle                  int64
+		active                *int64
+		pages                 *float64
 		edSHA, oalias, skey   *string
 	)
 	err := tx.QueryRowContext(ctx, q(
 		`SELECT work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key
 		 FROM sessions WHERE user_id = ? AND session_id = ?`), userID, ses.SessionID).
-		Scan(&workID, &edSHA, &devID, &started, &ended, &sp, &ep, &idle, &origin, &oalias, &skey)
+		Scan(&workID, &edSHA, &devID, &started, &ended, &sp, &ep, &idle, &active, &pages, &origin, &oalias, &skey)
 	if err != nil {
 		return false, err
 	}
 	return workID == ses.WorkID && devID == ses.DeviceID &&
 		tsEqual(started, ses.StartedAt) && tsEqual(ended, ses.EndedAt) &&
 		sp == ses.StartProg && ep == ses.EndProg && idle == ses.IdleMs &&
+		(active == nil) == (ses.ActiveMs == nil) && (active == nil || *active == *ses.ActiveMs) &&
+		(pages == nil) == (ses.ReportedPages == nil) && (pages == nil || *pages == *ses.ReportedPages) &&
 		origin == string(ses.Origin) &&
 		(edSHA == nil) == (ses.EditionSHA == nil) && (edSHA == nil || *edSHA == *ses.EditionSHA) &&
 		(oalias == nil) == (ses.OriginAlias == nil) && (oalias == nil || *oalias == *ses.OriginAlias) &&
@@ -172,7 +176,7 @@ func sameSession(ctx context.Context, tx *sql.Tx, userID string, ses store.Sessi
 func (s *Store) SessionsForWork(ctx context.Context, userID, workID string, limit int) ([]store.Session, error) {
 	rows, err := s.db.QueryContext(ctx, q(
 		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 		 FROM sessions WHERE user_id = ? AND work_id = ? ORDER BY started_at DESC LIMIT ?`),
 		userID, workID, limit)
 	if err != nil {
@@ -185,7 +189,7 @@ func (s *Store) SessionsForWork(ctx context.Context, userID, workID string, limi
 		var origin string
 		if err := rows.Scan(&ses.UserID, &ses.SessionID, &ses.WorkID, &ses.EditionSHA, &ses.DeviceID,
 			&ses.StartedAt, &ses.EndedAt, &ses.StartProg, &ses.EndProg, &ses.IdleMs,
-			&origin, &ses.OriginAlias, &ses.SourceKey, &ses.ReceivedAt); err != nil {
+			&ses.ActiveMs, &ses.ReportedPages, &origin, &ses.OriginAlias, &ses.SourceKey, &ses.ReceivedAt); err != nil {
 			return nil, err
 		}
 		ses.Origin = store.Origin(origin)
@@ -198,7 +202,7 @@ func (s *Store) SessionsForWork(ctx context.Context, userID, workID string, limi
 func (s *Store) CurrentSessionsForWork(ctx context.Context, userID, workID string, limit int) ([]store.Session, error) {
 	rows, err := s.db.QueryContext(ctx, q(
 		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 		 FROM sessions s WHERE user_id = ? AND work_id = ?
 		   AND (source_key IS NULL OR session_id = (
 		       SELECT ss.session_id FROM session_supersessions ss
@@ -216,7 +220,7 @@ func (s *Store) CurrentSessionsForWork(ctx context.Context, userID, workID strin
 		var origin string
 		if err := rows.Scan(&ses.UserID, &ses.SessionID, &ses.WorkID, &ses.EditionSHA, &ses.DeviceID,
 			&ses.StartedAt, &ses.EndedAt, &ses.StartProg, &ses.EndProg, &ses.IdleMs,
-			&origin, &ses.OriginAlias, &ses.SourceKey, &ses.ReceivedAt); err != nil {
+			&ses.ActiveMs, &ses.ReportedPages, &origin, &ses.OriginAlias, &ses.SourceKey, &ses.ReceivedAt); err != nil {
 			return nil, err
 		}
 		ses.Origin = store.Origin(origin)
@@ -233,7 +237,9 @@ func (s *Store) WorkIDsWithInsights(ctx context.Context, userID string) ([]strin
 		`SELECT work_id FROM sessions WHERE user_id = ?
 		 UNION
 		 SELECT work_id FROM session_rollups WHERE user_id = ?
-		 ORDER BY work_id`), userID, userID)
+		 UNION
+		 SELECT work_id FROM session_rollups_v2 WHERE user_id = ?
+		 ORDER BY work_id`), userID, userID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -253,7 +259,7 @@ func (s *Store) WorkIDsWithInsights(ctx context.Context, userID string) ([]strin
 func (s *Store) SessionsInRange(ctx context.Context, userID string, from, to time.Time) ([]store.Session, error) {
 	rows, err := s.db.QueryContext(ctx, q(
 		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 		 FROM sessions
 		 WHERE user_id = ? AND ended_at > ? AND started_at < ?
 		   AND (source_key IS NULL OR session_id = (
@@ -285,7 +291,7 @@ func scanSession(row interface{ Scan(...any) error }) (store.Session, error) {
 	var origin string
 	err := row.Scan(&ses.UserID, &ses.SessionID, &ses.WorkID, &ses.EditionSHA, &ses.DeviceID,
 		&ses.StartedAt, &ses.EndedAt, &ses.StartProg, &ses.EndProg, &ses.IdleMs,
-		&origin, &ses.OriginAlias, &ses.SourceKey, &ses.ReceivedAt)
+		&ses.ActiveMs, &ses.ReportedPages, &origin, &ses.OriginAlias, &ses.SourceKey, &ses.ReceivedAt)
 	ses.Origin = store.Origin(origin)
 	return ses, err
 }

--- a/internal/store/postgres/stats.go
+++ b/internal/store/postgres/stats.go
@@ -1,0 +1,204 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func (s *Store) StatisticsSnapshot(ctx context.Context, userID string, candidateIDs []string) (store.StatsSnapshot, error) {
+	var snap store.StatsSnapshot
+	tx, err := s.db.BeginTx(ctx, snapshotTx)
+	if err != nil {
+		return snap, err
+	}
+	defer tx.Rollback()
+
+	if err := tx.QueryRowContext(ctx, q(
+		`SELECT u.timezone, sr.revision
+		   FROM users u JOIN stats_revisions sr ON sr.user_id = u.id
+		  WHERE u.id = ?`), userID).Scan(&snap.Timezone, &snap.Revision); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return snap, store.ErrNotFound
+		}
+		return snap, err
+	}
+
+	rows, err := tx.QueryContext(ctx, q(
+		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
+		   FROM sessions s
+		  WHERE user_id = ?
+		    AND (source_key IS NULL OR session_id = (
+		        SELECT ss.session_id FROM session_supersessions ss
+		         WHERE ss.user_id = s.user_id AND ss.source_key = s.source_key
+		         ORDER BY ss.revision DESC LIMIT 1))
+		  ORDER BY started_at, session_id`), userID)
+	if err != nil {
+		return snap, err
+	}
+	snap.Sessions, err = scanSessions(rows)
+	if closeErr := rows.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return snap, err
+	}
+
+	rows, err = tx.QueryContext(ctx, q(
+		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
+		   FROM session_rollups WHERE user_id = ?
+		  UNION ALL
+		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		   FROM session_rollups_v2 WHERE user_id = ?
+		  ORDER BY day, work_id, attribution_version, timezone`), userID, userID)
+	if err != nil {
+		return snap, err
+	}
+	snap.Rollups, err = scanRollups(rows)
+	if closeErr := rows.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return snap, err
+	}
+
+	rows, err = tx.QueryContext(ctx, q(
+		`SELECT id, user_id, title, author, pending, created_at
+		   FROM works WHERE user_id = ? ORDER BY id`), userID)
+	if err != nil {
+		return snap, err
+	}
+	for rows.Next() {
+		var w store.Work
+		if err := rows.Scan(&w.ID, &w.UserID, &w.Title, &w.Author, &w.Pending, &w.CreatedAt); err != nil {
+			rows.Close()
+			return snap, err
+		}
+		snap.Works = append(snap.Works, w)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return snap, err
+	}
+	if err := rows.Close(); err != nil {
+		return snap, err
+	}
+
+	snap.Positions = make(map[string]store.Op)
+	rows, err = tx.QueryContext(ctx, q(
+		`SELECT user_id, seq, op_id, work_id, edition_sha, device_id, client_ts,
+		        progression, locator_json, foreign_pos, origin, origin_alias, received_at
+		   FROM (
+		     SELECT user_id, seq, op_id, work_id, edition_sha, device_id, client_ts,
+		            progression, locator_json, foreign_pos, origin, origin_alias, received_at,
+		            row_number() OVER (PARTITION BY work_id ORDER BY seq DESC) AS rn
+		       FROM ops WHERE user_id = ?
+		   ) ranked WHERE rn = 1 ORDER BY work_id`), userID)
+	if err != nil {
+		return snap, err
+	}
+	for rows.Next() {
+		op, err := scanOp(rows)
+		if err != nil {
+			rows.Close()
+			return snap, err
+		}
+		snap.Positions[op.WorkID] = op
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return snap, err
+	}
+	if err := rows.Close(); err != nil {
+		return snap, err
+	}
+
+	snap.Editions = make(map[string]store.Edition)
+	rows, err = tx.QueryContext(ctx, q(
+		`SELECT user_id, sha256, work_id, page_count, char_count, meta_json
+		   FROM editions WHERE user_id = ? ORDER BY sha256`), userID)
+	if err != nil {
+		return snap, err
+	}
+	for rows.Next() {
+		var e store.Edition
+		if err := rows.Scan(&e.UserID, &e.SHA256, &e.WorkID, &e.PageCount, &e.CharCount, &e.MetaJSON); err != nil {
+			rows.Close()
+			return snap, err
+		}
+		snap.Editions[e.SHA256] = e
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return snap, err
+	}
+	if err := rows.Close(); err != nil {
+		return snap, err
+	}
+
+	snap.Archived = make(map[string]store.ArchivedSession)
+	if err := loadArchivedSnapshot(ctx, tx, userID, candidateIDs, snap.Archived); err != nil {
+		return snap, err
+	}
+	return snap, tx.Commit()
+}
+
+func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []string, out map[string]store.ArchivedSession) error {
+	const chunk = 500
+	for start := 0; start < len(ids); start += chunk {
+		end := start + chunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		parts := make([]string, end-start)
+		args := make([]any, 0, end-start+1)
+		args = append(args, userID)
+		for i, id := range ids[start:end] {
+			parts[i] = fmt.Sprintf("$%d", i+2)
+			args = append(args, id)
+		}
+		rows, err := tx.QueryContext(ctx,
+			`SELECT session_id, fingerprint, work_id, day, timezone, attribution_version, present,
+			        active_seconds, pages, prog_delta, measured_active_seconds, measured_prog_delta
+			   FROM session_tombstones WHERE user_id = $1 AND session_id IN (`+strings.Join(parts, ",")+`)`, args...)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			var id string
+			var a store.ArchivedSession
+			var workID, day, timezone *string
+			if err := rows.Scan(&id, &a.Fingerprint, &workID, &day, &timezone, &a.AttributionVersion,
+				&a.Present, &a.ActiveSeconds, &a.Pages, &a.ProgDelta, &a.MeasuredActiveSeconds,
+				&a.MeasuredProgDelta); err != nil {
+				rows.Close()
+				return err
+			}
+			if workID != nil {
+				a.WorkID = *workID
+			}
+			if day != nil {
+				a.Day = *day
+			}
+			if timezone != nil {
+				a.Timezone = *timezone
+			}
+			out[id] = a
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/store/postgres/store_test.go
+++ b/internal/store/postgres/store_test.go
@@ -43,8 +43,8 @@ func reset(t *testing.T, s *Store) {
 		"series_name_overrides", "series_bindings", "book_series", "series",
 		"book_identifiers", "user_book_works", "user_folders",
 		"books", "folders",
-		"session_supersessions", "session_tombstones", "session_rollups", "sessions", "ops", "annotations", "aliases", "editions",
-		"works", "seq_counters", "compaction_state", "kosync_devices",
+		"session_supersessions", "session_tombstones", "session_rollups_v2", "session_rollups", "sessions", "ops", "annotations", "aliases", "editions",
+		"works", "seq_counters", "compaction_state", "stats_revisions", "kosync_devices",
 		"koplugin_devices", "pairing_codes", "invites", "auth_sessions",
 		"token_scopes", "tokens", "users", "schema_migrations",
 	}

--- a/internal/store/postgres/works.go
+++ b/internal/store/postgres/works.go
@@ -336,8 +336,9 @@ func (s *Store) SplitWork(ctx context.Context, userID, workID, editionSHA string
 	}
 	var rollupCount int
 	if err := tx.QueryRowContext(ctx, q(
-		`SELECT COUNT(1) FROM session_rollups WHERE user_id = ? AND work_id = ?`),
-		userID, workID).Scan(&rollupCount); err != nil {
+		`SELECT (SELECT COUNT(1) FROM session_rollups WHERE user_id = ? AND work_id = ?) +
+		        (SELECT COUNT(1) FROM session_rollups_v2 WHERE user_id = ? AND work_id = ?)`),
+		userID, workID, userID, workID).Scan(&rollupCount); err != nil {
 		return err
 	}
 	if rollupCount > 0 {
@@ -468,8 +469,9 @@ func (s *Store) MergeWorks(ctx context.Context, userID, fromWorkID, intoWorkID s
 	}
 	var rollupCount int
 	if err := tx.QueryRowContext(ctx, q(
-		`SELECT COUNT(1) FROM session_rollups WHERE user_id = ? AND work_id = ?`),
-		userID, fromWorkID).Scan(&rollupCount); err != nil {
+		`SELECT (SELECT COUNT(1) FROM session_rollups WHERE user_id = ? AND work_id = ?) +
+		        (SELECT COUNT(1) FROM session_rollups_v2 WHERE user_id = ? AND work_id = ?)`),
+		userID, fromWorkID, userID, fromWorkID).Scan(&rollupCount); err != nil {
 		return err
 	}
 	if rollupCount > 0 {

--- a/internal/store/rollups.go
+++ b/internal/store/rollups.go
@@ -1,0 +1,45 @@
+package store
+
+import "math"
+
+// ValidateRollupContributions checks v2 buckets against the exact proofs that
+// will be archived. Sum in session order, as the materializer does, so a stale
+// edition snapshot cannot commit different totals from its retained proofs.
+func ValidateRollupContributions(rollups []SessionRollup, proofs []ArchivedSession) error {
+	type key struct{ workID, day, timezone string }
+	totals := make(map[key]SessionRollup)
+	for _, p := range proofs {
+		k := key{p.WorkID, p.Day, p.Timezone}
+		r := totals[k]
+		r.ActiveSeconds += p.ActiveSeconds
+		r.Pages += p.Pages
+		r.ProgDelta += p.ProgDelta
+		r.SessionCount++
+		r.MeasuredActiveSeconds += p.MeasuredActiveSeconds
+		r.MeasuredProgDelta += p.MeasuredProgDelta
+		totals[k] = r
+	}
+	for _, r := range rollups {
+		k := key{r.WorkID, r.Day, r.Timezone}
+		total, ok := totals[k]
+		if !ok || r.SessionCount != total.SessionCount {
+			return ErrConflict
+		}
+		for _, pair := range [][2]float64{
+			{r.ActiveSeconds, total.ActiveSeconds},
+			{r.Pages, total.Pages},
+			{r.ProgDelta, total.ProgDelta},
+			{r.MeasuredActiveSeconds, total.MeasuredActiveSeconds},
+			{r.MeasuredProgDelta, total.MeasuredProgDelta},
+		} {
+			if pair[0] != pair[1] || math.IsNaN(pair[0]) || math.IsInf(pair[0], 0) {
+				return ErrConflict
+			}
+		}
+		delete(totals, k)
+	}
+	if len(totals) != 0 {
+		return ErrConflict
+	}
+	return nil
+}

--- a/internal/store/sqlite/delete.go
+++ b/internal/store/sqlite/delete.go
@@ -53,6 +53,12 @@ func deleteWorkTx(ctx context.Context, tx *sql.Tx, userID, workID string) error 
 	if mapped == 1 {
 		return errWorkStillMapped
 	}
+	if _, err := tx.ExecContext(ctx, `UPDATE session_tombstones
+		   SET present = 0
+		 WHERE user_id = ? AND work_id = ? AND attribution_version = 2 AND present = 1`,
+		userID, workID); err != nil {
+		return err
+	}
 	res, err := tx.ExecContext(ctx,
 		`DELETE FROM works WHERE user_id = ? AND id = ?`, userID, workID)
 	if err != nil {

--- a/internal/store/sqlite/koplugin.go
+++ b/internal/store/sqlite/koplugin.go
@@ -99,6 +99,10 @@ func (s *Store) UpsertKopluginSessionByAlias(ctx context.Context, userID, partia
 }
 
 func upsertKopluginSessionTx(ctx context.Context, tx *sql.Tx, userID string, ses store.Session) (string, error) {
+	if ses.ReportedPages == nil {
+		one := 1.0
+		ses.ReportedPages = &one
+	}
 	now := formatTime(time.Now())
 
 	// Does this exact session_id already exist? -> identical re-upload.
@@ -143,12 +147,12 @@ func upsertKopluginSessionTx(ctx context.Context, tx *sql.Tx, userID string, ses
 func insertSessionTx(ctx context.Context, tx *sql.Tx, userID string, ses store.Session, now string) error {
 	_, err := tx.ExecContext(ctx,
 		`INSERT INTO sessions (user_id, session_id, work_id, edition_sha, device_id,
-		                       started_at, ended_at, start_prog, end_prog, idle_ms,
+		                       started_at, ended_at, start_prog, end_prog, idle_ms, active_ms, reported_pages,
 		                       origin, origin_alias, source_key, received_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		userID, ses.SessionID, ses.WorkID, nullStr(ses.EditionSHA), ses.DeviceID,
 		formatTime(ses.StartedAt), formatTime(ses.EndedAt),
-		ses.StartProg, ses.EndProg, ses.IdleMs,
+		ses.StartProg, ses.EndProg, ses.IdleMs, ses.ActiveMs, ses.ReportedPages,
 		string(ses.Origin), nullStr(ses.OriginAlias), nullStr(ses.SourceKey), now)
 	if isUniqueErr(err) {
 		// Same session_id inserted before: treat as duplicate of that

--- a/internal/store/sqlite/migrate_test.go
+++ b/internal/store/sqlite/migrate_test.go
@@ -125,7 +125,7 @@ func TestBackfillLeavesAConfiguredServerAlone(t *testing.T) {
 			t.Cleanup(func() { s.Close() })
 			// Everything up to but not including the backfill, which is
 			// where a server running the broken image sits.
-			for i, m := range migrations[:len(migrations)-1] {
+			for i, m := range migrations[:len(migrations)-2] {
 				if _, err := s.db.ExecContext(ctx, m); err != nil {
 					t.Fatal(err)
 				}

--- a/internal/store/sqlite/reconcile.go
+++ b/internal/store/sqlite/reconcile.go
@@ -560,6 +560,8 @@ func collectEmptyWorksTx(ctx context.Context, tx *sql.Tx) error {
 		    AND NOT EXISTS (SELECT 1 FROM sessions s
 		                     WHERE s.user_id = works.user_id AND s.work_id = works.id)
 		    AND NOT EXISTS (SELECT 1 FROM session_rollups r
+		                     WHERE r.user_id = works.user_id AND r.work_id = works.id)
+		    AND NOT EXISTS (SELECT 1 FROM session_rollups_v2 r
 		                     WHERE r.user_id = works.user_id AND r.work_id = works.id)`)
 	return err
 }

--- a/internal/store/sqlite/rollups.go
+++ b/internal/store/sqlite/rollups.go
@@ -12,30 +12,21 @@ import (
 // SessionsEndedBefore returns sessions that ended before the cutoff,
 // oldest first — the input to the rollup job.
 func (s *Store) SessionsEndedBefore(ctx context.Context, userID string, before time.Time) ([]store.Session, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+	rows, err := s.db.QueryContext(ctx, `SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 		 FROM sessions s WHERE user_id = ? AND ended_at < ? AND source_key IS NULL
 		 ORDER BY started_at`, userID, formatTime(before))
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var out []store.Session
-	for rows.Next() {
-		ses, err := scanSession(rows)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, ses)
-	}
-	return out, rows.Err()
+	return scanSessions(rows)
 }
 
 // ApplyRollups additively upserts daily aggregates and deletes the
 // rolled-up raw session rows in one transaction. Supersession rows
-// referencing deleted sessions cascade. Idempotent by construction:
-// deletion happens with the upsert, so a re-run never re-counts.
+// referencing deleted sessions cascade. Version 2 rollups are kept in
+// their own table and write exact per-session proof to tombstones.
 func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store.SessionRollup, deleteSessions []store.Session) error {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -45,10 +36,17 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 	if err := lockWorkGraph(ctx, tx, userID); err != nil {
 		return err
 	}
+	v2 := rollupsV2(rollups)
+	for _, r := range v2 {
+		if r.Timezone == "" {
+			return store.ErrInvalidInput
+		}
+	}
+	proofs := make([]store.ArchivedSession, 0, len(deleteSessions))
+	pageCounts := make(map[string]sql.NullInt64)
 	for _, expected := range deleteSessions {
-		current, err := scanSession(tx.QueryRowContext(ctx,
-			`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-			        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+		current, err := scanSession(tx.QueryRowContext(ctx, `SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
+			        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 			 FROM sessions WHERE user_id = ? AND session_id = ?`,
 			userID, expected.SessionID))
 		if err != nil {
@@ -60,29 +58,70 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 		if store.SessionFingerprint(current) != store.SessionFingerprint(expected) {
 			return store.ErrConflict
 		}
+		if len(v2) > 0 {
+			proof, err := archivedContribution(ctx, tx, userID, current, v2, pageCounts)
+			if err != nil {
+				return err
+			}
+			proofs = append(proofs, proof)
+		}
+	}
+	if len(v2) > 0 {
+		if err := store.ValidateRollupContributions(v2, proofs); err != nil {
+			return err
+		}
 	}
 	for _, r := range rollups {
-		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO session_rollups (user_id, work_id, day, active_seconds, pages, prog_delta, session_count)
+		if rollupAttributionVersion(r) == 2 {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO session_rollups_v2 (user_id, work_id, day, timezone, attribution_version,
+				                              active_seconds, pages, prog_delta, session_count,
+				                              measured_active_seconds, measured_prog_delta)
+				 VALUES (?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(user_id, work_id, day, timezone) DO UPDATE SET
+				     active_seconds          = session_rollups_v2.active_seconds + excluded.active_seconds,
+				     pages                   = session_rollups_v2.pages + excluded.pages,
+				     prog_delta              = session_rollups_v2.prog_delta + excluded.prog_delta,
+				     session_count           = session_rollups_v2.session_count + excluded.session_count,
+				     measured_active_seconds = session_rollups_v2.measured_active_seconds + excluded.measured_active_seconds,
+				     measured_prog_delta     = session_rollups_v2.measured_prog_delta + excluded.measured_prog_delta`,
+				userID, r.WorkID, r.Day, r.Timezone, r.ActiveSeconds, r.Pages, r.ProgDelta,
+				r.SessionCount, r.MeasuredActiveSeconds, r.MeasuredProgDelta); err != nil {
+				return err
+			}
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO session_rollups (user_id, work_id, day, active_seconds, pages, prog_delta, session_count)
 			 VALUES (?, ?, ?, ?, ?, ?, ?)
 			 ON CONFLICT(user_id, work_id, day) DO UPDATE SET
-			     active_seconds = active_seconds + excluded.active_seconds,
-			     pages          = pages + excluded.pages,
-			     prog_delta     = prog_delta + excluded.prog_delta,
-			     session_count  = session_count + excluded.session_count`,
+			     active_seconds = session_rollups.active_seconds + excluded.active_seconds,
+			     pages          = session_rollups.pages + excluded.pages,
+			     prog_delta     = session_rollups.prog_delta + excluded.prog_delta,
+			     session_count  = session_rollups.session_count + excluded.session_count`,
 			userID, r.WorkID, r.Day, r.ActiveSeconds, r.Pages, r.ProgDelta, r.SessionCount); err != nil {
 			return err
 		}
 	}
-	for _, ses := range deleteSessions {
-		if _, err := tx.ExecContext(ctx,
-			`INSERT INTO session_tombstones (user_id, session_id, fingerprint) VALUES (?, ?, ?)
-			 ON CONFLICT(user_id, session_id) DO NOTHING`,
-			userID, ses.SessionID, store.SessionFingerprint(ses)); err != nil {
-			return err
+	for i, ses := range deleteSessions {
+		if len(v2) > 0 {
+			archived := proofs[i]
+			if _, err := tx.ExecContext(ctx, `INSERT INTO session_tombstones (user_id, session_id, fingerprint, work_id, day, timezone,
+				                                attribution_version, present, active_seconds, pages,
+				                                prog_delta, measured_active_seconds, measured_prog_delta)
+				 VALUES (?, ?, ?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?)
+				 ON CONFLICT(user_id, session_id) DO NOTHING`,
+				userID, ses.SessionID, store.SessionFingerprint(ses), archived.WorkID, archived.Day,
+				archived.Timezone, b2i(archived.Present), archived.ActiveSeconds, archived.Pages,
+				archived.ProgDelta, archived.MeasuredActiveSeconds, archived.MeasuredProgDelta); err != nil {
+				return err
+			}
+		} else {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO session_tombstones (user_id, session_id, fingerprint) VALUES (?, ?, ?)
+				 ON CONFLICT(user_id, session_id) DO NOTHING`,
+				userID, ses.SessionID, store.SessionFingerprint(ses)); err != nil {
+				return err
+			}
 		}
-		result, err := tx.ExecContext(ctx,
-			`DELETE FROM sessions WHERE user_id = ? AND session_id = ?`,
+		result, err := tx.ExecContext(ctx, `DELETE FROM sessions WHERE user_id = ? AND session_id = ?`,
 			userID, ses.SessionID)
 		if err != nil {
 			return err
@@ -98,39 +137,143 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 	return tx.Commit()
 }
 
+func rollupAttributionVersion(r store.SessionRollup) int {
+	if r.AttributionVersion == 2 || r.Timezone != "" {
+		return 2
+	}
+	return 0
+}
+
+func rollupsV2(rollups []store.SessionRollup) []store.SessionRollup {
+	out := make([]store.SessionRollup, 0, len(rollups))
+	for _, r := range rollups {
+		if rollupAttributionVersion(r) == 2 {
+			r.AttributionVersion = 2
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func archivedContribution(ctx context.Context, tx *sql.Tx, userID string, ses store.Session, rollups []store.SessionRollup, pageCounts map[string]sql.NullInt64) (store.ArchivedSession, error) {
+	for _, r := range rollups {
+		if r.WorkID != ses.WorkID || r.Timezone == "" {
+			continue
+		}
+		loc, err := time.LoadLocation(r.Timezone)
+		if err != nil {
+			return store.ArchivedSession{}, err
+		}
+		if ses.EndedAt.In(loc).Format("2006-01-02") != r.Day {
+			continue
+		}
+		proof := store.ArchivedSession{
+			Fingerprint:        store.SessionFingerprint(ses),
+			WorkID:             ses.WorkID,
+			Day:                r.Day,
+			Timezone:           r.Timezone,
+			AttributionVersion: 2,
+			Present:            true,
+			ActiveSeconds:      sessionActiveSeconds(ses),
+			ProgDelta:          sessionProgDelta(ses),
+		}
+		pages, err := sessionPages(ctx, tx, userID, ses, proof.ProgDelta, pageCounts)
+		if err != nil {
+			return store.ArchivedSession{}, err
+		}
+		proof.Pages = pages
+		if ses.Origin != store.OriginInferred {
+			proof.MeasuredActiveSeconds = proof.ActiveSeconds
+			proof.MeasuredProgDelta = proof.ProgDelta
+		}
+		return proof, nil
+	}
+	return store.ArchivedSession{}, store.ErrConflict
+}
+
+func sessionActiveSeconds(ses store.Session) float64 {
+	if ses.ActiveMs != nil {
+		if *ses.ActiveMs < 0 {
+			return 0
+		}
+		return float64(*ses.ActiveMs) / 1000
+	}
+	active := ses.EndedAt.Sub(ses.StartedAt).Seconds() - float64(ses.IdleMs)/1000
+	if active <= 0 {
+		return 0
+	}
+	return active
+}
+
+func sessionProgDelta(ses store.Session) float64 {
+	delta := ses.EndProg - ses.StartProg
+	if delta < 0 {
+		return 0
+	}
+	return delta
+}
+
+func sessionPages(ctx context.Context, tx *sql.Tx, userID string, ses store.Session, progDelta float64, pageCounts map[string]sql.NullInt64) (float64, error) {
+	if ses.ReportedPages != nil {
+		return *ses.ReportedPages, nil
+	}
+	if ses.EditionSHA == nil || progDelta <= 0 {
+		return 0, nil
+	}
+	pages, cached := pageCounts[*ses.EditionSHA]
+	if !cached {
+		err := tx.QueryRowContext(ctx, `SELECT page_count FROM editions WHERE user_id = ? AND sha256 = ?`,
+			userID, *ses.EditionSHA).Scan(&pages)
+		if err != nil {
+			return 0, err
+		}
+		pageCounts[*ses.EditionSHA] = pages
+	}
+	if !pages.Valid {
+		return 0, nil
+	}
+	return float64(pages.Int64) * progDelta, nil
+}
+
 func (s *Store) RollupsInRange(ctx context.Context, userID, fromDay, toDay string) ([]store.SessionRollup, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count
+	rows, err := s.db.QueryContext(ctx, `SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
 		 FROM session_rollups WHERE user_id = ? AND day >= ? AND day <= ?
-		 ORDER BY day`, userID, fromDay, toDay)
+		 UNION ALL
+		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		 FROM session_rollups_v2 WHERE user_id = ? AND day >= ? AND day <= ?
+		 ORDER BY day, work_id, attribution_version`, userID, fromDay, toDay, userID, fromDay, toDay)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	var out []store.SessionRollup
-	for rows.Next() {
-		var r store.SessionRollup
-		if err := rows.Scan(&r.UserID, &r.WorkID, &r.Day, &r.ActiveSeconds, &r.Pages, &r.ProgDelta, &r.SessionCount); err != nil {
-			return nil, err
-		}
-		out = append(out, r)
-	}
-	return out, rows.Err()
+	return scanRollups(rows)
 }
 
 func (s *Store) RollupsForWork(ctx context.Context, userID, workID string) ([]store.SessionRollup, error) {
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count
+	rows, err := s.db.QueryContext(ctx, `SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
 		 FROM session_rollups WHERE user_id = ? AND work_id = ?
-		 ORDER BY day`, userID, workID)
+		 UNION ALL
+		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		 FROM session_rollups_v2 WHERE user_id = ? AND work_id = ?
+		 ORDER BY day, attribution_version`, userID, workID, userID, workID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
+	return scanRollups(rows)
+}
+
+func scanRollups(rows *sql.Rows) ([]store.SessionRollup, error) {
 	var out []store.SessionRollup
 	for rows.Next() {
 		var r store.SessionRollup
-		if err := rows.Scan(&r.UserID, &r.WorkID, &r.Day, &r.ActiveSeconds, &r.Pages, &r.ProgDelta, &r.SessionCount); err != nil {
+		if err := rows.Scan(&r.UserID, &r.WorkID, &r.Day, &r.ActiveSeconds, &r.Pages, &r.ProgDelta,
+			&r.SessionCount, &r.Timezone, &r.AttributionVersion, &r.MeasuredActiveSeconds,
+			&r.MeasuredProgDelta); err != nil {
 			return nil, err
 		}
 		out = append(out, r)
@@ -148,16 +291,13 @@ func (s *Store) Housekeep(ctx context.Context, now time.Time) error {
 		return err
 	}
 	defer tx.Rollback()
-	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM pairing_codes WHERE expires_at < ?`, nowS); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM pairing_codes WHERE expires_at < ?`, nowS); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM auth_sessions WHERE expires_at < ? OR revoked_at IS NOT NULL`, nowS); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM auth_sessions WHERE expires_at < ? OR revoked_at IS NOT NULL`, nowS); err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM tokens WHERE (expires_at IS NOT NULL AND expires_at < ?)
+	if _, err := tx.ExecContext(ctx, `DELETE FROM tokens WHERE (expires_at IS NOT NULL AND expires_at < ?)
 		                       OR (revoked_at IS NOT NULL AND revoked_at < ?)`, graceS, graceS); err != nil {
 		return err
 	}

--- a/internal/store/sqlite/rollups_test.go
+++ b/internal/store/sqlite/rollups_test.go
@@ -1,0 +1,75 @@
+package sqlite
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+	"github.com/chmouel/liseur-sync/internal/store/storetest"
+)
+
+func TestRollupsRejectStaleEditionPageCount(t *testing.T) {
+	s := openStore(t).(*Store)
+	storetest.RollupsRejectStaleEditionPageCount(t, s, func(userID, sha string, pages *int64) error {
+		_, err := s.db.ExecContext(t.Context(), `UPDATE editions SET page_count = ? WHERE user_id = ? AND sha256 = ?`,
+			pages, userID, sha)
+		return err
+	})
+}
+
+func TestSessionPagesCachesNullableCountsAndPropagatesErrors(t *testing.T) {
+	s := openStore(t).(*Store)
+	ctx := t.Context()
+	user := storetest.MkUser(t, s, "page-cache")
+	storetest.MkWork(t, s, user, "page-cache-work", "page-cache-sha")
+	for _, tc := range []struct {
+		name  string
+		pages *int64
+		want  float64
+	}{
+		{"known-page-count", storetest.Ptr(int64(100)), 25},
+		{"null-page-count", nil, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, err := s.db.BeginTx(ctx, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer tx.Rollback()
+			if _, err := tx.ExecContext(ctx, `UPDATE editions SET page_count = ? WHERE user_id = ? AND sha256 = ?`,
+				tc.pages, user.ID, "page-cache-sha"); err != nil {
+				t.Fatal(err)
+			}
+			cache := make(map[string]sql.NullInt64)
+			ses := store.Session{EditionSHA: storetest.Ptr("page-cache-sha")}
+			got, err := sessionPages(ctx, tx, user.ID, ses, 0.25, cache)
+			if err != nil || got != tc.want || len(cache) != 1 {
+				t.Fatalf("initial contribution: pages=%v cache=%v err=%v", got, cache, err)
+			}
+			if err := tx.Rollback(); err != nil {
+				t.Fatal(err)
+			}
+			got, err = sessionPages(ctx, tx, user.ID, ses, 0.5, cache)
+			if err != nil || got != 2*tc.want {
+				t.Fatalf("cached contribution queried the closed transaction: pages=%v err=%v", got, err)
+			}
+			if _, err := sessionPages(ctx, tx, user.ID, ses, 0.25, make(map[string]sql.NullInt64)); !errors.Is(err, sql.ErrTxDone) {
+				t.Fatalf("query failure was swallowed: %v", err)
+			}
+		})
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback()
+	cache := make(map[string]sql.NullInt64)
+	ses := store.Session{EditionSHA: storetest.Ptr("missing-edition")}
+	if _, err := sessionPages(ctx, tx, user.ID, ses, 0.25, cache); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("missing edition was silently treated as zero pages: %v", err)
+	}
+	if len(cache) != 0 {
+		t.Fatalf("failed lookup was cached: %v", cache)
+	}
+}

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -626,10 +626,181 @@ SELECT u.id, f.id FROM users u CROSS JOIN folders f
 WHERE NOT EXISTS (SELECT 1 FROM user_folders);
 `
 
+const statisticsStorage = `
+ALTER TABLE sessions ADD COLUMN active_ms INTEGER;
+ALTER TABLE sessions ADD COLUMN reported_pages REAL;
+
+CREATE TABLE stats_revisions (
+    user_id  TEXT PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    revision INTEGER NOT NULL DEFAULT 0
+);
+INSERT OR IGNORE INTO stats_revisions (user_id, revision)
+SELECT id, 0 FROM users;
+
+CREATE TABLE session_rollups_v2 (
+    user_id                 TEXT NOT NULL,
+    work_id                 TEXT NOT NULL,
+    day                     TEXT NOT NULL,
+    timezone                TEXT NOT NULL,
+    attribution_version     INTEGER NOT NULL DEFAULT 2 CHECK (attribution_version = 2),
+    active_seconds          REAL NOT NULL DEFAULT 0,
+    pages                   REAL NOT NULL DEFAULT 0,
+    prog_delta              REAL NOT NULL DEFAULT 0,
+    session_count           INTEGER NOT NULL DEFAULT 0,
+    measured_active_seconds REAL NOT NULL DEFAULT 0,
+    measured_prog_delta     REAL NOT NULL DEFAULT 0,
+    PRIMARY KEY (user_id, work_id, day, timezone),
+    FOREIGN KEY (user_id, work_id) REFERENCES works(user_id, id) ON DELETE CASCADE
+);
+CREATE INDEX session_rollups_v2_user_day ON session_rollups_v2(user_id, day);
+
+ALTER TABLE session_tombstones ADD COLUMN work_id TEXT;
+ALTER TABLE session_tombstones ADD COLUMN day TEXT;
+ALTER TABLE session_tombstones ADD COLUMN timezone TEXT;
+ALTER TABLE session_tombstones ADD COLUMN attribution_version INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN present INTEGER NOT NULL DEFAULT 0 CHECK (present IN (0, 1));
+ALTER TABLE session_tombstones ADD COLUMN active_seconds REAL NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN pages REAL NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN prog_delta REAL NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN measured_active_seconds REAL NOT NULL DEFAULT 0;
+ALTER TABLE session_tombstones ADD COLUMN measured_prog_delta REAL NOT NULL DEFAULT 0;
+CREATE INDEX session_tombstones_user_work ON session_tombstones(user_id, work_id);
+
+CREATE TRIGGER stats_revisions_users_insert
+AFTER INSERT ON users
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.id, 0);
+END;
+
+CREATE TRIGGER stats_revisions_users_timezone_update
+AFTER UPDATE OF timezone ON users
+WHEN OLD.timezone IS NOT NEW.timezone
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.id;
+END;
+
+CREATE TRIGGER stats_revisions_sessions_insert AFTER INSERT ON sessions BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_sessions_update AFTER UPDATE ON sessions BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_sessions_delete AFTER DELETE ON sessions
+WHEN EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id)
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (OLD.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = OLD.user_id;
+END;
+
+CREATE TRIGGER stats_revisions_supersessions_insert AFTER INSERT ON session_supersessions BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_supersessions_delete AFTER DELETE ON session_supersessions
+WHEN EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id)
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (OLD.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = OLD.user_id;
+END;
+
+CREATE TRIGGER stats_revisions_rollups_insert AFTER INSERT ON session_rollups BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_rollups_update AFTER UPDATE ON session_rollups BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_rollups_delete AFTER DELETE ON session_rollups
+WHEN EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id)
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (OLD.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = OLD.user_id;
+END;
+
+CREATE TRIGGER stats_revisions_rollups_v2_insert AFTER INSERT ON session_rollups_v2 BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_rollups_v2_update AFTER UPDATE ON session_rollups_v2 BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_rollups_v2_delete AFTER DELETE ON session_rollups_v2
+WHEN EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id)
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (OLD.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = OLD.user_id;
+END;
+
+CREATE TRIGGER stats_revisions_tombstones_insert AFTER INSERT ON session_tombstones BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_tombstones_update AFTER UPDATE ON session_tombstones BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_tombstones_delete AFTER DELETE ON session_tombstones
+WHEN EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id)
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (OLD.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = OLD.user_id;
+END;
+
+CREATE TRIGGER stats_revisions_ops_insert AFTER INSERT ON ops BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_ops_update AFTER UPDATE ON ops BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_ops_delete AFTER DELETE ON ops
+WHEN EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id)
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (OLD.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = OLD.user_id;
+END;
+
+CREATE TRIGGER stats_revisions_works_insert AFTER INSERT ON works BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_works_update AFTER UPDATE ON works BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_works_delete AFTER DELETE ON works
+WHEN EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id)
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (OLD.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = OLD.user_id;
+END;
+
+CREATE TRIGGER stats_revisions_editions_insert AFTER INSERT ON editions BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_editions_update AFTER UPDATE ON editions BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (NEW.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = NEW.user_id;
+END;
+CREATE TRIGGER stats_revisions_editions_delete AFTER DELETE ON editions
+WHEN EXISTS (SELECT 1 FROM users WHERE id = OLD.user_id)
+BEGIN
+    INSERT OR IGNORE INTO stats_revisions (user_id, revision) VALUES (OLD.user_id, 0);
+    UPDATE stats_revisions SET revision = revision + 1 WHERE user_id = OLD.user_id;
+END;
+`
+
 // migrations is append-only: entry n is applied to a database that has
 // applied n-1 of them, so an entry that has shipped is never edited
 // again — the baseline included.
 var migrations = []string{
 	schema, claimRevisions, folderUploads, folderAccess, annotationSync,
-	folderBackfill,
+	folderBackfill, statisticsStorage,
 }

--- a/internal/store/sqlite/sessions.go
+++ b/internal/store/sqlite/sessions.go
@@ -89,12 +89,12 @@ func appendSessionsTx(ctx context.Context, tx *sql.Tx, userID string, ss []store
 		}
 		_, err = tx.ExecContext(ctx,
 			`INSERT INTO sessions (user_id, session_id, work_id, edition_sha, device_id,
-			                       started_at, ended_at, start_prog, end_prog, idle_ms,
+			                       started_at, ended_at, start_prog, end_prog, idle_ms, active_ms, reported_pages,
 			                       origin, origin_alias, source_key, received_at)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 			userID, ses.SessionID, ses.WorkID, nullStr(ses.EditionSHA), ses.DeviceID,
 			formatTime(ses.StartedAt), formatTime(ses.EndedAt),
-			ses.StartProg, ses.EndProg, ses.IdleMs,
+			ses.StartProg, ses.EndProg, ses.IdleMs, ses.ActiveMs, ses.ReportedPages,
 			string(ses.Origin), nullStr(ses.OriginAlias), nullStr(ses.SourceKey), now)
 		if err != nil {
 			return inserted, err
@@ -162,19 +162,23 @@ func sameSession(ctx context.Context, tx *sql.Tx, userID string, ses store.Sessi
 		started, ended        string
 		sp, ep                float64
 		idle                  int64
+		active                sql.NullInt64
+		pages                 sql.NullFloat64
 		edSHA, oalias, skey   sql.NullString
 	)
 	err := tx.QueryRowContext(ctx,
 		`SELECT work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key
 		 FROM sessions WHERE user_id = ? AND session_id = ?`, userID, ses.SessionID).
-		Scan(&workID, &edSHA, &devID, &started, &ended, &sp, &ep, &idle, &origin, &oalias, &skey)
+		Scan(&workID, &edSHA, &devID, &started, &ended, &sp, &ep, &idle, &active, &pages, &origin, &oalias, &skey)
 	if err != nil {
 		return false, err
 	}
 	return workID == ses.WorkID && devID == ses.DeviceID &&
 		started == formatTime(ses.StartedAt) && ended == formatTime(ses.EndedAt) &&
 		sp == ses.StartProg && ep == ses.EndProg && idle == ses.IdleMs &&
+		active.Valid == (ses.ActiveMs != nil) && (!active.Valid || active.Int64 == *ses.ActiveMs) &&
+		pages.Valid == (ses.ReportedPages != nil) && (!pages.Valid || pages.Float64 == *ses.ReportedPages) &&
 		origin == string(ses.Origin) &&
 		edSHA.Valid == (ses.EditionSHA != nil) && (!edSHA.Valid || edSHA.String == *ses.EditionSHA) &&
 		oalias.Valid == (ses.OriginAlias != nil) && (!oalias.Valid || oalias.String == *ses.OriginAlias) &&
@@ -184,7 +188,7 @@ func sameSession(ctx context.Context, tx *sql.Tx, userID string, ses store.Sessi
 func (s *Store) SessionsForWork(ctx context.Context, userID, workID string, limit int) ([]store.Session, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 		 FROM sessions WHERE user_id = ? AND work_id = ? ORDER BY started_at DESC LIMIT ?`,
 		userID, workID, limit)
 	if err != nil {
@@ -206,7 +210,7 @@ func (s *Store) SessionsForWork(ctx context.Context, userID, workID string, limi
 func (s *Store) CurrentSessionsForWork(ctx context.Context, userID, workID string, limit int) ([]store.Session, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 		 FROM sessions s WHERE user_id = ? AND work_id = ?
 		   AND (source_key IS NULL OR session_id = (
 		       SELECT ss.session_id FROM session_supersessions ss
@@ -237,7 +241,9 @@ func (s *Store) WorkIDsWithInsights(ctx context.Context, userID string) ([]strin
 		`SELECT work_id FROM sessions WHERE user_id = ?
 		 UNION
 		 SELECT work_id FROM session_rollups WHERE user_id = ?
-		 ORDER BY work_id`, userID, userID)
+		 UNION
+		 SELECT work_id FROM session_rollups_v2 WHERE user_id = ?
+		 ORDER BY work_id`, userID, userID, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -253,13 +259,27 @@ func (s *Store) WorkIDsWithInsights(ctx context.Context, userID string) ([]strin
 	return out, rows.Err()
 }
 
+func scanSessions(rows *sql.Rows) ([]store.Session, error) {
+	var out []store.Session
+	for rows.Next() {
+		ses, err := scanSession(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, ses)
+	}
+	return out, rows.Err()
+}
+
 func scanSession(row interface{ Scan(...any) error }) (store.Session, error) {
 	var ses store.Session
 	var edSHA, oalias, skey sql.NullString
+	var active sql.NullInt64
+	var pages sql.NullFloat64
 	var started, ended, received string
 	err := row.Scan(&ses.UserID, &ses.SessionID, &ses.WorkID, &edSHA, &ses.DeviceID,
 		&started, &ended, &ses.StartProg, &ses.EndProg, &ses.IdleMs,
-		&ses.Origin, &oalias, &skey, &received)
+		&active, &pages, &ses.Origin, &oalias, &skey, &received)
 	if err != nil {
 		return ses, err
 	}
@@ -271,6 +291,12 @@ func scanSession(row interface{ Scan(...any) error }) (store.Session, error) {
 	}
 	if skey.Valid {
 		ses.SourceKey = &skey.String
+	}
+	if active.Valid {
+		ses.ActiveMs = &active.Int64
+	}
+	if pages.Valid {
+		ses.ReportedPages = &pages.Float64
 	}
 	if ses.StartedAt, err = parseTime(started); err != nil {
 		return ses, err
@@ -289,7 +315,7 @@ var _ = errors.Is // keep import used if helpers change
 func (s *Store) SessionsInRange(ctx context.Context, userID string, from, to time.Time) ([]store.Session, error) {
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
-		        start_prog, end_prog, idle_ms, origin, origin_alias, source_key, received_at
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
 		 FROM sessions
 		 WHERE user_id = ? AND ended_at > ? AND started_at < ?
 		   AND (source_key IS NULL OR session_id = (

--- a/internal/store/sqlite/stats.go
+++ b/internal/store/sqlite/stats.go
@@ -1,0 +1,211 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func (s *Store) StatisticsSnapshot(ctx context.Context, userID string, candidateIDs []string) (store.StatsSnapshot, error) {
+	var snap store.StatsSnapshot
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{ReadOnly: true})
+	if err != nil {
+		return snap, err
+	}
+	defer tx.Rollback()
+
+	if err := tx.QueryRowContext(ctx,
+		`SELECT u.timezone, sr.revision
+		   FROM users u JOIN stats_revisions sr ON sr.user_id = u.id
+		  WHERE u.id = ?`, userID).Scan(&snap.Timezone, &snap.Revision); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return snap, store.ErrNotFound
+		}
+		return snap, err
+	}
+
+	rows, err := tx.QueryContext(ctx,
+		`SELECT user_id, session_id, work_id, edition_sha, device_id, started_at, ended_at,
+		        start_prog, end_prog, idle_ms, active_ms, reported_pages, origin, origin_alias, source_key, received_at
+		   FROM sessions s
+		  WHERE user_id = ?
+		    AND (source_key IS NULL OR session_id = (
+		        SELECT ss.session_id FROM session_supersessions ss
+		         WHERE ss.user_id = s.user_id AND ss.source_key = s.source_key
+		         ORDER BY ss.revision DESC LIMIT 1))
+		  ORDER BY started_at, session_id`, userID)
+	if err != nil {
+		return snap, err
+	}
+	snap.Sessions, err = scanSessions(rows)
+	if closeErr := rows.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return snap, err
+	}
+
+	rows, err = tx.QueryContext(ctx,
+		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
+		   FROM session_rollups WHERE user_id = ?
+		  UNION ALL
+		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		   FROM session_rollups_v2 WHERE user_id = ?
+		  ORDER BY day, work_id, attribution_version, timezone`, userID, userID)
+	if err != nil {
+		return snap, err
+	}
+	snap.Rollups, err = scanRollups(rows)
+	if closeErr := rows.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return snap, err
+	}
+
+	rows, err = tx.QueryContext(ctx,
+		`SELECT id, user_id, title, author, pending, created_at
+		   FROM works WHERE user_id = ? ORDER BY id`, userID)
+	if err != nil {
+		return snap, err
+	}
+	for rows.Next() {
+		var w store.Work
+		var pending int
+		var created string
+		if err := rows.Scan(&w.ID, &w.UserID, &w.Title, &w.Author, &pending, &created); err != nil {
+			rows.Close()
+			return snap, err
+		}
+		w.Pending = pending != 0
+		if w.CreatedAt, err = parseTime(created); err != nil {
+			rows.Close()
+			return snap, err
+		}
+		snap.Works = append(snap.Works, w)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return snap, err
+	}
+	if err := rows.Close(); err != nil {
+		return snap, err
+	}
+
+	snap.Positions = make(map[string]store.Op)
+	rows, err = tx.QueryContext(ctx,
+		`SELECT user_id, seq, op_id, work_id, edition_sha, device_id, client_ts,
+		        progression, locator_json, foreign_pos, origin, origin_alias, received_at
+		   FROM (
+		     SELECT user_id, seq, op_id, work_id, edition_sha, device_id, client_ts,
+		            progression, locator_json, foreign_pos, origin, origin_alias, received_at,
+		            row_number() OVER (PARTITION BY work_id ORDER BY seq DESC) AS rn
+		       FROM ops WHERE user_id = ?
+		   ) WHERE rn = 1 ORDER BY work_id`, userID)
+	if err != nil {
+		return snap, err
+	}
+	for rows.Next() {
+		op, err := scanOp(rows)
+		if err != nil {
+			rows.Close()
+			return snap, err
+		}
+		snap.Positions[op.WorkID] = op
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return snap, err
+	}
+	if err := rows.Close(); err != nil {
+		return snap, err
+	}
+
+	snap.Editions = make(map[string]store.Edition)
+	rows, err = tx.QueryContext(ctx,
+		`SELECT user_id, sha256, work_id, page_count, char_count, meta_json
+		   FROM editions WHERE user_id = ? ORDER BY sha256`, userID)
+	if err != nil {
+		return snap, err
+	}
+	for rows.Next() {
+		var e store.Edition
+		if err := rows.Scan(&e.UserID, &e.SHA256, &e.WorkID, &e.PageCount, &e.CharCount, &e.MetaJSON); err != nil {
+			rows.Close()
+			return snap, err
+		}
+		snap.Editions[e.SHA256] = e
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return snap, err
+	}
+	if err := rows.Close(); err != nil {
+		return snap, err
+	}
+
+	snap.Archived = make(map[string]store.ArchivedSession)
+	if err := loadArchivedSnapshot(ctx, tx, userID, candidateIDs, snap.Archived); err != nil {
+		return snap, err
+	}
+	return snap, tx.Commit()
+}
+
+func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []string, out map[string]store.ArchivedSession) error {
+	const chunk = 500
+	for start := 0; start < len(ids); start += chunk {
+		end := start + chunk
+		if end > len(ids) {
+			end = len(ids)
+		}
+		placeholders := strings.TrimRight(strings.Repeat("?,", end-start), ",")
+		args := make([]any, 0, end-start+1)
+		args = append(args, userID)
+		for _, id := range ids[start:end] {
+			args = append(args, id)
+		}
+		rows, err := tx.QueryContext(ctx,
+			`SELECT session_id, fingerprint, work_id, day, timezone, attribution_version, present,
+			        active_seconds, pages, prog_delta, measured_active_seconds, measured_prog_delta
+			   FROM session_tombstones WHERE user_id = ? AND session_id IN (`+placeholders+`)`, args...)
+		if err != nil {
+			return err
+		}
+		for rows.Next() {
+			var id string
+			var a store.ArchivedSession
+			var workID, day, timezone sql.NullString
+			var present int
+			if err := rows.Scan(&id, &a.Fingerprint, &workID, &day, &timezone, &a.AttributionVersion,
+				&present, &a.ActiveSeconds, &a.Pages, &a.ProgDelta, &a.MeasuredActiveSeconds,
+				&a.MeasuredProgDelta); err != nil {
+				rows.Close()
+				return err
+			}
+			if workID.Valid {
+				a.WorkID = workID.String
+			}
+			if day.Valid {
+				a.Day = day.String
+			}
+			if timezone.Valid {
+				a.Timezone = timezone.String
+			}
+			a.Present = present != 0
+			out[id] = a
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/store/sqlite/works.go
+++ b/internal/store/sqlite/works.go
@@ -350,8 +350,9 @@ func (s *Store) SplitWork(ctx context.Context, userID, workID, editionSHA string
 	}
 	var rollupCount int
 	if err := tx.QueryRowContext(ctx,
-		`SELECT COUNT(1) FROM session_rollups WHERE user_id = ? AND work_id = ?`,
-		userID, workID).Scan(&rollupCount); err != nil {
+		`SELECT (SELECT COUNT(1) FROM session_rollups WHERE user_id = ? AND work_id = ?) +
+		        (SELECT COUNT(1) FROM session_rollups_v2 WHERE user_id = ? AND work_id = ?)`,
+		userID, workID, userID, workID).Scan(&rollupCount); err != nil {
 		return err
 	}
 	if rollupCount > 0 {
@@ -495,8 +496,9 @@ func (s *Store) MergeWorks(ctx context.Context, userID, fromWorkID, intoWorkID s
 	}
 	var rollupCount int
 	if err := tx.QueryRowContext(ctx,
-		`SELECT COUNT(1) FROM session_rollups WHERE user_id = ? AND work_id = ?`,
-		userID, fromWorkID).Scan(&rollupCount); err != nil {
+		`SELECT (SELECT COUNT(1) FROM session_rollups WHERE user_id = ? AND work_id = ?) +
+		        (SELECT COUNT(1) FROM session_rollups_v2 WHERE user_id = ? AND work_id = ?)`,
+		userID, fromWorkID, userID, fromWorkID).Scan(&rollupCount); err != nil {
 		return err
 	}
 	if rollupCount > 0 {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1071,20 +1071,22 @@ type Op struct {
 
 // Session is one reading session fact.
 type Session struct {
-	UserID      string
-	SessionID   string
-	WorkID      string
-	EditionSHA  *string
-	DeviceID    string
-	StartedAt   time.Time
-	EndedAt     time.Time
-	StartProg   float64
-	EndProg     float64
-	IdleMs      int64
-	Origin      Origin
-	OriginAlias *string
-	SourceKey   *string // koplugin legacy upsert key
-	ReceivedAt  time.Time
+	UserID        string
+	SessionID     string
+	WorkID        string
+	EditionSHA    *string
+	DeviceID      string
+	StartedAt     time.Time
+	EndedAt       time.Time
+	StartProg     float64
+	EndProg       float64
+	IdleMs        int64
+	ActiveMs      *int64
+	ReportedPages *float64
+	Origin        Origin
+	OriginAlias   *string
+	SourceKey     *string // koplugin legacy upsert key
+	ReceivedAt    time.Time
 }
 
 // SessionFingerprint identifies the immutable client payload. It is
@@ -1111,6 +1113,16 @@ func SessionFingerprint(s Session) string {
 		s.WorkID, edition, s.DeviceID, s.StartedAt.UTC().Truncate(time.Microsecond).Format(time.RFC3339Nano),
 		s.EndedAt.UTC().Truncate(time.Microsecond).Format(time.RFC3339Nano), s.SessionID, s.StartProg, s.EndProg,
 		s.IdleMs, s.Origin, alias, source)
+	if s.ActiveMs != nil || s.ReportedPages != nil {
+		active, pages := "", ""
+		if s.ActiveMs != nil {
+			active = fmt.Sprintf("%d", *s.ActiveMs)
+		}
+		if s.ReportedPages != nil {
+			pages = fmt.Sprintf("%.17g", *s.ReportedPages)
+		}
+		raw += fmt.Sprintf("\x00v2\x00%s\x00%s", active, pages)
+	}
 	sum := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(sum[:])
 }
@@ -1121,16 +1133,47 @@ func SessionFingerprint(s Session) string {
 // timezone at rollup time and are not re-bucketed if the user later
 // changes timezone.
 type SessionRollup struct {
-	UserID        string
-	WorkID        string
-	Day           string // YYYY-MM-DD
-	ActiveSeconds float64
-	Pages         float64
-	ProgDelta     float64
-	SessionCount  int64
+	UserID                string
+	WorkID                string
+	Day                   string // YYYY-MM-DD
+	ActiveSeconds         float64
+	Pages                 float64
+	ProgDelta             float64
+	SessionCount          int64
+	Timezone              string
+	AttributionVersion    int
+	MeasuredActiveSeconds float64
+	MeasuredProgDelta     float64
 }
 
 // OpResult is the per-item outcome of a batch push.
+// ArchivedSession is retained contribution proof for a compacted session.
+type ArchivedSession struct {
+	Fingerprint           string
+	WorkID                string
+	Day                   string
+	Timezone              string
+	AttributionVersion    int
+	Present               bool
+	ActiveSeconds         float64
+	Pages                 float64
+	ProgDelta             float64
+	MeasuredActiveSeconds float64
+	MeasuredProgDelta     float64
+}
+
+// StatsSnapshot is the coherent store input for statistics aggregation.
+type StatsSnapshot struct {
+	Timezone  string
+	Revision  int64
+	Sessions  []Session
+	Rollups   []SessionRollup
+	Works     []Work
+	Positions map[string]Op
+	Editions  map[string]Edition
+	Archived  map[string]ArchivedSession
+}
+
 type OpResult struct {
 	OpID   string
 	Status string // "applied" | "duplicate" | "conflict" | "invalid"
@@ -1823,6 +1866,7 @@ type Store interface {
 	CurrentSessionsForWork(ctx context.Context, userID, workID string, limit int) ([]Session, error)
 	WorkIDsWithInsights(ctx context.Context, userID string) ([]string, error)
 	EditionBySHA(ctx context.Context, userID, sha256 string) (Edition, error)
+	StatisticsSnapshot(ctx context.Context, userID string, candidateIDs []string) (StatsSnapshot, error)
 
 	// Session rollups (retention). SessionsEndedBefore feeds the rollup
 	// job; ApplyRollups additively upserts daily aggregates and deletes

--- a/internal/store/storetest/rollups.go
+++ b/internal/store/storetest/rollups.go
@@ -1,0 +1,187 @@
+package storetest
+
+import (
+	"errors"
+	"math"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// RollupsRejectStaleEditionPageCount needs a backend-specific metadata write:
+// the public store API currently registers editions without updating them.
+func RollupsRejectStaleEditionPageCount(t *testing.T, s store.Store, updatePages func(string, string, *int64) error) {
+	ctx := t.Context()
+	user := MkUser(t, s, "stale-edition")
+	work := MkWork(t, s, user, "stale-edition-work", "stale-edition-sha")
+	now := time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name       string
+		old, fresh *int64
+	}{
+		{"changed-page-count", Ptr(int64(100)), Ptr(int64(200))},
+		{"previously-unknown-page-count", nil, Ptr(int64(200))},
+		{"now-unknown-page-count", Ptr(int64(100)), nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := updatePages(user.ID, "stale-edition-sha", tc.old); err != nil {
+				t.Fatal(err)
+			}
+			sessions := []store.Session{
+				{
+					SessionID: tc.name + "-native", WorkID: work.ID, EditionSHA: Ptr("stale-edition-sha"),
+					DeviceID: "reader", StartedAt: now, EndedAt: now.Add(10 * time.Minute),
+					StartProg: 0, EndProg: 0.25, ActiveMs: Ptr(int64(300000)), Origin: store.OriginNative,
+				},
+				{
+					SessionID: tc.name + "-inferred", WorkID: work.ID, EditionSHA: Ptr("stale-edition-sha"),
+					DeviceID: "reader", StartedAt: now, EndedAt: now.Add(10 * time.Minute),
+					StartProg: 0.25, EndProg: 0.375, Origin: store.OriginInferred,
+				},
+				{
+					SessionID: tc.name + "-reported", WorkID: work.ID, EditionSHA: Ptr("stale-edition-sha"),
+					DeviceID: "reader", StartedAt: now, EndedAt: now.Add(time.Minute),
+					StartProg: 0.375, EndProg: 0.625, ReportedPages: Ptr(12.5), Origin: store.OriginNative,
+				},
+			}
+			if err := s.AppendSessions(ctx, user.ID, sessions); err != nil {
+				t.Fatal(err)
+			}
+			ids := []string{sessions[0].SessionID, sessions[1].SessionID, sessions[2].SessionID}
+			before, err := s.StatisticsSnapshot(ctx, user.ID, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+			edition := before.Editions["stale-edition-sha"]
+			pages := 12.5
+			if edition.PageCount != nil {
+				pages += 0.375 * float64(*edition.PageCount)
+			}
+			rollup := store.SessionRollup{
+				UserID: user.ID, WorkID: work.ID, Day: now.Format("2006-01-02"), Timezone: "UTC",
+				AttributionVersion: 2, ActiveSeconds: 960, Pages: pages, ProgDelta: 0.625,
+				SessionCount: 3, MeasuredActiveSeconds: 360, MeasuredProgDelta: 0.5,
+			}
+			if err := updatePages(user.ID, edition.SHA256, tc.fresh); err != nil {
+				t.Fatal(err)
+			}
+			if err := s.ApplyRollups(ctx, user.ID, []store.SessionRollup{rollup}, sessions); !errors.Is(err, store.ErrConflict) {
+				t.Fatalf("stale edition must refuse compaction, got %v", err)
+			}
+			after, err := s.StatisticsSnapshot(ctx, user.ID, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(after.Sessions) != 3 || !reflect.DeepEqual(after.Rollups, before.Rollups) || len(after.Archived) != 0 {
+				t.Fatalf("refused compaction changed history: %+v", after)
+			}
+
+			rollup.Pages = 12.5
+			if tc.fresh != nil {
+				rollup.Pages += 0.375 * float64(*tc.fresh)
+			}
+			if err := s.ApplyRollups(ctx, user.ID, []store.SessionRollup{rollup}, sessions); err != nil {
+				t.Fatalf("fresh metadata retry: %v", err)
+			}
+			after, err = s.StatisticsSnapshot(ctx, user.ID, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(after.Sessions) != 0 || len(after.Archived) != 3 || len(after.Rollups) != len(before.Rollups)+1 {
+				t.Fatalf("successful retry lost archive proofs: %+v", after)
+			}
+			var proofs []store.ArchivedSession
+			for _, ses := range sessions {
+				proof := after.Archived[ses.SessionID]
+				if !proof.Present || proof.Fingerprint != store.SessionFingerprint(ses) {
+					t.Fatalf("invalid archive proof for %s: %+v", ses.SessionID, proof)
+				}
+				proofs = append(proofs, proof)
+			}
+			if err := store.ValidateRollupContributions([]store.SessionRollup{rollup}, proofs); err != nil {
+				t.Fatalf("fresh bucket differs from archived contributions: %v", err)
+			}
+			got := after.Rollups[len(after.Rollups)-1]
+			if got != rollup {
+				t.Fatalf("fresh bucket: got %+v, want %+v", got, rollup)
+			}
+			now = now.Add(24 * time.Hour)
+		})
+	}
+}
+
+func testV2RollupsRejectMismatchedContributions(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := t.Context()
+	user := MkUser(t, s, "rollup-contributions")
+	work := MkWork(t, s, user, "contribution-work", "contribution-sha")
+	now := time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
+	ses := store.Session{
+		SessionID: "contribution-session", WorkID: work.ID, DeviceID: "reader",
+		StartedAt: now, EndedAt: now.Add(10001 * time.Microsecond), IdleMs: 1,
+		StartProg: 0, EndProg: 0.25, ReportedPages: Ptr(12.5), Origin: store.OriginNative,
+	}
+	if err := s.AppendSessions(ctx, user.ID, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	active := ses.EndedAt.Sub(ses.StartedAt).Seconds() - float64(ses.IdleMs)/1000
+	rollup := store.SessionRollup{
+		UserID: user.ID, WorkID: work.ID, Day: "2026-09-04", Timezone: "UTC", AttributionVersion: 2,
+		ActiveSeconds: active, Pages: 12.5, ProgDelta: 0.25, SessionCount: 1,
+		MeasuredActiveSeconds: active, MeasuredProgDelta: 0.25,
+	}
+	for _, tc := range []struct {
+		name   string
+		change func(*store.SessionRollup)
+	}{
+		{"active-seconds", func(r *store.SessionRollup) { r.ActiveSeconds++ }},
+		{"pages", func(r *store.SessionRollup) { r.Pages++ }},
+		{"progression", func(r *store.SessionRollup) { r.ProgDelta++ }},
+		{"session-count", func(r *store.SessionRollup) { r.SessionCount++ }},
+		{"measured-active-seconds", func(r *store.SessionRollup) { r.MeasuredActiveSeconds++ }},
+		{"measured-progression", func(r *store.SessionRollup) { r.MeasuredProgDelta++ }},
+		{"work", func(r *store.SessionRollup) { r.WorkID = "other-work" }},
+		{"day", func(r *store.SessionRollup) { r.Day = "2026-09-03" }},
+		{"nonfinite-pages", func(r *store.SessionRollup) { r.Pages = math.Inf(1) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			changed := rollup
+			tc.change(&changed)
+			if err := s.ApplyRollups(ctx, user.ID, []store.SessionRollup{changed}, []store.Session{ses}); !errors.Is(err, store.ErrConflict) {
+				t.Fatalf("mismatched bucket must conflict, got %v", err)
+			}
+		})
+	}
+	for _, tc := range []struct {
+		name    string
+		rollups []store.SessionRollup
+	}{
+		{"duplicate-bucket", []store.SessionRollup{rollup, rollup}},
+		{"unbacked-bucket", []store.SessionRollup{rollup, {
+			UserID: user.ID, WorkID: work.ID, Day: "2026-09-05", Timezone: "UTC",
+			AttributionVersion: 2, SessionCount: 1,
+		}}},
+		{"unbacked-timezone", []store.SessionRollup{rollup, {
+			UserID: user.ID, WorkID: work.ID, Day: rollup.Day, Timezone: "Europe/Paris",
+			AttributionVersion: 2, SessionCount: 1,
+		}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := s.ApplyRollups(ctx, user.ID, tc.rollups, []store.Session{ses}); !errors.Is(err, store.ErrConflict) {
+				t.Fatalf("unbacked bucket must conflict, got %v", err)
+			}
+		})
+	}
+	before, err := s.StatisticsSnapshot(ctx, user.ID, []string{ses.SessionID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(before.Sessions) != 1 || len(before.Rollups) != 0 || len(before.Archived) != 0 {
+		t.Fatalf("refused compaction changed history: %+v", before)
+	}
+	if err := s.ApplyRollups(ctx, user.ID, []store.SessionRollup{rollup}, []store.Session{ses}); err != nil {
+		t.Fatalf("matching contributions must compact: %v", err)
+	}
+}

--- a/internal/store/storetest/statistics.go
+++ b/internal/store/storetest/statistics.go
@@ -1,0 +1,130 @@
+package storetest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func testStatisticsStorage(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "stats")
+	w := MkWork(t, s, u, "w-stats", "stats-sha")
+	start := time.Date(2026, 9, 4, 22, 30, 0, 0, time.UTC)
+	active := int64(30 * 60 * 1000)
+	reported := 12.5
+	ses := store.Session{
+		SessionID: "stats-s1", WorkID: w.ID, EditionSHA: Ptr("stats-sha"), DeviceID: "d1",
+		StartedAt: start, EndedAt: start.Add(10 * time.Minute), StartProg: 0.10, EndProg: 0.20,
+		IdleMs: 1000, ActiveMs: &active, ReportedPages: &reported, Origin: store.OriginNative,
+	}
+	legacy := ses
+	legacy.SessionID = "stats-legacy"
+	legacy.ActiveMs = nil
+	legacy.ReportedPages = nil
+	if store.SessionFingerprint(legacy) != legacyFingerprint(legacy) {
+		t.Fatalf("legacy fingerprint bytes changed")
+	}
+	withoutReported := ses
+	withoutReported.ReportedPages = nil
+	if store.SessionFingerprint(ses) == store.SessionFingerprint(withoutReported) || store.SessionFingerprint(ses) == store.SessionFingerprint(legacy) {
+		t.Fatalf("optional session fields are not part of the v2 fingerprint")
+	}
+
+	if err := s.AppendSessions(ctx, u.ID, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AppendSessions(ctx, u.ID, []store.Session{ses}); err != nil {
+		t.Fatalf("v2 duplicate was not idempotent: %v", err)
+	}
+	changed := ses
+	changed.ReportedPages = Ptr(13.0)
+	if err := s.AppendSessions(ctx, u.ID, []store.Session{changed}); !errors.Is(err, store.ErrIDMismatch) {
+		t.Fatalf("changed optional metadata: want ErrIDMismatch, got %v", err)
+	}
+
+	snap, err := s.StatisticsSnapshot(ctx, u.ID, []string{"stats-s1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Timezone != u.Timezone || snap.Revision == 0 || len(snap.Sessions) != 1 {
+		t.Fatalf("bad initial snapshot: %+v", snap)
+	}
+	if snap.Sessions[0].ActiveMs == nil || *snap.Sessions[0].ActiveMs != active || snap.Sessions[0].ReportedPages == nil || *snap.Sessions[0].ReportedPages != reported {
+		t.Fatalf("snapshot lost optional session fields: %+v", snap.Sessions[0])
+	}
+	if _, ok := snap.Editions["stats-sha"]; !ok {
+		t.Fatalf("snapshot did not batch editions: %+v", snap.Editions)
+	}
+
+	day := ses.EndedAt.In(time.FixedZone("CEST", 2*60*60)).Format("2006-01-02")
+	ru := store.SessionRollup{
+		UserID: u.ID, WorkID: w.ID, Day: day, Timezone: "Europe/Paris", AttributionVersion: 2,
+		ActiveSeconds: 1800, Pages: reported, ProgDelta: 0.10, SessionCount: 1,
+		MeasuredActiveSeconds: 1800, MeasuredProgDelta: 0.10,
+	}
+	if err := s.ApplyRollups(ctx, u.ID, []store.SessionRollup{ru}, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	snap, err = s.StatisticsSnapshot(ctx, u.ID, []string{"stats-s1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Sessions) != 0 || len(snap.Rollups) != 1 || snap.Rollups[0].AttributionVersion != 2 || snap.Rollups[0].Timezone != "Europe/Paris" {
+		t.Fatalf("snapshot did not expose v2 rollup only: %+v", snap)
+	}
+	arch, ok := snap.Archived["stats-s1"]
+	if !ok || !arch.Present || arch.Fingerprint != store.SessionFingerprint(ses) || arch.WorkID != w.ID || arch.Day != day || arch.Timezone != "Europe/Paris" || arch.AttributionVersion != 2 {
+		t.Fatalf("missing archived proof: %#v present=%v", arch, ok)
+	}
+	if arch.ActiveSeconds != 1800 || arch.Pages != reported || arch.ProgDelta != 0.10 || arch.MeasuredActiveSeconds != 1800 || arch.MeasuredProgDelta != 0.10 {
+		t.Fatalf("bad archived contribution: %#v", arch)
+	}
+	ids, err := s.WorkIDsWithInsights(ctx, u.ID)
+	if err != nil || len(ids) != 1 || ids[0] != w.ID {
+		t.Fatalf("v2 work insight ids: %+v %v", ids, err)
+	}
+	if err := s.SplitWork(ctx, u.ID, w.ID, "stats-sha", nil, store.Work{ID: "w-split", UserID: u.ID, CreatedAt: time.Now()}); err != store.ErrConflict {
+		t.Fatalf("split with v2 rollup: want ErrConflict, got %v", err)
+	}
+	if err := s.DeleteWork(ctx, u.ID, w.ID); err != nil {
+		t.Fatal(err)
+	}
+	snap, err = s.StatisticsSnapshot(ctx, u.ID, []string{"stats-s1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if arch := snap.Archived["stats-s1"]; arch.Present || arch.Fingerprint != store.SessionFingerprint(ses) || arch.WorkID != w.ID {
+		t.Fatalf("work deletion did not retain absent proof: %#v", arch)
+	}
+}
+
+func legacyFingerprint(s store.Session) string {
+	edition, alias, source := "", "", ""
+	if s.EditionSHA != nil {
+		edition = *s.EditionSHA
+	}
+	if s.OriginAlias != nil {
+		alias = *s.OriginAlias
+	}
+	if s.SourceKey != nil {
+		source = *s.SourceKey
+	}
+	if s.Origin == store.OriginInferred {
+		alias = ""
+		source = ""
+	}
+	raw := fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%s\x00%s\x00%.17g\x00%.17g\x00%d\x00%s\x00%s\x00%s",
+		s.WorkID, edition, s.DeviceID, s.StartedAt.UTC().Truncate(time.Microsecond).Format(time.RFC3339Nano),
+		s.EndedAt.UTC().Truncate(time.Microsecond).Format(time.RFC3339Nano), s.SessionID, s.StartProg, s.EndProg,
+		s.IdleMs, s.Origin, alias, source)
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/store/storetest/statistics_regressions.go
+++ b/internal/store/storetest/statistics_regressions.go
@@ -1,0 +1,154 @@
+package storetest
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func testSessionRangeAndCompactionReadsPreserveOptionalMeasurements(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	user := MkUser(t, s, "session-measurements")
+	work := MkWork(t, s, user, "measured-work", "measured-sha")
+	start := time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name   string
+		active *int64
+		pages  *float64
+	}{
+		{name: "legacy-null"},
+		{name: "explicit-zero", active: Ptr(int64(0)), pages: Ptr(0.0)},
+		{name: "active-only", active: Ptr(int64(123456))},
+		{name: "pages-only", pages: Ptr(12.5)},
+		{name: "both-measured", active: Ptr(int64(234567)), pages: Ptr(23.75)},
+	}
+	var sessions []store.Session
+	for i, tc := range cases {
+		at := start.Add(time.Duration(i) * time.Hour)
+		sessions = append(sessions, store.Session{
+			SessionID: tc.name, WorkID: work.ID, EditionSHA: Ptr("measured-sha"), DeviceID: "reader",
+			StartedAt: at, EndedAt: at.Add(10 * time.Minute), StartProg: 0.25, EndProg: 0.5,
+			IdleMs: 1000, ActiveMs: tc.active, ReportedPages: tc.pages,
+			Origin: store.OriginNative, OriginAlias: Ptr("sha256:measured-sha"),
+		})
+	}
+	if err := s.AppendSessions(ctx, user.ID, sessions); err != nil {
+		t.Fatal(err)
+	}
+	until := start.Add(24 * time.Hour)
+	for _, read := range []struct {
+		name string
+		run  func() ([]store.Session, error)
+	}{
+		{"SessionsInRange", func() ([]store.Session, error) {
+			return s.SessionsInRange(ctx, user.ID, start, until)
+		}},
+		{"SessionsEndedBefore", func() ([]store.Session, error) {
+			return s.SessionsEndedBefore(ctx, user.ID, until)
+		}},
+	} {
+		t.Run(read.name, func(t *testing.T) {
+			got, err := read.run()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(got) != len(sessions) {
+				t.Fatalf("want %d sessions, got %d", len(sessions), len(got))
+			}
+			for i, want := range sessions {
+				if !reflect.DeepEqual(got[i].ActiveMs, want.ActiveMs) ||
+					!reflect.DeepEqual(got[i].ReportedPages, want.ReportedPages) ||
+					store.SessionFingerprint(got[i]) != store.SessionFingerprint(want) {
+					t.Errorf("%s: session payload changed: got %+v, want %+v", want.SessionID, got[i], want)
+				}
+				if got[i].UserID != user.ID || got[i].ReceivedAt.IsZero() {
+					t.Errorf("%s: missing stored session metadata: %+v", want.SessionID, got[i])
+				}
+			}
+		})
+	}
+}
+
+func testReconcileCalibrePreservesV2RollupHistoryAndArchiveProof(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	user := MkUser(t, s, "calibre-v2-history")
+	folder := MkFolder(t, s, "calibre-v2-history", store.FolderCalibre)
+	now := time.Date(2026, 9, 4, 10, 0, 0, 0, time.UTC)
+	observed := []store.ObservedBook{{
+		CalibreID: Ptr(int64(1)), RelativePath: "Kept (1)/book.epub", SizeBytes: 1,
+		MTime: now, ContentSHA256: "kept-sha", Title: "Kept",
+	}}
+	doReconcile(t, s, folder.ID, observed, true, now)
+	work := MkWork(t, s, user, "unmapped-history", "history-sha")
+	ses := store.Session{
+		SessionID: "archived-history", WorkID: work.ID, EditionSHA: Ptr("history-sha"), DeviceID: "reader",
+		StartedAt: now, EndedAt: now.Add(10 * time.Minute), StartProg: 0.25, EndProg: 0.5,
+		ActiveMs: Ptr(int64(300000)), ReportedPages: Ptr(12.5), Origin: store.OriginNative,
+	}
+	if err := s.AppendSessions(ctx, user.ID, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	doReconcile(t, s, folder.ID, observed, true, now.Add(time.Hour))
+	if _, err := s.WorkByID(ctx, user.ID, work.ID); err != nil {
+		t.Fatalf("unmapped work with raw history was collected: %v", err)
+	}
+	rollup := store.SessionRollup{
+		UserID: user.ID, WorkID: work.ID, Day: "2026-09-04", Timezone: "Europe/Paris",
+		AttributionVersion: 2, ActiveSeconds: 300, Pages: 12.5, ProgDelta: 0.25,
+		SessionCount: 1, MeasuredActiveSeconds: 300, MeasuredProgDelta: 0.25,
+	}
+	if err := s.ApplyRollups(ctx, user.ID, []store.SessionRollup{rollup}, []store.Session{ses}); err != nil {
+		t.Fatal(err)
+	}
+	wantProof := store.ArchivedSession{
+		Fingerprint: store.SessionFingerprint(ses), WorkID: work.ID, Day: rollup.Day,
+		Timezone: rollup.Timezone, AttributionVersion: 2, Present: true,
+		ActiveSeconds: 300, Pages: 12.5, ProgDelta: 0.25,
+		MeasuredActiveSeconds: 300, MeasuredProgDelta: 0.25,
+	}
+	assertHistory := func() {
+		t.Helper()
+		snap, err := s.StatisticsSnapshot(ctx, user.ID, []string{ses.SessionID})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(snap.Sessions) != 0 || len(snap.Rollups) != 1 || snap.Rollups[0] != rollup {
+			t.Fatalf("want only the intact v2 rollup, got raw=%+v rollups=%+v", snap.Sessions, snap.Rollups)
+		}
+		if proof, ok := snap.Archived[ses.SessionID]; !ok || proof != wantProof {
+			t.Fatalf("archive proof changed: got %+v (exists=%v), want %+v", proof, ok, wantProof)
+		}
+		if _, err := s.WorkByID(ctx, user.ID, work.ID); err != nil {
+			t.Fatalf("unmapped work with v2 history was collected: %v", err)
+		}
+	}
+	assertHistory()
+
+	// The guard must match both the reader and the work, not protect all
+	// empty works whenever any reader has a v2 rollup.
+	empty := MkWork(t, s, user, "empty-work", "empty-sha")
+	other := MkUser(t, s, "calibre-v2-other-reader")
+	MkWork(t, s, other, work.ID, "other-sha")
+	result := doReconcile(t, s, folder.ID, observed, true, now.Add(2*time.Hour))
+	if result.Purged != 0 {
+		t.Fatalf("cleanup-only pass unexpectedly purged a book: %+v", result)
+	}
+	for _, orphan := range []struct{ userID, workID string }{
+		{user.ID, empty.ID}, {other.ID, work.ID},
+	} {
+		if _, err := s.WorkByID(ctx, orphan.userID, orphan.workID); !errors.Is(err, store.ErrNotFound) {
+			t.Errorf("empty work %s/%s was not collected: %v", orphan.userID, orphan.workID, err)
+		}
+	}
+	assertHistory()
+	if err := s.AppendSessions(ctx, user.ID, []store.Session{ses}); err != nil {
+		t.Fatalf("archived replay after reconciliation: %v", err)
+	}
+	assertHistory()
+}

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -200,6 +200,9 @@ func Run(t *testing.T, open OpenFunc) {
 	t.Run("ReconcileCalibreCollectsExistingEmptyWorks", func(t *testing.T) {
 		testReconcileCalibreCollectsExistingEmptyWorks(t, open)
 	})
+	t.Run("ReconcileCalibrePreservesV2RollupHistoryAndArchiveProof", func(t *testing.T) {
+		testReconcileCalibrePreservesV2RollupHistoryAndArchiveProof(t, open)
+	})
 	t.Run("ReconcilePlainFolderNeverPurges", func(t *testing.T) {
 		testReconcilePlainFolderNeverPurges(t, open)
 	})
@@ -239,7 +242,14 @@ func Run(t *testing.T, open OpenFunc) {
 	t.Run("ChangesIsASnapshot", func(t *testing.T) { testChangesIsASnapshot(t, open) })
 	t.Run("SplitAndMerge", func(t *testing.T) { testSplitAndMerge(t, open) })
 	t.Run("SessionsAppendOnly", func(t *testing.T) { testSessionsAppendOnly(t, open) })
+	t.Run("SessionRangeAndCompactionReadsPreserveOptionalMeasurements", func(t *testing.T) {
+		testSessionRangeAndCompactionReadsPreserveOptionalMeasurements(t, open)
+	})
 	t.Run("SessionRollups", func(t *testing.T) { testSessionRollups(t, open) })
+	t.Run("StatisticsStorage", func(t *testing.T) { testStatisticsStorage(t, open) })
+	t.Run("V2RollupsRejectMismatchedContributions", func(t *testing.T) {
+		testV2RollupsRejectMismatchedContributions(t, open)
+	})
 	t.Run("Housekeeping", func(t *testing.T) { testHousekeeping(t, open) })
 	t.Run("ConcurrentAppendGapFreeSeq", func(t *testing.T) { testConcurrentAppend(t, open) })
 	t.Run("AnnotationPushIdempotencyAndRevConflict", func(t *testing.T) {

--- a/internal/webui/dashboardchart.go
+++ b/internal/webui/dashboardchart.go
@@ -1,12 +1,10 @@
 package webui
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	"github.com/chmouel/liseur-sync/internal/insights"
-	"github.com/chmouel/liseur-sync/internal/store"
 )
 
 // Laying out the dashboard's two charts.
@@ -221,41 +219,4 @@ func chartLabel(days []DayCell) string {
 	}
 	return fmt.Sprintf("daily reading minutes, %s to %s: %s minutes over %d days with reading",
 		days[0].Date, days[len(days)-1].Date, f0(total), active)
-}
-
-// pageCounter turns a sitting's progress into a number of pages.
-//
-// The same arithmetic the API and the per-work page do: how far through
-// the book the reader got, times how many pages the edition has. It is
-// an approximation and says so, but a page count is what a reader
-// recognises and a progression fraction is not.
-//
-// The editions are remembered for the length of one request because a
-// dashboard is a few books read many times over: without the map, a
-// year of reading is a year of lookups for the same handful of rows.
-type pageCounter struct {
-	st       store.Store
-	editions map[string]*int64
-}
-
-func newPageCounter(st store.Store) *pageCounter {
-	return &pageCounter{st: st, editions: map[string]*int64{}}
-}
-
-func (p *pageCounter) of(ctx context.Context, ses store.Session) float64 {
-	delta := ses.EndProg - ses.StartProg
-	if delta <= 0 || ses.EditionSHA == nil {
-		return 0
-	}
-	count, seen := p.editions[*ses.EditionSHA]
-	if !seen {
-		if ed, err := p.st.EditionBySHA(ctx, ses.UserID, *ses.EditionSHA); err == nil {
-			count = ed.PageCount
-		}
-		p.editions[*ses.EditionSHA] = count
-	}
-	if count == nil {
-		return 0
-	}
-	return delta * float64(*count)
 }

--- a/internal/webui/dashboardspan_ext_test.go
+++ b/internal/webui/dashboardspan_ext_test.go
@@ -1,8 +1,12 @@
 package webui
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -260,6 +264,7 @@ func TestWorkCountsRollupsOnce(t *testing.T) {
 		at := base.Add(time.Duration(i) * time.Hour)
 		seedSession(t, st, "recent-"+string(rune('a'+i)), ed, at, at.Add(10*time.Minute))
 	}
+
 	// And an hour of reading from before the compaction cut-off.
 	err := st.ApplyRollups(t.Context(), "u1", []store.SessionRollup{{
 		UserID: "u1", WorkID: ed.WorkID, Day: "2024-01-01",
@@ -277,6 +282,130 @@ func TestWorkCountsRollupsOnce(t *testing.T) {
 	// Three sittings plus the two the rollup stands for.
 	if !strings.Contains(body, ">5<") {
 		t.Error("sessions are not 3 raw + 2 rolled up, counted once")
+	}
+}
+
+func TestWorkSessionsAreNewestFirst(t *testing.T) {
+	ts, st := testServer(t)
+	cookie := loginCookie(t, ts)
+	ed := seedWork(t, st, "ordered", "Two sittings")
+	old := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	newer := old.Add(time.Hour)
+	seedSession(t, st, "old", ed, old, old.Add(10*time.Minute))
+	seedSession(t, st, "new", ed, newer, newer.Add(10*time.Minute))
+	_, body := page(t, ts, cookie, "/ui/works/"+ed.WorkID)
+	oldIndex, newIndex := strings.Index(body, "Aug 1 09:00"), strings.Index(body, "Aug 1 10:00")
+	if oldIndex < 0 || newIndex < 0 || newIndex >= oldIndex {
+		t.Fatal("the recent session log did not put the newest sitting first")
+	}
+}
+
+func TestWorkTotalsIncludeAllSessions(t *testing.T) {
+	ts, st := testServer(t)
+	cookie := loginCookie(t, ts)
+	ed := seedWork(t, st, "many-sittings", "Many short sittings")
+	base := time.Date(2026, 8, 1, 9, 0, 0, 0, time.UTC)
+	sessions := make([]store.Session, 10_001)
+	for i := range sessions {
+		at := base.Add(time.Duration(i) * time.Minute)
+		sessions[i] = store.Session{
+			SessionID: fmt.Sprintf("s-%d", i), WorkID: ed.WorkID, DeviceID: "reader",
+			StartedAt: at, EndedAt: at.Add(time.Minute), Origin: store.OriginNative,
+		}
+	}
+	if err := st.AppendSessions(t.Context(), "u1", sessions); err != nil {
+		t.Fatal(err)
+	}
+	_, body := page(t, ts, cookie, "/ui/works/"+ed.WorkID)
+	if !strings.Contains(body, ">10001<") {
+		t.Fatal("the work total was truncated to the session log's limit")
+	}
+}
+
+type failedStatsStore struct {
+	store.Store
+}
+
+func (*failedStatsStore) StatisticsSnapshot(context.Context, string, []string) (store.StatsSnapshot, error) {
+	return store.StatsSnapshot{}, errors.New("statistics read failed")
+}
+
+func TestDashboardAndWorkRefusePartialStatistics(t *testing.T) {
+	s := &Server{St: &failedStatsStore{}}
+	for _, path := range []string{"/ui", "/ui/works/w"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.SetPathValue("id", "w")
+		w := httptest.NewRecorder()
+		if path == "/ui" {
+			s.handleDashboard(w, req, store.AuthSession{}, &store.User{ID: "u1"})
+		} else {
+			s.handleWork(w, req, store.AuthSession{}, &store.User{ID: "u1"})
+		}
+		if w.Code != http.StatusInternalServerError {
+			t.Fatalf("%s: got %d, want an explicit failure", path, w.Code)
+		}
+	}
+}
+
+type dashboardLinksStore struct {
+	store.Store
+	lookups []string
+	err     error
+}
+
+func (s *dashboardLinksStore) WorkBookIDs(_ context.Context, _, workID string) ([]string, error) {
+	s.lookups = append(s.lookups, workID)
+	return nil, s.err
+}
+
+func TestDashboardResolvesOnlyDisplayedWorks(t *testing.T) {
+	works := make([]store.WorkSummary, 100)
+	progression := 0.5
+	for i := range works {
+		at := time.Now().Add(-time.Duration(i) * time.Hour)
+		works[i] = store.WorkSummary{
+			Work:        store.Work{ID: fmt.Sprintf("w-%d", i)},
+			Progression: &progression, LastActive: &at,
+		}
+	}
+	st := &dashboardLinksStore{}
+	s := &Server{St: st}
+	rows, err := s.linkReadingWorks(httptest.NewRequest(http.MethodGet, "/ui", nil), "u1",
+		continueReading(works, nil, time.UTC))
+	if err != nil || len(rows) != continueReadingLimit || len(st.lookups) != continueReadingLimit {
+		t.Fatalf("rows=%d lookups=%d err=%v", len(rows), len(st.lookups), err)
+	}
+	for i, id := range st.lookups {
+		if id != fmt.Sprintf("w-%d", i) {
+			t.Fatalf("resolved an undisplayed work: %s", id)
+		}
+	}
+}
+
+func TestDashboardLinkErrorsPropagate(t *testing.T) {
+	failed := errors.New("store unavailable")
+	s := &Server{St: &dashboardLinksStore{err: failed}}
+	if _, err := s.linkReadingWorks(httptest.NewRequest(http.MethodGet, "/ui", nil), "u1",
+		[]WorkRow{{ID: "w"}}); !errors.Is(err, failed) {
+		t.Fatalf("got %v, want store failure", err)
+	}
+}
+
+func TestDashboardStreakRequiresPositiveActivity(t *testing.T) {
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+	snapshot := store.StatsSnapshot{Timezone: "UTC", Sessions: []store.Session{{
+		StartedAt: now.Add(-time.Hour), EndedAt: now, IdleMs: int64(time.Hour / time.Millisecond),
+	}}}
+	got, err := insights.Build(snapshot, insights.Window{}, now)
+	if err != nil || got.Summary.StreakDays != 0 {
+		t.Fatalf("idle-only sitting created streak %d: %v", got.Summary.StreakDays, err)
+	}
+}
+
+func TestDashboardUsesReportedPagesWithoutEdition(t *testing.T) {
+	pages := 1.0
+	if got, err := insights.Pages(store.Session{ReportedPages: &pages}, nil); err != nil || got != 1 {
+		t.Fatalf("reported page count lost: %f: %v", got, err)
 	}
 }
 

--- a/internal/webui/handlers.go
+++ b/internal/webui/handlers.go
@@ -26,78 +26,60 @@ import (
 // no way to ask.
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User) {
 	now := time.Now()
-	loc := userLoc(u)
-	span := dashboardSpan(w, r)
-	win := span.Window(now, loc)
-
-	from, to := win.SessionBounds(now, loc)
-	stored, err := s.St.SessionsInRange(r.Context(), u.ID, from, to)
+	snapshot, err := s.St.StatisticsSnapshot(r.Context(), u.ID, nil)
 	if err != nil {
 		http.Error(w, "internal", http.StatusInternalServerError)
 		return
 	}
-	// SessionsInRange asks for an overlap, so it also answers with a
-	// sitting that began inside the span and ran out the far end of
-	// it. The window decides membership by the day a sitting ended,
-	// and it has to decide it here too or the totals count reading
-	// that has not happened yet.
-	sessions := make([]store.Session, 0, len(stored))
-	for _, ses := range stored {
+	loc := userLoc(&store.User{Timezone: snapshot.Timezone})
+	span := dashboardSpan(w, r)
+	win := span.Window(now, loc)
+	stats, err := insights.Build(snapshot, win, now)
+	if err != nil {
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
+
+	sessions := make([]store.Session, 0, len(snapshot.Sessions))
+	for _, ses := range snapshot.Sessions {
 		if win.HoldsSession(ses) {
 			sessions = append(sessions, ses)
 		}
 	}
-	works, _ := s.St.ListWorks(r.Context(), u.ID)
+	works, err := s.St.ListWorks(r.Context(), u.ID)
+	if err != nil {
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
 	titles := map[string]string{}
-	for _, ws := range works {
-		titles[ws.Work.ID] = orPlaceholder(ws.Work.Title)
+	for _, work := range snapshot.Works {
+		titles[work.ID] = orPlaceholder(work.Title)
 	}
 
 	sum := SummaryData{
 		Span: span, RangeDays: win.Days(),
-		Bars: span.SuitsDailyBars(now, loc),
+		Bars:          span.SuitsDailyBars(now, loc),
+		ActiveMinutes: stats.Summary.TotalActiveMinutes,
+		Sessions:      stats.Summary.Sessions,
+		Pages:         stats.Summary.TotalPages,
+		StreakDays:    stats.Summary.StreakDays,
 	}
 	dayMin := map[string]float64{}
-	pages := newPageCounter(s.St)
-	for _, ses := range sessions {
-		active := insights.ActiveSeconds(ses)
-		sum.ActiveMinutes += active / 60
-		sum.Sessions++
-		sum.Pages += pages.of(r.Context(), ses)
-		// By the day it ended, which is where the app puts it and
-		// where the window draws its own edges. A sitting read across
-		// midnight belongs to one day, and the reader should find it
-		// on the same one wherever they look.
-		//
-		// A rollup is the exception, and knowingly: the materializer
-		// divides a crossing sitting between the days it touched, so
-		// once retention compacts that evening its minutes move off
-		// the end day. Making the two agree means changing how
-		// rollups are allocated, which is a change to stored data and
-		// to what the API answers, not to this page.
-		dayMin[ses.EndedAt.In(loc).Format(insights.DayFormat)] += active / 60
+	for _, day := range stats.Days {
+		dayMin[day.Date] = day.Minutes
 	}
-	fromDay, toDay := win.DayBounds(now, loc)
-	if rollups, err := s.St.RollupsInRange(r.Context(), u.ID, fromDay, toDay); err == nil {
-		for _, ru := range rollups {
-			sum.ActiveMinutes += ru.ActiveSeconds / 60
-			sum.Sessions += int(ru.SessionCount)
-			sum.Pages += ru.Pages
-			dayMin[ru.Day] += ru.ActiveSeconds / 60
-		}
-	}
-	// The streak is answered from further back than the span on
-	// purpose: asking about the last week must not report a
-	// months-long run as seven days.
-	sum.StreakDays = s.streakFor(r, u.ID, loc, now, win, dayMin)
 
-	links := s.workBookIDs(r.Context(), u.ID, works)
+	reading, err := s.linkReadingWorks(r, u.ID, continueReading(works, nil, loc))
+	if err != nil {
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
 	labels := deviceLabels(r.Context(), s.St, u.ID)
 	dashboard(relPrefix(r.URL.Path), uiCtx(r, u), csrfFor(a),
 		sum,
 		daySeries(win, dayMin, now, loc),
 		recentSessions(sessions, titles, loc, labels),
-		s.markReadable(r, u.ID, continueReading(works, links.active, loc))).
+		reading).
 		Render(r.Context(), w)
 }
 
@@ -151,49 +133,6 @@ func recentSessions(sessions []store.Session, titles map[string]string, loc *tim
 	return rows
 }
 
-// streakFor counts the reader's current run of days.
-//
-// It looks back over the whole lookback rather than over the span,
-// because a streak is a fact about the reader and not about the
-// question: narrowing it to the chosen span would report a
-// months-long run as seven days to anybody looking at their week.
-// The days already counted for the span are passed in so the common
-// case — a span that reaches back further than the run — needs no
-// second read.
-func (s *Server) streakFor(
-	r *http.Request, userID string, loc *time.Location, now time.Time,
-	win insights.Window, known map[string]float64,
-) int {
-	days := make(map[string]bool, len(known))
-	for day, minutes := range known {
-		if minutes > 0 {
-			days[day] = true
-		}
-	}
-	// An unbounded span has already read everything there is, so the
-	// lookback would be the same two queries over the same rows.
-	if win.Unbounded() {
-		return insights.StreakDays(days, loc, now)
-	}
-	from := now.AddDate(0, 0, -insights.StreakLookbackDays)
-	if sessions, err := s.St.SessionsInRange(r.Context(), userID, from, now); err == nil {
-		for _, ses := range sessions {
-			if insights.ActiveSeconds(ses) > 0 {
-				days[ses.EndedAt.In(loc).Format(insights.DayFormat)] = true
-			}
-		}
-	}
-	if rollups, err := s.St.RollupsInRange(r.Context(), userID,
-		from.In(loc).Format(insights.DayFormat), now.In(loc).Format(insights.DayFormat)); err == nil {
-		for _, ru := range rollups {
-			if ru.ActiveSeconds > 0 {
-				days[ru.Day] = true
-			}
-		}
-	}
-	return insights.StreakDays(days, loc, now)
-}
-
 // continueReadingLimit is a shelf, not a list: the point is to get back
 // into the book you put down, and a wall of half-read books is a guilt
 // trip rather than a shortcut.
@@ -240,72 +179,75 @@ func userLoc(u *store.User) *time.Location {
 
 // --- works ---
 
-// markReadable says which of these works' books the browser reader can
-// open. The shelf it answers for is bounded (continueReadingLimit), so
-// it is a handful of book lookups rather than the wall of them a whole
-// catalog page would be.
-func (s *Server) markReadable(r *http.Request, userID string, rows []WorkRow) []WorkRow {
-	ids := make([]string, 0, len(rows))
-	for _, row := range rows {
-		if row.BookID != "" {
-			ids = append(ids, row.BookID)
+// Resolve catalog links only after selecting the six displayed works.
+// The dashboard needs neither the rest of the library nor deletion eligibility.
+func (s *Server) linkReadingWorks(r *http.Request, userID string, rows []WorkRow) ([]WorkRow, error) {
+	for i := range rows {
+		ids, err := s.St.WorkBookIDs(r.Context(), userID, rows[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		for _, id := range ids {
+			book, err := s.St.CatalogBookByID(r.Context(), userID, id)
+			if errors.Is(err, store.ErrNotFound) {
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			if book.Status == store.BookActive {
+				rows[i].BookID = id
+				rows[i].CanRead = bookReadable(book)
+				break
+			}
 		}
 	}
-	books := s.booksByID(r.Context(), userID, ids)
-	for i := range rows {
-		book, ok := books[rows[i].BookID]
-		rows[i].CanRead = ok && bookReadable(book)
-	}
-	return rows
+	return rows, nil
 }
 
 func (s *Server) handleWork(w http.ResponseWriter, r *http.Request, a store.AuthSession, u *store.User) {
 	workID := r.PathValue("id")
-	wk, err := s.St.WorkByID(r.Context(), u.ID, workID)
+	snapshot, err := s.St.StatisticsSnapshot(r.Context(), u.ID, nil)
 	if err != nil {
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
+	var wk store.Work
+	for _, work := range snapshot.Works {
+		if work.ID == workID {
+			wk = work
+			break
+		}
+	}
+	if wk.ID == "" {
 		http.NotFound(w, r)
 		return
 	}
-	sessions, _ := s.St.CurrentSessionsForWork(r.Context(), u.ID, workID, 10_000)
-	var d WorkDetail
-	d.Work = wk
-	d.Sessions = len(sessions)
-	var progDelta float64
-	for _, ses := range sessions {
-		d.Minutes += insights.ActiveSeconds(ses) / 60
-		if delta := ses.EndProg - ses.StartProg; delta > 0 {
-			progDelta += delta
-			if ses.EditionSHA != nil {
-				if ed, err := s.St.EditionBySHA(r.Context(), u.ID, *ses.EditionSHA); err == nil && ed.PageCount != nil {
-					d.Pages += delta * float64(*ed.PageCount)
-				}
-			}
+	sessions := make([]store.Session, 0)
+	for _, ses := range snapshot.Sessions {
+		if ses.WorkID == workID {
+			sessions = append(sessions, ses)
 		}
 	}
-	// Once, not once per sitting. A work old enough for its early
-	// sessions to have been compacted counted its rolled-up totals
-	// again for every session it still holds in full, so the longer a
-	// book had been read the more wrong this page was about it.
-	if rollups, err := s.St.RollupsForWork(r.Context(), u.ID, workID); err == nil {
-		for _, ru := range rollups {
-			d.Sessions += int(ru.SessionCount)
-			d.Minutes += ru.ActiveSeconds / 60
-			d.Pages += ru.Pages
-			progDelta += ru.ProgDelta
-		}
+	stats, err := insights.Build(snapshot, insights.Window{}, time.Now())
+	if err != nil {
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
 	}
-	ops, _ := s.St.Positions(r.Context(), u.ID, workID, 50)
-	if len(ops) > 0 {
-		d.CurrentProg = ops[0].Progression
-		if progDelta > 0 && d.Minutes > 0 {
-			speed := progDelta / (d.Minutes * 60)
-			if remaining := 1 - d.CurrentProg; remaining > 0 && speed > 0 {
-				eta := time.Duration(remaining/speed) * time.Second
-				d.ETAHuman = humanDuration(eta)
-			}
-		}
+	stat := stats.ByWork[workID]
+	d := WorkDetail{
+		Work: wk, Sessions: stat.Sessions, Minutes: stat.TotalActiveMinutes,
+		Pages: stat.TotalPages, CurrentProg: stat.CurrentProgression,
 	}
-	loc := userLoc(u)
+	if seconds := stat.ETASeconds; seconds != nil && *seconds <= float64((1<<63-1)/int64(time.Second)) {
+		d.ETAHuman = humanDuration(time.Duration(*seconds) * time.Second)
+	}
+	ops, err := s.St.Positions(r.Context(), u.ID, workID, 50)
+	if err != nil {
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
+	loc := userLoc(&store.User{Timezone: snapshot.Timezone})
 	// The work's own book, when it has one: it makes this page a way
 	// back into the reading rather than only a report about it.
 	if ids, err := s.St.WorkBookIDs(r.Context(), u.ID, workID); err == nil && len(ids) > 0 {
@@ -319,8 +261,9 @@ func (s *Server) handleWork(w http.ResponseWriter, r *http.Request, a store.Auth
 	// Newest first, and only the sessions still held one by one — the
 	// aged ones live on as the daily totals counted in the statistics
 	// above, which is why this list can be shorter than that count.
-	sessionRows := make([]SessionRow, 0, len(sessions))
-	for i := len(sessions) - 1; i >= 0; i-- {
+	const sessionLogLimit = 10_000
+	sessionRows := make([]SessionRow, 0, min(len(sessions), sessionLogLimit))
+	for i := len(sessions) - 1; i >= 0 && len(sessionRows) < sessionLogLimit; i-- {
 		ses := sessions[i]
 		sessionRows = append(sessionRows, SessionRow{
 			When:      ses.StartedAt.In(loc).Format("Jan 2 15:04"),

--- a/internal/webui/readersession_ext_test.go
+++ b/internal/webui/readersession_ext_test.go
@@ -11,3 +11,7 @@ import (
 func TestReaderSessionAccounting(t *testing.T) {
 	runNodeTests(t, "readersession.test.mjs")
 }
+
+func TestReaderSessionUploads(t *testing.T) {
+	runNodeTests(t, "readersessionupload.test.mjs")
+}

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -15,6 +15,7 @@
 import "./vendor/foliate/view.js";
 import { Overlayer } from "./vendor/foliate/overlayer.js";
 import { openSession } from "./reader-session.js";
+import { uploadSessions } from "./reader-session-upload.js";
 import { positionTable, pageAt, pageLocation } from "./reader-positions.js";
 import { readerAuth } from "./reader-auth.js";
 import { liveStream } from "./reader-live.js";
@@ -630,6 +631,7 @@ function beginSession() {
     startedAt: new Date(),
     now: performance.now(),
     fraction: here.fraction,
+    supportsActiveMs: auth.identity()?.supportsActiveMs === true,
   });
 }
 
@@ -672,39 +674,44 @@ function endSession() {
   pushSession(true);
 }
 
-let sessionInFlight = false;
+let sessionsInFlight = 0;
 
 // pushSession sends every unconfirmed sitting in one batch. A retry
 // prodded by activity waits for the request already out; a close does
 // not, because the page may not be here when that one comes back, and
 // the server holds the same payload twice as once.
 async function pushSession(closing) {
-  if (!unsent.length || (sessionInFlight && !closing)) return;
+  if (!unsent.length || (sessionsInFlight && !closing)) return;
   const batch = unsent.slice();
   const stamp = snapshot();
-  sessionInFlight = true;
+  sessionsInFlight++;
   try {
-    const resp = await api("v1/sessions", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      keepalive: true,
-      body: JSON.stringify({ sessions: batch }),
+    await uploadSessions(batch, {
+      canSend: () => current(stamp),
+      send: async (body) => {
+        const resp = await api("v1/sessions", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          keepalive: true,
+          body,
+        });
+        stamp.identity = auth.responseIdentity(resp) || stamp.identity;
+        return resp;
+      },
+      responseCurrent: (resp) => current(stamp) && auth.responseCurrent(resp),
+      accepted: (sent) => { unsent = unsent.filter((p) => !sent.includes(p)); },
+      deferred: (status, code) => console.warn("Reading sessions are waiting to sync:", status, code),
+      refused: (item, code) => {
+        unsent = unsent.filter((p) => p !== item);
+        console.warn("Reading session refused:", code);
+        say("A reading session could not be saved; other reading will still sync.", true);
+      },
     });
-    stamp.identity = auth.responseIdentity(resp) || stamp.identity;
-    // 2xx: filed (re-posting the same payload is idempotently a 2xx too).
-    // 409: this session_id was already used with a *different* payload —
-    // a collision, not a repeat of this sitting — and replaying the same
-    // batch cannot fix that. Any other 4xx is a payload the server will
-    // refuse however often it is sent — an unknown work, say. Only a
-    // server error or no answer at all leaves the batch to try again.
-    if (current(stamp) && auth.responseCurrent(resp) &&
-        (resp.ok || (resp.status >= 400 && resp.status < 500))) {
-      unsent = unsent.filter((p) => !batch.includes(p));
-    }
   } catch (err) {
-    /* offline: the next activity or close replays these exact sittings */
+    // The next activity or close retries the unchanged pending sittings.
+    if (!err.terminal) console.warn("Reading sessions are waiting to sync:", err);
   } finally {
-    sessionInFlight = false;
+    sessionsInFlight--;
   }
 }
 

--- a/internal/webui/static/reader-auth.js
+++ b/internal/webui/static/reader-auth.js
@@ -61,6 +61,7 @@ export function readerAuth({
         expires: Date.parse(got.expires_at) || (detached ? Infinity : now() + 3600000),
         account: info.account_id || "credential:" + (generation + 1),
         device: info.device_id || got.device_id || null,
+        supportsActiveMs: info.session_active_ms === true,
         generation: ++generation,
       };
       handed = null;

--- a/internal/webui/static/reader-session-upload.js
+++ b/internal/webui/static/reader-session-upload.js
@@ -1,0 +1,95 @@
+const permanentCodes = new Set([
+  "id_reused", "missing_field", "bad_time", "time_in_future",
+  "progression_out_of_range", "idle_out_of_range", "active_out_of_range",
+]);
+const encoder = new TextEncoder();
+const maxBatch = 1000;
+// Leave space below fetch's 64 KiB keepalive body limit.
+const maxBodyBytes = 60000;
+const maxRequests = 32;
+
+function batches(sessions) {
+  const result = [];
+  let batch = [], bytes = encoder.encode('{"sessions":[]}').length;
+  for (const session of sessions) {
+    const size = encoder.encode(JSON.stringify(session)).length + (batch.length ? 1 : 0);
+    if (batch.length && (batch.length === maxBatch || bytes + size > maxBodyBytes)) {
+      result.push(batch);
+      batch = [];
+      bytes = encoder.encode('{"sessions":[]}').length;
+    }
+    batch.push(session);
+    bytes += size;
+  }
+  if (batch.length) result.push(batch);
+  return result;
+}
+
+function namedIndex(body, batch) {
+  if (Number.isInteger(body.item_index) &&
+      body.item_index >= 0 && body.item_index < batch.length) return body.item_index;
+  if (typeof body.session_id !== "string") return -1;
+  return batch.findIndex((session) => session.session_id === body.session_id);
+}
+
+// Refusal is atomic: settle only successful batches or a specifically
+// permanent bad item. Everything else stays with the caller for retry.
+export async function uploadSessions(sessions, {
+  send, canSend, responseCurrent, accepted, refused, deferred,
+}) {
+  const queue = batches(sessions);
+  for (let requests = 0; queue.length && requests < maxRequests; requests++) {
+    if (!canSend()) return;
+    const batch = queue.shift();
+    const response = await send(JSON.stringify({ sessions: batch }));
+    if (!responseCurrent(response)) return;
+    if (!response.ok && ![400, 409, 413].includes(response.status)) {
+      deferred(response.status);
+      return;
+    }
+    let body;
+    try {
+      body = await response.json();
+    } catch (err) {
+      if (!(err instanceof SyntaxError)) throw err;
+    }
+    if (!responseCurrent(response)) return;
+    body = body && typeof body === "object" ? body : {};
+    if (response.ok) {
+      if (body.accepted !== batch.length) {
+        deferred(response.status, "malformed_acknowledgement");
+        return;
+      }
+      accepted(batch);
+      continue;
+    }
+    if (response.status === 413 || body.code === "batch_too_large") {
+      if (batch.length === 1) {
+        deferred(response.status, body.code);
+        return;
+      }
+      const limit = Number.isInteger(body.limit) && body.limit > 0 && body.limit < batch.length
+        ? body.limit : Math.ceil(batch.length / 2);
+      const split = [];
+      for (let i = 0; i < batch.length; i += limit) split.push(batch.slice(i, i + limit));
+      queue.unshift(...split);
+      continue;
+    }
+    if (!permanentCodes.has(body.code)) {
+      deferred(response.status, body.code);
+      return;
+    }
+    const index = namedIndex(body, batch);
+    if (index >= 0) {
+      refused(batch[index], body.code);
+      const rest = batch.filter((_, i) => i !== index);
+      if (rest.length) queue.unshift(rest);
+    } else if (batch.length === 1) {
+      refused(batch[0], body.code);
+    } else {
+      const middle = Math.ceil(batch.length / 2);
+      queue.unshift(batch.slice(0, middle), batch.slice(middle));
+    }
+  }
+  if (queue.length) deferred(null, "request_budget");
+}

--- a/internal/webui/static/reader-session-upload.js
+++ b/internal/webui/static/reader-session-upload.js
@@ -43,10 +43,6 @@ export async function uploadSessions(sessions, {
     const batch = queue.shift();
     const response = await send(JSON.stringify({ sessions: batch }));
     if (!responseCurrent(response)) return;
-    if (!response.ok && ![400, 409, 413].includes(response.status)) {
-      deferred(response.status);
-      return;
-    }
     let body;
     try {
       body = await response.json();
@@ -55,6 +51,10 @@ export async function uploadSessions(sessions, {
     }
     if (!responseCurrent(response)) return;
     body = body && typeof body === "object" ? body : {};
+    if (!response.ok && ![400, 409, 413].includes(response.status)) {
+      deferred(response.status, body.code);
+      return;
+    }
     if (response.ok) {
       if (body.accepted !== batch.length) {
         deferred(response.status, "malformed_acknowledgement");

--- a/internal/webui/static/reader-session.js
+++ b/internal/webui/static/reader-session.js
@@ -34,7 +34,7 @@ function clamp01(v) {
 // compares payloads under; `now` is monotonic ms; `startedAt` is the
 // wall-clock Date; `fraction` may be non-finite, in which case the start
 // progression is the first finite one progress() or activity() reports.
-export function openSession({ id, workID, startedAt, now, fraction }) {
+export function openSession({ id, workID, startedAt, now, fraction, supportsActiveMs = false }) {
   let last = now;
   let idle = 0;
   let startProg = finite(fraction) ? clamp01(fraction) : null;
@@ -91,7 +91,7 @@ export function openSession({ id, workID, startedAt, now, fraction }) {
       // server refuses anything else.
       const span = ended - started;
       const idleMs = Math.max(0, Math.min(Math.round(span - active), span));
-      return {
+      const payload = {
         session_id: id,
         work_id: workID,
         started_at: new Date(started).toISOString(),
@@ -100,6 +100,10 @@ export function openSession({ id, workID, startedAt, now, fraction }) {
         end_progression: endProg,
         idle_ms: idleMs,
       };
+      // Capability is captured at open: renewing a token cannot change
+      // the payload of a sitting already queued for an immutable retry.
+      if (supportsActiveMs) payload.active_ms = Math.round(active);
+      return payload;
     },
   };
 }

--- a/internal/webui/testdata/readerauth.test.mjs
+++ b/internal/webui/testdata/readerauth.test.mjs
@@ -12,6 +12,18 @@ const deferred = () => {
 const options = { apiBase: "/proxy/", tokenURL: "/proxy/ui/reader/token", csrf: "csrf" };
 const metadata = (account = "a", device = "browser") => json({ account_id: account, device_id: device });
 
+test("measured session duration requires an explicit server capability", async () => {
+  for (const advertised of [undefined, false, "true", true]) {
+    const auth = readerAuth({
+      ...options,
+      fetcher: async (url) => url === options.tokenURL ? json({ token: "one" }) :
+        json({ account_id: "a", device_id: "browser", session_active_ms: advertised }),
+    });
+    const identity = await auth.acquire();
+    assert.equal(identity.supportsActiveMs, advertised === true);
+  }
+});
+
 test("concurrent streaming and API calls mint a single credential with Bearer headers", async () => {
   const mint = deferred();
   let mints = 0, inspections = 0;

--- a/internal/webui/testdata/readersession.test.mjs
+++ b/internal/webui/testdata/readersession.test.mjs
@@ -105,6 +105,34 @@ test('a wall clock corrected forward lands in idle, not in reading', () => {
   assert.equal(span - out.idle_ms, MIN);
 });
 
+test('negotiated active time survives a backward wall-clock correction', () => {
+  const s = openSession({
+    id: 'measured', workID: 'w1', startedAt: t0, now: 0,
+    fraction: 0.1, supportsActiveMs: true,
+  });
+  for (let m = 1; m <= 30; m++) s.activity(m * MIN, 0.1 + m / 100);
+  const out = s.close(30 * MIN, wall(10 * MIN), 0.4);
+  assert.equal(out.active_ms, 30 * MIN);
+  assert.equal(Date.parse(out.ended_at) - Date.parse(out.started_at), 10 * MIN);
+  assert.equal(out.idle_ms, 0);
+});
+
+test('measured time retains idle accounting and does not fabricate timestamps', () => {
+  const s = openSession({
+    id: 'idle', workID: 'w1', startedAt: t0, now: 0,
+    fraction: 0.1, supportsActiveMs: true,
+  });
+  const out = s.close(30 * MIN, wall(-MIN), 0.1);
+  assert.equal(out.active_ms, IDLE_AFTER_MS);
+  assert.equal(out.ended_at, out.started_at);
+  assert.equal(out.idle_ms, 0);
+});
+
+test('a legacy payload never gains active_ms without capability negotiation', () => {
+  const out = open().close(1000 + MIN, wall(MIN), 0.2);
+  assert.equal(Object.hasOwn(out, 'active_ms'), false);
+});
+
 test('a relocate the reader did not cause is not activity', () => {
   const s = open();
   // Twenty minutes of the engine re-anchoring on resizes, no input.

--- a/internal/webui/testdata/readersessionupload.test.mjs
+++ b/internal/webui/testdata/readersessionupload.test.mjs
@@ -1,0 +1,203 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { uploadSessions } from '../static/reader-session-upload.js';
+
+const item = (id) => ({ session_id: id, work_id: 'work', idle_ms: 0 });
+const reply = (status, body) => new Response(JSON.stringify(body), { status });
+const ok = (body) => reply(200, { accepted: JSON.parse(body).sessions.length });
+
+async function run(pending, responses, extra = {}) {
+  const requests = [], failures = [];
+  await uploadSessions(pending.slice(), {
+    canSend: () => true,
+    responseCurrent: () => true,
+    deferred: () => {},
+    send: async (body) => {
+      requests.push(body);
+      const response = responses.shift();
+      assert.ok(response, 'unexpected request');
+      return typeof response === 'function' ? response(body) : response;
+    },
+    accepted: (batch) => {
+      for (const value of batch) {
+        const index = pending.indexOf(value);
+        if (index >= 0) pending.splice(index, 1);
+      }
+    },
+    refused: (value, code) => {
+      failures.push({ value, code });
+      const index = pending.indexOf(value);
+      if (index >= 0) pending.splice(index, 1);
+    },
+    ...extra,
+  });
+  return { requests: requests.map(JSON.parse), failures };
+}
+
+test('a named refusal removes only the bad sitting and retries its peers', async () => {
+  const pending = [item('a'), item('bad'), item('b')];
+  const result = await run(pending, [
+    reply(409, { code: 'id_reused', item_index: 1, session_id: 'bad' }),
+    reply(200, { accepted: 2 }),
+  ]);
+  assert.deepEqual(result.requests[1].sessions.map((v) => v.session_id), ['a', 'b']);
+  assert.equal(result.failures.length, 1);
+  assert.deepEqual(pending, []);
+});
+
+test('an item index takes precedence over an ambiguous id', async () => {
+  const pending = [item('same'), item('same')];
+  const first = pending[0];
+  const result = await run(pending, [
+    reply(409, { code: 'id_reused', item_index: 1, session_id: 'same' }),
+    reply(200, { accepted: 1 }),
+  ]);
+  assert.notEqual(result.failures[0].value, first);
+  assert.deepEqual(pending, []);
+});
+
+test('a refused oversized batch is split to the server limit', async () => {
+  const pending = ['a', 'b', 'c'].map(item);
+  const result = await run(pending, [
+    reply(400, { code: 'batch_too_large', limit: 1 }),
+    ok, ok, ok,
+  ]);
+  assert.deepEqual(result.requests.map((v) => v.sessions.length), [3, 1, 1, 1]);
+  assert.deepEqual(pending, []);
+});
+
+test('a proxy HTML 413 splits instead of discarding the batch', async () => {
+  const pending = [item('a'), item('b')];
+  await run(pending, [new Response('<html>large</html>', { status: 413 }),
+    ok, ok]);
+  assert.deepEqual(pending, []);
+});
+
+test('a singleton still refused for size remains queued', async () => {
+  const pending = [item('a')];
+  await run(pending, [reply(413, {})]);
+  assert.equal(pending.length, 1);
+});
+
+test('retryable and unknown refusals leave even named items queued', async () => {
+  for (const [status, code] of [[429, 'limited'], [503, 'unavailable'],
+    [400, 'new_refusal'], [400, 'unknown_work'], [403, 'forbidden'], [409, undefined]]) {
+    const pending = [item('a'), item('b')];
+    await run(pending, [reply(status, { code, item_index: 0, session_id: 'a' })]);
+    assert.equal(pending.length, 2, `${status} ${code}`);
+  }
+});
+
+test('an unnamed permanent refusal bisects and preserves the good half', async () => {
+  const pending = [item('a'), item('bad')];
+  const result = await run(pending, [
+    reply(400, { code: 'bad_time' }), ok,
+    reply(400, { code: 'bad_time' }),
+  ]);
+  assert.deepEqual(result.failures.map((v) => v.value.session_id), ['bad']);
+  assert.deepEqual(pending, []);
+});
+
+test('an obsolete credential response settles nothing', async () => {
+  const pending = [item('a')];
+  await run(pending, [ok], { responseCurrent: () => false });
+  assert.equal(pending.length, 1);
+});
+
+test('account changes during refusal parsing settle nothing', async () => {
+  const pending = [item('a')];
+  let current = true;
+  const response = { status: 400, ok: false, json: async () => {
+    current = false;
+    return { code: 'bad_time', item_index: 0 };
+  } };
+  await run(pending, [response], { responseCurrent: () => current });
+  assert.equal(pending.length, 1);
+});
+
+test('a success only settles the captured batch, not a newly closed sitting', async () => {
+  const pending = [item('a')];
+  await run(pending, [(body) => {
+    pending.push(item('new'));
+    return ok(body);
+  }]);
+  assert.deepEqual(pending.map((v) => v.session_id), ['new']);
+});
+
+test('network failure keeps payloads identical for the next attempt', async () => {
+  const pending = [item('a')];
+  let first;
+  await assert.rejects(run(pending, [(body) => {
+    first = body;
+    throw new TypeError('offline');
+  }]), /offline/);
+  await run(pending, [(body) => {
+    assert.equal(body, first);
+    return ok(body);
+  }]);
+  assert.deepEqual(pending, []);
+});
+
+test('initial batches stay below the keepalive body budget, including unicode', async () => {
+  const pending = Array.from({ length: 250 }, (_, i) => ({
+    ...item(String(i)), work_id: '\u00e9'.repeat(250),
+  }));
+  let requests = 0;
+  await run(pending, [], {
+    send: async (body) => {
+      requests++;
+      assert.ok(new TextEncoder().encode(body).length <= 60000);
+      return ok(body);
+    },
+  });
+  assert.ok(requests > 1);
+  assert.deepEqual(pending, []);
+});
+
+test('a malformed success acknowledgement does not discard pending reading', async () => {
+  for (const body of [{}, { accepted: 0 }, { accepted: 2 }, { accepted: '1' }]) {
+    const pending = [item('a')];
+    const deferred = [];
+    await run(pending, [reply(200, body)], {
+      deferred: (...reason) => deferred.push(reason),
+    });
+    assert.equal(pending.length, 1);
+    assert.deepEqual(deferred, [[200, 'malformed_acknowledgement']]);
+  }
+});
+
+test('unknown refusals report why reading remains queued', async () => {
+  const pending = [item('a')];
+  const deferred = [];
+  await run(pending, [reply(400, { code: 'unknown_reason' })], {
+    deferred: (...reason) => deferred.push(reason),
+  });
+  assert.deepEqual(deferred, [[400, 'unknown_reason']]);
+  assert.equal(pending.length, 1);
+});
+
+test('a flush reports its request budget only when it leaves batches pending', async () => {
+  const pending = Array.from({ length: 33 }, (_, i) => ({
+    ...item(String(i)), work_id: 'w'.repeat(40000),
+  }));
+  const deferred = [];
+  let requests = 0;
+  await run(pending, [], {
+    send: async (body) => { requests++; return ok(body); },
+    deferred: (...reason) => deferred.push(reason),
+  });
+  assert.equal(requests, 32);
+  assert.equal(pending.length, 1);
+  assert.deepEqual(deferred, [[null, 'request_budget']]);
+});
+
+test('active duration refusal isolates its item without claiming budget exhaustion', async () => {
+  const pending = [item('bad'), item('good')];
+  const deferred = [];
+  const result = await run(pending, [
+    reply(400, { code: 'active_out_of_range', item_index: 0 }), ok,
+  ], { deferred: (...reason) => deferred.push(reason) });
+  assert.deepEqual(pending, []);
+  assert.deepEqual(result.failures.map((v) => v.value.session_id), ['bad']);
+  assert.deepEqual(deferred, []);
+});

--- a/internal/webui/testdata/readersessionupload.test.mjs
+++ b/internal/webui/testdata/readersessionupload.test.mjs
@@ -176,6 +176,16 @@ test('unknown refusals report why reading remains queued', async () => {
   assert.equal(pending.length, 1);
 });
 
+test('an unhandled status with a JSON refusal code forwards that code', async () => {
+  const pending = [item('a')];
+  const deferred = [];
+  await run(pending, [reply(429, { code: 'rate_limited' })], {
+    deferred: (...reason) => deferred.push(reason),
+  });
+  assert.deepEqual(deferred, [[429, 'rate_limited']]);
+  assert.equal(pending.length, 1);
+});
+
 test('a flush reports its request budget only when it leaves batches pending', async () => {
   const pending = Array.from({ length: 33 }, (_, i) => ({
     ...item(String(i)), work_id: 'w'.repeat(40000),


### PR DESCRIPTION
## Summary

Reading stats could drift between the raw session log and the compacted
history behind it: a query could see part-old, part-compacted data mid
compaction, a sitting spanning midnight could shift day or session
counts once compacted, and long-lived KOPlugin books could silently
truncate their history past 10,000 raw sessions.

## Changes

- Read a single coherent snapshot for statistics instead of separate
  raw-session and rollup queries that could straddle a compaction.
- Add a new authenticated insights snapshot endpoint so clients (like
  the liseur Android app) can merge their local activity against the
  server's totals without double-counting.
- Support an optional, capability-negotiated measured session duration
  so sync no longer loses reading time after a backward wall-clock
  correction.
- Reject malformed request bodies outright instead of silently
  accepting trailing garbage.
- Keep valid sessions in a browser upload batch instead of discarding
  the whole batch over one refused item.
- Preserve KOPlugin page-count evidence through compaction instead of
  dropping it.

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [x] If `.templ` files changed: `go tool templ generate ./internal/webui/` and committed generated output (no changes needed)
- [ ] If `docs/openapi.yaml` changed: `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish`
- [ ] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable

## Screenshots, logs, or API examples

No dashboard layout changes; the new endpoint is additive and existing
clients ignore it.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.

Pairs with the matching client change in `chmouel/liseur` (uses the new
snapshot endpoint when available, falls back to local-only stats
against older servers).
