### PR TITLE
Add cross-device reading comparisons

### DIFF
--- a/docs/integrating.md
+++ b/docs/integrating.md
@@ -558,6 +558,7 @@ First request `GET /v1/insights/capabilities`:
   "account_id": "usr_31b0",
   "all_time": true,
   "active_ms": true,
+  "comparison": true,
   "attribution_version": 2,
   "timezone": "Europe/Paris",
   "max_candidates": 10000,
@@ -567,7 +568,7 @@ First request `GET /v1/insights/capabilities`:
 }
 ```
 
-Require the supported versions, `all_time: true`, and an `account_id`
+Require the supported versions, `all_time: true`, `comparison: true`, and an `account_id`
 matching the captured account before using snapshots. Both evidence
 limits are explicit: `max_candidates` bounds session candidates and
 `max_local_active_days` bounds local activity dates. These fields are
@@ -582,6 +583,13 @@ Capture local totals and their evidence together, then send
   "timezone": "Europe/Paris",
   "from": "2026-08-01",
   "to": "2026-08-31",
+  "comparison": {
+    "current_from": "2026-08-01",
+    "current_to": "2026-08-31",
+    "previous_from": "2026-07-01",
+    "previous_to": "2026-07-31",
+    "through": "08:48:42.375"
+  },
   "candidates": [{
     "session_id": "sitting-42",
     "work_id": "work-7",
@@ -621,6 +629,16 @@ evidence and then claim a complete union.
 The limit covers the entire body, including trailing whitespace. Send
 one JSON value only; trailing JSON or garbage gets `400` within the limit.
 
+`comparison` is optional and is never sent for `range: "all"`. Its current
+dates must exactly match the bounded headline `from`/`to`, `current_to`
+must be account-local today, and `previous_to` must be before
+`current_from`. Each inclusive span may contain at most 4000 days.
+`through` accepts `HH:mm` or seconds with zero through three fractional
+digits; it is normalized and echoed as `HH:mm:ss.SSS`. The cutoff is the
+same wall-clock time on each span's last day. A repeated DST time uses the
+earlier occurrence, while a skipped time moves forward by the size of the
+gap, matching Java/Kotlin `LocalDateTime.atZone`.
+
 The response contains:
 
 | Field | Meaning |
@@ -637,6 +655,9 @@ The response contains:
 | `days` | Server daily rows: `date`, `minutes`, `pages`, `sessions`. Missing dates contribute zero. |
 | `overlap` | Actual included candidates: `total_active_minutes`, `sessions`, `works`, `days`. No top-level page total. |
 | `combined_streak_days` | Streak from all server positive-activity days unioned with `local_active_days`. |
+| `comparison` | Optional server `current_active_minutes` and `previous_active_minutes`, with the four echoed dates and normalized `through`. |
+| `overlap.comparison` | Optional `current_active_minutes` and `previous_active_minutes` overlap totals for the top-level comparison's echoed spans. |
+| `comparison_incomplete_reason` | Present only when comparison was requested but both comparison blocks were omitted. It never changes headline `complete`. |
 
 Work rows carry `work_id`, `sessions`, `total_active_minutes`,
 `total_pages`, `current_progression`, nullable `eta_seconds` and
@@ -664,6 +685,35 @@ payload mismatches do too. Reasons are
 Use local-only statistics when negotiation is unavailable or the response
 cannot certify the requested union. Do not guess a merge with legacy
 summary/calendar endpoints.
+
+Comparison totals use raw timestamps up to the wall-clock cutoff. A session
+ending at or before the cutoff contributes its whole active duration; one
+that starts before and ends after it contributes
+`active_ms * elapsed_wall_time / total_wall_time`, rounded per session to
+the nearest millisecond with the same positive tie behavior as Kotlin
+`roundToLong`. When `active_ms` is absent, wall-clock milliseconds minus
+`idle_ms` are used. A session may end after midnight and still contribute
+the portion before the cutoff.
+
+A v2 rollup on a whole day before a span's last day contributes in full.
+A positive rollup on the partial last day, or on any later day that could
+hide a session crossing the cutoff, lacks the timestamps needed to prorate
+and refuses the comparison. Legacy and different-timezone rollups also
+refuse it. V2 rollups written before the server began retaining the exact
+sum of per-session comparison milliseconds likewise refuse rather than
+rounding an old floating-point aggregate and claiming it is exact. In these
+cases the response keeps the valid headline, omits
+both `comparison` and `overlap.comparison`, and sets
+`comparison_incomplete_reason: "comparison_history_incomplete"`.
+Candidate payload or archive-proof failures use the corresponding existing
+reason. Clients fall back to a local-only comparison for any reason they do
+not recognize.
+
+Headline and comparison evidence are scoped separately. A baseline-only
+candidate or work cannot set headline `complete: false`; conversely, an
+unverifiable comparison never turns a valid all-device headline into a
+local one. Both comparison totals and both overlap totals still come from
+the same database snapshot and `stats_revision`.
 
 Calendar bounds are independent of aggregate bounds: optional
 `calendar_from`/`calendar_to` filter only `days` and `overlap.days`,

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -891,7 +891,8 @@ paths:
       summary: Negotiate statistics snapshot support
       description: |
         Requires `read-insights`. Returns the account id and timezone,
-        protocol and attribution versions, all-history support and request limits.
+        protocol and attribution versions, all-history and period-comparison
+        support, and request limits.
         A sync-only client can negotiate session duration through
         `GET /v1/token` instead; browser tokens do not need wider scopes.
       security: [{ deviceToken: [] }]  # requires read-insights scope
@@ -927,6 +928,15 @@ paths:
         Use local-only statistics if negotiation or complete proof is
         unavailable, including on legacy servers.
 
+        An optional `comparison` asks for current and previous date spans
+        stopped at the same account-local wall-clock time. Its current dates
+        must equal the bounded headline dates and end today; comparison is
+        unavailable for `range: all`. Both server totals and overlap totals
+        come from this same snapshot. If raw timestamps or candidate evidence
+        cannot prove all four values, the response omits both comparison
+        objects and sets `comparison_incomplete_reason`; headline `complete`
+        and its totals are unaffected by comparison-only evidence.
+
         Explicit calendar bounds affect only `days` and `overlap.days`.
         Across chunks require the same decimal-string `stats_revision`
         and response identity; do not sum repeated summary/work totals.
@@ -939,8 +949,10 @@ paths:
       responses:
         "200":
           description: |
-            Coherent aggregates and overlap. An incomplete result still
+            Coherent aggregates and overlap. An incomplete headline still
             returns totals, but cannot certify an exact local/server union.
+            A refused optional comparison is reported separately and never
+            invalidates an otherwise complete headline.
           content:
             application/json:
               schema: { $ref: "#/components/schemas/InsightsSnapshot" }
@@ -2940,7 +2952,7 @@ components:
         reason: { type: string }
     InsightsCapabilities:
       type: object
-      required: [version, account_id, all_time, active_ms, attribution_version, timezone, max_candidates, max_local_active_days, max_calendar_days, max_body_bytes]
+      required: [version, account_id, all_time, active_ms, comparison, attribution_version, timezone, max_candidates, max_local_active_days, max_calendar_days, max_body_bytes]
       properties:
         version: { type: integer, const: 1 }
         account_id:
@@ -2951,6 +2963,10 @@ components:
           const: true
           description: Supports range all without a total-history row cap.
         active_ms: { type: boolean, const: true }
+        comparison:
+          type: boolean
+          const: true
+          description: Supports one-snapshot current/previous period comparison.
         attribution_version: { type: integer, const: 2 }
         timezone: { type: string, description: "Account IANA timezone", example: Europe/Paris }
         max_candidates: { type: integer, const: 10000 }
@@ -3128,6 +3144,50 @@ components:
             Last daily-output day, inclusive; requires calendar_from and
             must not precede it. Defaults to aggregate end, or today for all.
             Calendar bounds do not narrow summary, works or streaks.
+        comparison: { $ref: "#/components/schemas/InsightsComparisonInput" }
+    InsightsComparisonInput:
+      type: object
+      required: [current_from, current_to, previous_from, previous_to, through]
+      description: |
+        Optional current/previous comparison inside the same statistics
+        snapshot. Both spans are inclusive, ordered and at most 4000 days.
+        The previous span must end before the current span starts. The current
+        dates must equal the bounded headline dates and current_to must be
+        account-local today; range all cannot carry a comparison.
+
+        `through` is a local wall-clock cutoff with optional seconds and up
+        to millisecond precision. The response normalizes it to HH:mm:ss.SSS.
+        A repeated DST time uses its earlier occurrence; a skipped time moves
+        forward by the size of the gap.
+      properties:
+        current_from: { type: string, format: date }
+        current_to: { type: string, format: date }
+        previous_from: { type: string, format: date }
+        previous_to: { type: string, format: date }
+        through:
+          type: string
+          pattern: '^(?:[01][0-9]|2[0-3]):[0-5][0-9](?::[0-5][0-9](?:\.[0-9]{1,3})?)?$'
+          example: "08:48:42.375"
+    InsightsComparison:
+      type: object
+      required: [current_active_minutes, previous_active_minutes, current_from, current_to, previous_from, previous_to, through]
+      properties:
+        current_active_minutes: { type: number, minimum: 0 }
+        previous_active_minutes: { type: number, minimum: 0 }
+        current_from: { type: string, format: date }
+        current_to: { type: string, format: date }
+        previous_from: { type: string, format: date }
+        previous_to: { type: string, format: date }
+        through:
+          type: string
+          pattern: '^(?:[01][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]\.[0-9]{3}$'
+          description: Millisecond-normalized account-local cutoff echoed from the request.
+    InsightsComparisonTotals:
+      type: object
+      required: [current_active_minutes, previous_active_minutes]
+      properties:
+        current_active_minutes: { type: number, minimum: 0 }
+        previous_active_minutes: { type: number, minimum: 0 }
     InsightsOverlap:
       type: object
       required: [total_active_minutes, sessions, works, days]
@@ -3149,6 +3209,13 @@ components:
           type: array
           description: Daily overlap within the echoed calendar bounds, ordered by date.
           items: { $ref: "#/components/schemas/InsightsDay" }
+        comparison:
+          allOf:
+            - { $ref: "#/components/schemas/InsightsComparisonTotals" }
+          description: |
+            Actual candidate overlap in the comparison's current and previous
+            spans. The bounds are the echoed top-level comparison bounds.
+            Present exactly when the top-level comparison is present.
     InsightsSnapshot:
       allOf:
         - { $ref: "#/components/schemas/InsightsWindow" }
@@ -3170,6 +3237,19 @@ components:
               description: Present only when complete is false; unknown reasons also require fallback.
               enum:
                 - legacy_or_different_timezone_rollups
+                - candidate_payload_mismatch
+                - unknown_archived_contribution
+                - archived_timezone_mismatch
+                - archived_work_missing
+            comparison_incomplete_reason:
+              type: string
+              description: |
+                Present only when a comparison was requested but omitted.
+                It does not change `complete`, which describes the headline
+                union only. Unknown reasons also require local comparison
+                fallback.
+              enum:
+                - comparison_history_incomplete
                 - candidate_payload_mismatch
                 - unknown_archived_contribution
                 - archived_timezone_mismatch
@@ -3198,6 +3278,14 @@ components:
                 All-history streak over server positive-activity days
                 unioned with local_active_days, ending today or yesterday.
                 Independent of aggregate and calendar bounds.
+            comparison:
+              allOf:
+                - { $ref: "#/components/schemas/InsightsComparison" }
+              description: |
+                Server totals for the requested current and previous spans.
+                Omitted with `comparison_incomplete_reason` when exact
+                proration cannot be proven. Rollups created before exact
+                millisecond comparison evidence was introduced are refused.
             overlap: { $ref: "#/components/schemas/InsightsOverlap" }
     SessionInput:
       type: object

--- a/internal/api/insights.go
+++ b/internal/api/insights.go
@@ -142,8 +142,8 @@ func calendarBounds(r *http.Request, loc *time.Location) (insights.Window, bool,
 	q := r.URL.Query()
 	rawFrom, rawTo := q.Get("from"), q.Get("to")
 	if rawFrom != "" && rawTo != "" {
-		from, errFrom := time.ParseInLocation(insights.DayFormat, rawFrom, loc)
-		to, errTo := time.ParseInLocation(insights.DayFormat, rawTo, loc)
+		from, errFrom := time.Parse(insights.DayFormat, rawFrom)
+		to, errTo := time.Parse(insights.DayFormat, rawTo)
 		if errFrom == nil && errTo == nil && !to.Before(from) {
 			win := insights.DayWindow(from, to, loc)
 			return win, true, win.Days() <= maxCalendarDays

--- a/internal/api/insights_snapshot.go
+++ b/internal/api/insights_snapshot.go
@@ -26,7 +26,7 @@ func (s *Server) HandleInsightsCapabilities(w http.ResponseWriter, r *http.Reque
 	}
 	writeJSON(w, http.StatusOK, map[string]any{
 		"version": 1, "active_ms": true, "attribution_version": 2,
-		"account_id": tok.UserID, "all_time": true,
+		"account_id": tok.UserID, "all_time": true, "comparison": true,
 		"timezone": user.Timezone, "max_candidates": maxInsightCandidates,
 		"max_calendar_days":     maxCalendarDays,
 		"max_body_bytes":        s.Cfg.Ops.MaxBodyBytes,
@@ -49,12 +49,26 @@ type insightSnapshotRequest struct {
 	LocalActiveDays []string           `json:"local_active_days"`
 	CalendarFrom    string             `json:"calendar_from"`
 	CalendarTo      string             `json:"calendar_to"`
+	Comparison      *insightComparison `json:"comparison"`
+}
+
+type insightComparison struct {
+	CurrentFrom  string `json:"current_from"`
+	CurrentTo    string `json:"current_to"`
+	PreviousFrom string `json:"previous_from"`
+	PreviousTo   string `json:"previous_to"`
+	Through      string `json:"through"`
+}
+
+type comparisonWindows struct {
+	current  insights.ComparisonWindow
+	previous insights.ComparisonWindow
 }
 
 func snapshotWindow(req insightSnapshotRequest, loc *time.Location, now time.Time) (insights.Window, bool) {
 	if req.From != "" || req.To != "" {
-		from, errFrom := time.ParseInLocation(insights.DayFormat, req.From, loc)
-		to, errTo := time.ParseInLocation(insights.DayFormat, req.To, loc)
+		from, errFrom := time.Parse(insights.DayFormat, req.From)
+		to, errTo := time.Parse(insights.DayFormat, req.To)
 		if errFrom != nil || errTo != nil || to.Before(from) || req.Range != "" {
 			return insights.Window{}, false
 		}
@@ -71,6 +85,48 @@ func snapshotWindow(req insightSnapshotRequest, loc *time.Location, now time.Tim
 		return insights.Window{}, false
 	}
 	return insights.ParseWindow("", "", req.Range, "", loc, now), true
+}
+
+func snapshotComparisonWindows(
+	req *insightComparison,
+	headline insights.Window,
+	loc *time.Location,
+	now time.Time,
+) (comparisonWindows, bool) {
+	if req == nil || headline.Unbounded() ||
+		req.CurrentFrom != headline.FromDay() || req.CurrentTo != headline.ToDay() ||
+		req.CurrentTo != now.In(loc).Format(insights.DayFormat) ||
+		req.PreviousTo >= req.CurrentFrom {
+		return comparisonWindows{}, false
+	}
+	current, ok := insights.NewComparisonWindow(req.CurrentFrom, req.CurrentTo, req.Through, loc)
+	if !ok || current.Days() > maxCalendarDays {
+		return comparisonWindows{}, false
+	}
+	previous, ok := insights.NewComparisonWindow(req.PreviousFrom, req.PreviousTo, req.Through, loc)
+	if !ok || previous.Days() > maxCalendarDays {
+		return comparisonWindows{}, false
+	}
+	return comparisonWindows{current: current, previous: previous}, true
+}
+
+func comparisonAnswer(current, previous float64, windows comparisonWindows) map[string]any {
+	return map[string]any{
+		"current_active_minutes":  current,
+		"previous_active_minutes": previous,
+		"current_from":            windows.current.FromDay(),
+		"current_to":              windows.current.ToDay(),
+		"previous_from":           windows.previous.FromDay(),
+		"previous_to":             windows.previous.ToDay(),
+		"through":                 windows.current.Through(),
+	}
+}
+
+func comparisonTotals(current, previous float64) map[string]any {
+	return map[string]any{
+		"current_active_minutes":  current,
+		"previous_active_minutes": previous,
+	}
 }
 
 // Candidates and aggregates are read together; an upload acknowledgement,
@@ -118,6 +174,15 @@ func (s *Server) HandleInsightsSnapshot(w http.ResponseWriter, r *http.Request) 
 		writeError(w, http.StatusBadRequest, "invalid statistics window")
 		return
 	}
+	var comparison *comparisonWindows
+	if req.Comparison != nil {
+		windows, valid := snapshotComparisonWindows(req.Comparison, win, loc, now)
+		if !valid {
+			writeError(w, http.StatusBadRequest, "invalid comparison window")
+			return
+		}
+		comparison = &windows
+	}
 	result, ok := buildInsights(w, snap, win, now)
 	if !ok {
 		return
@@ -144,8 +209,8 @@ func (s *Server) HandleInsightsSnapshot(w http.ResponseWriter, r *http.Request) 
 	if req.CalendarFrom != "" || req.CalendarTo != "" {
 		calendarFrom, calendarTo = req.CalendarFrom, req.CalendarTo
 	}
-	first, errFrom := time.ParseInLocation(insights.DayFormat, calendarFrom, loc)
-	last, errTo := time.ParseInLocation(insights.DayFormat, calendarTo, loc)
+	first, errFrom := time.Parse(insights.DayFormat, calendarFrom)
+	last, errTo := time.Parse(insights.DayFormat, calendarTo)
 	if errFrom != nil || errTo != nil || last.Before(first) {
 		writeError(w, http.StatusBadRequest, "invalid calendar window")
 		return
@@ -159,22 +224,49 @@ func (s *Server) HandleInsightsSnapshot(w http.ResponseWriter, r *http.Request) 
 	overlapSnapshot := store.StatsSnapshot{
 		Timezone: snap.Timezone, Works: snap.Works, Editions: snap.Editions,
 	}
+	comparisonOverlapSnapshot := store.StatsSnapshot{Timezone: snap.Timezone}
 	raw := make(map[string]store.Session, len(snap.Sessions))
 	for _, ses := range snap.Sessions {
 		raw[ses.SessionID] = ses
+	}
+	knownWorks := make(map[string]bool, len(snap.Works))
+	for _, work := range snap.Works {
+		knownWorks[work.ID] = true
 	}
 	incomplete := func(reason string) {
 		result.Complete = false
 		result.IncompleteReason = reason
 	}
+	comparisonIncompleteReason := ""
+	comparisonIncomplete := func(reason string) {
+		if comparisonIncompleteReason == "" {
+			comparisonIncompleteReason = reason
+		}
+	}
 	for _, candidate := range candidates {
+		headlineCandidate := win.HoldsSession(candidate)
+		comparisonCandidate := comparison != nil &&
+			(comparison.current.HoldsSession(candidate) || comparison.previous.HoldsSession(candidate))
+		if !headlineCandidate && !comparisonCandidate {
+			continue
+		}
 		fingerprint := store.SessionFingerprint(candidate)
 		if ses, exists := raw[candidate.SessionID]; exists {
 			if store.SessionFingerprint(ses) != fingerprint {
-				incomplete("candidate_payload_mismatch")
+				if headlineCandidate {
+					incomplete("candidate_payload_mismatch")
+				}
+				if comparisonCandidate {
+					comparisonIncomplete("candidate_payload_mismatch")
+				}
 				continue
 			}
-			overlapSnapshot.Sessions = append(overlapSnapshot.Sessions, ses)
+			if headlineCandidate {
+				overlapSnapshot.Sessions = append(overlapSnapshot.Sessions, ses)
+			}
+			if comparisonCandidate {
+				comparisonOverlapSnapshot.Sessions = append(comparisonOverlapSnapshot.Sessions, ses)
+			}
 			continue
 		}
 		proof, archived := snap.Archived[candidate.SessionID]
@@ -182,30 +274,70 @@ func (s *Server) HandleInsightsSnapshot(w http.ResponseWriter, r *http.Request) 
 			continue
 		}
 		if proof.Fingerprint != fingerprint || proof.AttributionVersion != 2 {
-			incomplete("unknown_archived_contribution")
+			if headlineCandidate {
+				incomplete("unknown_archived_contribution")
+			}
+			if comparisonCandidate {
+				comparisonIncomplete("unknown_archived_contribution")
+			}
 			continue
 		}
 		if !proof.Present {
 			continue
 		}
 		if proof.Timezone != snap.Timezone {
-			incomplete("archived_timezone_mismatch")
+			if headlineCandidate {
+				incomplete("archived_timezone_mismatch")
+			}
+			if comparisonCandidate {
+				comparisonIncomplete("archived_timezone_mismatch")
+			}
 			continue
 		}
-		if _, exists := result.ByWork[proof.WorkID]; !exists {
-			incomplete("archived_work_missing")
+		if proof.WorkID != candidate.WorkID || proof.Day != candidate.EndedAt.In(loc).Format(insights.DayFormat) {
+			if headlineCandidate {
+				incomplete("unknown_archived_contribution")
+			}
+			if comparisonCandidate {
+				comparisonIncomplete("unknown_archived_contribution")
+			}
 			continue
 		}
-		overlapSnapshot.Rollups = append(overlapSnapshot.Rollups, store.SessionRollup{
-			WorkID: proof.WorkID, Day: proof.Day, Timezone: proof.Timezone,
-			AttributionVersion: 2, SessionCount: 1, ActiveSeconds: proof.ActiveSeconds,
-			Pages: proof.Pages, ProgDelta: proof.ProgDelta,
-			MeasuredActiveSeconds: proof.MeasuredActiveSeconds, MeasuredProgDelta: proof.MeasuredProgDelta,
-		})
+		if !knownWorks[proof.WorkID] {
+			if headlineCandidate {
+				incomplete("archived_work_missing")
+			}
+			if comparisonCandidate {
+				comparisonIncomplete("archived_work_missing")
+			}
+			continue
+		}
+		if headlineCandidate {
+			overlapSnapshot.Rollups = append(overlapSnapshot.Rollups, store.SessionRollup{
+				WorkID: proof.WorkID, Day: proof.Day, Timezone: proof.Timezone,
+				AttributionVersion: 2, SessionCount: 1, ActiveSeconds: proof.ActiveSeconds,
+				Pages: proof.Pages, ProgDelta: proof.ProgDelta,
+				MeasuredActiveSeconds: proof.MeasuredActiveSeconds, MeasuredProgDelta: proof.MeasuredProgDelta,
+			})
+		}
+		if comparisonCandidate {
+			if proof.ComparisonActiveMs == nil || *proof.ComparisonActiveMs < 0 {
+				comparisonIncomplete("unknown_archived_contribution")
+				continue
+			}
+			archivedCandidate := candidate
+			activeMs := *proof.ComparisonActiveMs
+			archivedCandidate.ActiveMs = &activeMs
+			comparisonOverlapSnapshot.Sessions = append(comparisonOverlapSnapshot.Sessions, archivedCandidate)
+		}
 	}
 	overlap, ok := buildInsights(w, overlapSnapshot, win, now)
 	if !ok {
 		return
+	}
+	overlapAnswer := map[string]any{
+		"total_active_minutes": overlap.Summary.TotalActiveMinutes, "sessions": overlap.Summary.Sessions,
+		"works": overlap.Works, "days": calendarDays(overlap.Days, calendarWin),
 	}
 	answer := map[string]any{
 		"version": 1, "account_id": tok.UserID, "snapshot_id": req.SnapshotID,
@@ -213,13 +345,25 @@ func (s *Server) HandleInsightsSnapshot(w http.ResponseWriter, r *http.Request) 
 		"today": today, "calendar_from": calendarFrom, "calendar_to": calendarTo,
 		"summary": result.Summary, "works": result.Works, "days": calendarDays(result.Days, calendarWin),
 		"combined_streak_days": insights.StreakDays(result.ActiveDays, loc, now),
-		"overlap": map[string]any{
-			"total_active_minutes": overlap.Summary.TotalActiveMinutes, "sessions": overlap.Summary.Sessions,
-			"works": overlap.Works, "days": calendarDays(overlap.Days, calendarWin),
-		},
+		"overlap":              overlapAnswer,
 	}
 	if !result.Complete {
 		answer["incomplete_reason"] = result.IncompleteReason
+	}
+	if comparison != nil {
+		current, currentOK := insights.SpanMinutes(snap, comparison.current, loc)
+		previous, previousOK := insights.SpanMinutes(snap, comparison.previous, loc)
+		overlapCurrent, overlapCurrentOK := insights.SpanMinutes(comparisonOverlapSnapshot, comparison.current, loc)
+		overlapPrevious, overlapPreviousOK := insights.SpanMinutes(comparisonOverlapSnapshot, comparison.previous, loc)
+		if comparisonIncompleteReason == "" && currentOK && previousOK && overlapCurrentOK && overlapPreviousOK {
+			answer["comparison"] = comparisonAnswer(current, previous, *comparison)
+			overlapAnswer["comparison"] = comparisonTotals(overlapCurrent, overlapPrevious)
+		} else {
+			if comparisonIncompleteReason == "" {
+				comparisonIncompleteReason = "comparison_history_incomplete"
+			}
+			answer["comparison_incomplete_reason"] = comparisonIncompleteReason
+		}
 	}
 	describe(win, answer)
 	describeSnapshot(snap, answer)

--- a/internal/api/insights_snapshot_regression_test.go
+++ b/internal/api/insights_snapshot_regression_test.go
@@ -117,16 +117,39 @@ type snapshotReply struct {
 	Revision           string           `json:"stats_revision"`
 	Complete           bool             `json:"complete"`
 	IncompleteReason   string           `json:"incomplete_reason"`
+	ComparisonReason   string           `json:"comparison_incomplete_reason"`
 	CombinedStreakDays int              `json:"combined_streak_days"`
 	Summary            insights.Summary `json:"summary"`
 	Works              []insights.Work  `json:"works"`
 	Days               []insights.Day   `json:"days"`
+	Comparison         *comparisonReply `json:"comparison"`
 	Overlap            struct {
-		Minutes  float64         `json:"total_active_minutes"`
-		Sessions int             `json:"sessions"`
-		Works    []insights.Work `json:"works"`
-		Days     []insights.Day  `json:"days"`
+		Minutes    float64                `json:"total_active_minutes"`
+		Sessions   int                    `json:"sessions"`
+		Works      []insights.Work        `json:"works"`
+		Days       []insights.Day         `json:"days"`
+		Comparison *comparisonTotalsReply `json:"comparison"`
 	} `json:"overlap"`
+}
+
+type comparisonTotalsReply struct {
+	CurrentMinutes  float64 `json:"current_active_minutes"`
+	PreviousMinutes float64 `json:"previous_active_minutes"`
+	CurrentFrom     string  `json:"current_from"`
+	CurrentTo       string  `json:"current_to"`
+	PreviousFrom    string  `json:"previous_from"`
+	PreviousTo      string  `json:"previous_to"`
+	Through         string  `json:"through"`
+}
+
+type comparisonReply struct {
+	CurrentMinutes  float64 `json:"current_active_minutes"`
+	PreviousMinutes float64 `json:"previous_active_minutes"`
+	CurrentFrom     string  `json:"current_from"`
+	CurrentTo       string  `json:"current_to"`
+	PreviousFrom    string  `json:"previous_from"`
+	PreviousTo      string  `json:"previous_to"`
+	Through         string  `json:"through"`
 }
 
 func readSnapshot(t *testing.T, url, token string, body map[string]any) snapshotReply {
@@ -169,6 +192,24 @@ func snapshotNear(t *testing.T, label string, got, want float64) {
 	if math.IsNaN(got) || math.IsInf(got, 0) || math.Abs(got-want) > 1e-9 {
 		t.Errorf("%s: got %v, want %v", label, got, want)
 	}
+}
+
+func comparisonBody(now time.Time, sessions ...store.Session) map[string]any {
+	today := now.UTC()
+	currentFrom := today.AddDate(0, 0, -1).Format(insights.DayFormat)
+	currentTo := today.Format(insights.DayFormat)
+	previousFrom := today.AddDate(0, 0, -3).Format(insights.DayFormat)
+	previousTo := today.AddDate(0, 0, -2).Format(insights.DayFormat)
+	body := snapshotBody(sessions...)
+	delete(body, "range")
+	body["from"], body["to"] = currentFrom, currentTo
+	body["calendar_from"], body["calendar_to"] = currentFrom, currentTo
+	body["comparison"] = map[string]any{
+		"current_from": currentFrom, "current_to": currentTo,
+		"previous_from": previousFrom, "previous_to": previousTo,
+		"through": "12:00:00",
+	}
+	return body
 }
 
 func requireSnapshotError(t *testing.T, code int, out map[string]any, want int) {
@@ -381,12 +422,13 @@ func TestInsightsSnapshotAuthScopesAndTenantIsolation(t *testing.T) {
 	code, caps := get(t, f.ts.URL+"/v1/insights/capabilities", f.reader)
 	if code != http.StatusOK || caps["version"] != float64(1) || caps["active_ms"] != true ||
 		caps["attribution_version"] != float64(2) || caps["timezone"] != "UTC" ||
-		caps["account_id"] != f.user.ID || caps["all_time"] != true ||
+		caps["account_id"] != f.user.ID || caps["all_time"] != true || caps["comparison"] != true ||
 		caps["max_candidates"] != float64(10_000) || caps["max_calendar_days"] != float64(4000) ||
 		caps["max_local_active_days"] != float64(10_000) ||
 		caps["max_body_bytes"] != float64(config.Default().Ops.MaxBodyBytes) {
 		t.Errorf("capability contract: %d %v", code, caps)
 	}
+
 	other := store.User{ID: "other-user", Name: "other-reader", Argon2Hash: f.user.Argon2Hash, Timezone: "Europe/Paris", CreatedAt: time.Now()}
 	if err := f.st.CreateUser(t.Context(), other); err != nil {
 		t.Fatal(err)
@@ -923,6 +965,202 @@ func TestInsightsSnapshotTokenAdvertisesMeasuredSessionsWithoutInsightsScope(t *
 	got := readSnapshot(t, f.ts.URL, f.reader, snapshotBody(ses))
 	if !got.Complete || got.Summary.TotalActiveMinutes != 30 || got.Overlap.Minutes != 30 {
 		t.Errorf("advertised measured session was not preserved: %+v", got)
+	}
+}
+
+func TestInsightsSnapshotComparisonTotalsAndOverlapShareOneSnapshot(t *testing.T) {
+	f := newSnapshotFixture(t)
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	current, remote, previous := f.session("comparison-current"), f.session("comparison-remote"), f.session("comparison-previous")
+	current.StartedAt, current.EndedAt = today.Add(10*time.Hour), today.Add(14*time.Hour)
+	currentActive := int64(120 * 60 * 1000)
+	current.ActiveMs = &currentActive
+	remote.StartedAt, remote.EndedAt = today.Add(9*time.Hour), today.Add(10*time.Hour)
+	remoteActive := int64(60 * 60 * 1000)
+	remote.ActiveMs, remote.DeviceID = &remoteActive, "other-device"
+	previousDay := today.AddDate(0, 0, -2)
+	previous.StartedAt, previous.EndedAt = previousDay.Add(10*time.Hour), previousDay.Add(14*time.Hour)
+	previousActive := int64(240 * 60 * 1000)
+	previous.ActiveMs = &previousActive
+	if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{current, remote, previous}); err != nil {
+		t.Fatal(err)
+	}
+	body := comparisonBody(now, current, previous)
+	got := readSnapshot(t, f.ts.URL, f.reader, body)
+	if !got.Complete || got.Comparison == nil || got.Overlap.Comparison == nil || got.ComparisonReason != "" {
+		t.Fatalf("comparison missing from complete snapshot: %+v", got)
+	}
+	if got.Comparison.Through != "12:00:00.000" {
+		t.Fatalf("cutoff was not normalized: server=%+v", got.Comparison)
+	}
+	requested := body["comparison"].(map[string]any)
+	if got.Comparison.CurrentFrom != requested["current_from"] || got.Comparison.CurrentTo != requested["current_to"] ||
+		got.Comparison.PreviousFrom != requested["previous_from"] || got.Comparison.PreviousTo != requested["previous_to"] {
+		t.Fatalf("comparison bounds were not echoed: request=%v server=%+v", requested, got.Comparison)
+	}
+	if got.Overlap.Comparison.CurrentFrom != "" || got.Overlap.Comparison.CurrentTo != "" ||
+		got.Overlap.Comparison.PreviousFrom != "" || got.Overlap.Comparison.PreviousTo != "" ||
+		got.Overlap.Comparison.Through != "" {
+		t.Fatalf("overlap comparison must contain totals only: %+v", got.Overlap.Comparison)
+	}
+	snapshotNear(t, "current server comparison", got.Comparison.CurrentMinutes, 120)
+	snapshotNear(t, "previous server comparison", got.Comparison.PreviousMinutes, 120)
+	snapshotNear(t, "current overlap comparison", got.Overlap.Comparison.CurrentMinutes, 60)
+	snapshotNear(t, "previous overlap comparison", got.Overlap.Comparison.PreviousMinutes, 120)
+	snapshotNear(t, "whole-day headline remains unchanged", got.Summary.TotalActiveMinutes, 180)
+}
+
+func TestInsightsSnapshotComparisonRefusalDoesNotInvalidateHeadline(t *testing.T) {
+	f := newSnapshotFixture(t)
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	current, previous := f.session("current"), f.session("previous")
+	current.StartedAt, current.EndedAt = today.Add(9*time.Hour), today.Add(10*time.Hour)
+	currentActive := int64(60 * 60 * 1000)
+	current.ActiveMs = &currentActive
+	previousDay := today.AddDate(0, 0, -2)
+	previous.StartedAt, previous.EndedAt = previousDay.Add(9*time.Hour), previousDay.Add(10*time.Hour)
+	previousActive := int64(60 * 60 * 1000)
+	previous.ActiveMs = &previousActive
+	if err := f.st.AppendSessions(t.Context(), f.user.ID, []store.Session{current, previous}); err != nil {
+		t.Fatal(err)
+	}
+	changed := previous
+	changedActive := int64(30 * 60 * 1000)
+	changed.ActiveMs = &changedActive
+	got := readSnapshot(t, f.ts.URL, f.reader, comparisonBody(now, changed))
+	if !got.Complete || got.IncompleteReason != "" || got.Comparison != nil ||
+		got.Overlap.Comparison != nil || got.ComparisonReason != "candidate_payload_mismatch" {
+		t.Fatalf("baseline-only mismatch damaged the headline or produced a comparison: %+v", got)
+	}
+	snapshotNear(t, "valid headline survives", got.Summary.TotalActiveMinutes, 60)
+}
+
+func TestInsightsSnapshotComparisonRefusesCompactedBoundaryOnly(t *testing.T) {
+	f := newSnapshotFixture(t)
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	current := f.session("current")
+	current.StartedAt, current.EndedAt = today.Add(9*time.Hour), today.Add(10*time.Hour)
+	active := int64(60 * 60 * 1000)
+	current.ActiveMs = &active
+	previousTo := today.AddDate(0, 0, -2).Format(insights.DayFormat)
+	snap := store.StatsSnapshot{
+		Timezone: "UTC", Revision: 19, Works: []store.Work{f.work}, Sessions: []store.Session{current},
+		Rollups: []store.SessionRollup{{
+			WorkID: f.work.ID, Day: previousTo, Timezone: "UTC",
+			AttributionVersion: 2, ActiveSeconds: 3600, SessionCount: 1,
+		}},
+	}
+	st := &snapshotReadStore{Store: f.st, read: func(context.Context, string, []string) (store.StatsSnapshot, error) {
+		return snap, nil
+	}}
+	ts := snapshotTestServer(t, f, st, 0)
+	got := readSnapshot(t, ts.URL, f.reader, comparisonBody(now))
+	if !got.Complete || got.IncompleteReason != "" || got.Comparison != nil ||
+		got.ComparisonReason != "comparison_history_incomplete" {
+		t.Fatalf("comparison-only rollup refusal damaged the headline: %+v", got)
+	}
+	snapshotNear(t, "headline current raw session", got.Summary.TotalActiveMinutes, 60)
+}
+
+func TestInsightsSnapshotComparisonAcceptsArchivedBaselineOnlyWork(t *testing.T) {
+	f := newSnapshotFixture(t)
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	current := f.session("current")
+	current.StartedAt, current.EndedAt = today.Add(9*time.Hour), today.Add(10*time.Hour)
+	active := int64(60 * 60 * 1000)
+	current.ActiveMs = &active
+	baselineWork := store.Work{ID: "baseline-work", UserID: f.user.ID}
+	baseline := f.session("baseline")
+	baseline.WorkID = baselineWork.ID
+	baselineDay := today.AddDate(0, 0, -3)
+	baseline.StartedAt, baseline.EndedAt = baselineDay.Add(9*time.Hour), baselineDay.Add(10*time.Hour)
+	baseline.ActiveMs = &active
+	baselineExact := active
+	snap := store.StatsSnapshot{
+		Timezone: "UTC", Revision: 20, Works: []store.Work{f.work, baselineWork},
+		Sessions: []store.Session{current},
+		Rollups: []store.SessionRollup{{
+			WorkID: baselineWork.ID, Day: baselineDay.Format(insights.DayFormat), Timezone: "UTC",
+			AttributionVersion: 2, ActiveSeconds: 3600, SessionCount: 1,
+			ComparisonActiveMs: &baselineExact,
+		}},
+		Archived: map[string]store.ArchivedSession{
+			baseline.SessionID: {
+				Fingerprint: store.SessionFingerprint(baseline), WorkID: baselineWork.ID,
+				Day: baselineDay.Format(insights.DayFormat), Timezone: "UTC",
+				AttributionVersion: 2, Present: true, ActiveSeconds: 3600,
+				ComparisonActiveMs: &baselineExact,
+			},
+		},
+	}
+	st := &snapshotReadStore{Store: f.st, read: func(context.Context, string, []string) (store.StatsSnapshot, error) {
+		return snap, nil
+	}}
+	ts := snapshotTestServer(t, f, st, 0)
+	got := readSnapshot(t, ts.URL, f.reader, comparisonBody(now, baseline))
+	if !got.Complete || got.Comparison == nil || got.Overlap.Comparison == nil || got.ComparisonReason != "" {
+		t.Fatalf("baseline-only archived work was refused: %+v", got)
+	}
+	snapshotNear(t, "baseline server", got.Comparison.PreviousMinutes, 60)
+	snapshotNear(t, "baseline overlap", got.Overlap.Comparison.PreviousMinutes, 60)
+}
+
+func TestInsightsSnapshotRejectsInvalidComparisonWindows(t *testing.T) {
+	f := newSnapshotFixture(t)
+	now := time.Now().UTC()
+	for _, tc := range []struct {
+		name string
+		edit func(map[string]any, map[string]any)
+	}{
+		{"all-time headline", func(body, comparison map[string]any) {
+			delete(body, "from")
+			delete(body, "to")
+			body["range"] = "all"
+		}},
+		{"missing comparison date", func(_ map[string]any, comparison map[string]any) {
+			delete(comparison, "previous_from")
+		}},
+		{"invalid comparison date", func(_ map[string]any, comparison map[string]any) {
+			comparison["previous_from"] = "2026-02-30"
+		}},
+		{"overlapping spans", func(_ map[string]any, comparison map[string]any) {
+			comparison["previous_to"] = comparison["current_from"]
+		}},
+		{"headline mismatch", func(_ map[string]any, comparison map[string]any) {
+			comparison["current_from"] = now.AddDate(0, 0, -2).Format(insights.DayFormat)
+		}},
+		{"current does not end today", func(body, comparison map[string]any) {
+			yesterday := now.AddDate(0, 0, -1).Format(insights.DayFormat)
+			body["to"], body["calendar_to"], comparison["current_to"] = yesterday, yesterday, yesterday
+		}},
+		{"malformed through", func(_ map[string]any, comparison map[string]any) {
+			comparison["through"] = "noon"
+		}},
+		{"sub-millisecond through", func(_ map[string]any, comparison map[string]any) {
+			comparison["through"] = "12:00:00.0001"
+		}},
+		{"excessive previous span", func(_ map[string]any, comparison map[string]any) {
+			previousTo, _ := time.Parse(insights.DayFormat, comparison["previous_to"].(string))
+			comparison["previous_from"] = previousTo.AddDate(0, 0, -4000).Format(insights.DayFormat)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			body := comparisonBody(now)
+			comparison := body["comparison"].(map[string]any)
+			tc.edit(body, comparison)
+			code, out := post(t, f.ts.URL+"/v1/insights/snapshot", f.reader, body)
+			requireSnapshotError(t, code, out, http.StatusBadRequest)
+		})
+	}
+	body := comparisonBody(now)
+	delete(body, "comparison")
+	got := readSnapshot(t, f.ts.URL, f.reader, body)
+	if !got.Complete || got.Comparison != nil || got.ComparisonReason != "" || got.Overlap.Comparison != nil {
+		t.Fatalf("absent comparison changed the existing response: %+v", got)
 	}
 }
 

--- a/internal/insights/aggregate.go
+++ b/internal/insights/aggregate.go
@@ -92,7 +92,7 @@ func Build(snap store.StatsSnapshot, win Window, now time.Time) (Result, error) 
 	for _, w := range snap.Works {
 		out.ByWork[w.ID] = Work{WorkID: w.ID, Title: w.Title, Author: w.Author}
 	}
-	add := func(workID, day string, seconds, pages float64, count int, last time.Time, measuredSeconds, delta float64, legacy bool) {
+	recordActiveDay := func(day string, seconds float64) {
 		if seconds > 0 && day <= today {
 			out.ActiveDays[day] = true
 			if out.FirstActivityDay == nil || day < *out.FirstActivityDay {
@@ -100,6 +100,9 @@ func Build(snap store.StatsSnapshot, win Window, now time.Time) (Result, error) 
 				out.FirstActivityDay = &date
 			}
 		}
+	}
+	add := func(workID, day string, seconds, pages float64, count int, last time.Time, measuredSeconds, delta float64, legacy bool) {
+		recordActiveDay(day, seconds)
 		if day < from || day > to {
 			return
 		}
@@ -142,15 +145,29 @@ func Build(snap store.StatsSnapshot, win Window, now time.Time) (Result, error) 
 			ses.EndedAt, measured, delta, false)
 	}
 	for _, ru := range snap.Rollups {
-		day, err := time.ParseInLocation(DayFormat, ru.Day, loc)
+		day, err := time.Parse(DayFormat, ru.Day)
 		if err != nil {
 			return out, err
 		}
-		if ru.AttributionVersion != 2 || ru.Timezone != snap.Timezone {
+		recordActiveDay(ru.Day, ru.ActiveSeconds)
+		if ru.AttributionVersion != 2 && win.HoldsDay(ru.Day) {
 			out.Complete = false
 			out.IncompleteReason = "legacy_or_different_timezone_rollups"
 		}
-		add(ru.WorkID, ru.Day, ru.ActiveSeconds, ru.Pages, int(ru.SessionCount), day,
+		if ru.AttributionVersion == 2 && ru.Timezone != snap.Timezone {
+			intersects, err := rollupDayIntersectsWindow(ru, win, now)
+			if err != nil {
+				return out, err
+			}
+			if intersects {
+				out.Complete = false
+				out.IncompleteReason = "legacy_or_different_timezone_rollups"
+			} else {
+				continue
+			}
+		}
+		dayStart, _ := DayWindow(day, day, loc).SessionBounds(now, loc)
+		add(ru.WorkID, ru.Day, ru.ActiveSeconds, ru.Pages, int(ru.SessionCount), dayStart,
 			ru.MeasuredActiveSeconds, ru.MeasuredProgDelta, ru.AttributionVersion != 2)
 	}
 	var totalPace pace
@@ -198,4 +215,21 @@ func Build(snap store.StatsSnapshot, win Window, now time.Time) (Result, error) 
 		return out.Works[i].TotalActiveMinutes > out.Works[j].TotalActiveMinutes
 	})
 	return out, nil
+}
+
+func rollupDayIntersectsWindow(rollup store.SessionRollup, win Window, now time.Time) (bool, error) {
+	loc, err := time.LoadLocation(rollup.Timezone)
+	if err != nil {
+		return false, err
+	}
+	day, err := time.Parse(DayFormat, rollup.Day)
+	if err != nil {
+		return false, err
+	}
+	rollupWindow := DayWindow(day, day, loc)
+	from, to := rollupWindow.SessionBounds(now, loc)
+	if win.Unbounded() {
+		return true, nil
+	}
+	return from.Before(win.to) && to.After(win.from), nil
 }

--- a/internal/insights/aggregate_regression_test.go
+++ b/internal/insights/aggregate_regression_test.go
@@ -146,6 +146,7 @@ func TestAggregateLegacyAndForeignTimezoneRollupsRemainVisible(t *testing.T) {
 					SessionCount: 2, ProgDelta: 0.2, Timezone: tc.zone, AttributionVersion: tc.version,
 				}},
 			}
+
 			got, err := Build(snap, Window{}, now)
 			if err != nil {
 				t.Fatal(err)
@@ -161,6 +162,88 @@ func TestAggregateLegacyAndForeignTimezoneRollupsRemainVisible(t *testing.T) {
 				t.Errorf("fallback loses totals or fabricates pace: %+v", got)
 			}
 		})
+	}
+}
+
+func TestAggregateIgnoresOldTimezoneRollupOutsideBoundedWindow(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+	snap := store.StatsSnapshot{
+		Timezone: "UTC",
+		Works:    []store.Work{{ID: "book"}},
+		Rollups: []store.SessionRollup{
+			{WorkID: "book", Day: "2025-01-01", Timezone: "Europe/Paris", AttributionVersion: 2, ActiveSeconds: 600, SessionCount: 1},
+			{WorkID: "book", Day: "2026-03-30", ActiveSeconds: 300, SessionCount: 1, Timezone: "UTC", AttributionVersion: 2},
+		},
+	}
+
+	got, err := Build(snap, DayWindow(now, now, time.UTC), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Complete || got.IncompleteReason != "" || got.Summary.TotalActiveMinutes != 5 {
+		t.Fatalf("out-of-window legacy history invalidated a bounded headline: %+v", got)
+	}
+}
+
+func TestAggregateIgnoresLegacyRollupOutsideBoundedWindow(t *testing.T) {
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, time.UTC)
+	snap := store.StatsSnapshot{
+		Timezone: "UTC",
+		Works:    []store.Work{{ID: "book"}},
+		Rollups: []store.SessionRollup{
+			{WorkID: "book", Day: "2025-01-01", ActiveSeconds: 600, SessionCount: 1},
+			{WorkID: "book", Day: "2026-03-30", Timezone: "UTC", AttributionVersion: 2, ActiveSeconds: 300, SessionCount: 1},
+		},
+	}
+	got, err := Build(snap, DayWindow(now, now, time.UTC), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Complete || got.IncompleteReason != "" || got.Summary.TotalActiveMinutes != 5 {
+		t.Fatalf("out-of-window legacy history invalidated a bounded headline: %+v", got)
+	}
+}
+
+func TestAggregateDetectsOldTimezoneDayCrossingBoundedWindow(t *testing.T) {
+	kiritimati := mustLoad("Pacific/Kiritimati")
+	now := time.Date(2026, 9, 2, 12, 0, 0, 0, kiritimati)
+	win := DayWindow(now, now, kiritimati)
+	snap := store.StatsSnapshot{
+		Timezone: "Pacific/Kiritimati",
+		Works:    []store.Work{{ID: "book"}},
+		Rollups: []store.SessionRollup{{
+			WorkID: "book", Day: "2026-09-01", Timezone: "UTC",
+			AttributionVersion: 2, ActiveSeconds: 600, SessionCount: 1,
+		}},
+	}
+	got, err := Build(snap, win, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Complete || got.IncompleteReason != "legacy_or_different_timezone_rollups" {
+		t.Fatalf("old-timezone day intersecting the requested instants claimed complete: %+v", got)
+	}
+}
+
+func TestAggregateSkippedForeignTimezoneRollupStillDecoratesStreak(t *testing.T) {
+	honolulu := mustLoad("Pacific/Honolulu")
+	now := time.Date(2026, 3, 30, 12, 0, 0, 0, honolulu)
+	snap := store.StatsSnapshot{
+		Timezone: "Pacific/Honolulu",
+		Works:    []store.Work{{ID: "book"}},
+		Rollups: []store.SessionRollup{{
+			WorkID: "book", Day: "2026-03-30", Timezone: "Pacific/Kiritimati",
+			AttributionVersion: 2, ActiveSeconds: 600, SessionCount: 1,
+		}},
+	}
+	got, err := Build(snap, DayWindow(now, now, honolulu), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Complete || got.Summary.TotalActiveMinutes != 0 || len(got.Days) != 0 ||
+		got.Summary.StreakDays != 1 || !got.ActiveDays["2026-03-30"] ||
+		got.FirstActivityDay == nil || *got.FirstActivityDay != "2026-03-30" {
+		t.Fatalf("skipped old-timezone rollup lost all-history activity: %+v", got)
 	}
 }
 

--- a/internal/insights/comparison.go
+++ b/internal/insights/comparison.go
@@ -1,0 +1,278 @@
+package insights
+
+import (
+	"math"
+	"sort"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+const ComparisonTimeFormat = "15:04:05.000"
+
+// ComparisonWindow is a bounded date span whose last day stops at one
+// account-local wall-clock time rather than at midnight.
+type ComparisonWindow struct {
+	fromDay string
+	toDay   string
+	through string
+	from    time.Time
+	cutoff  time.Time
+}
+
+// NewComparisonWindow validates and resolves a comparison span. Repeated
+// wall times use the earlier occurrence; skipped wall times move forward by
+// the size of the gap, matching java.time.LocalDateTime.atZone.
+func NewComparisonWindow(rawFrom, rawTo, rawThrough string, loc *time.Location) (ComparisonWindow, bool) {
+	fromDay, errFrom := time.Parse(DayFormat, rawFrom)
+	toDay, errTo := time.Parse(DayFormat, rawTo)
+	hour, minute, second, millisecond, through, ok := parseComparisonTime(rawThrough)
+	if errFrom != nil || errTo != nil || toDay.Before(fromDay) || !ok {
+		return ComparisonWindow{}, false
+	}
+	from, ok := resolveWallTime(fromDay, 0, 0, 0, 0, loc)
+	if !ok {
+		return ComparisonWindow{}, false
+	}
+	cutoff, ok := resolveWallTime(toDay, hour, minute, second, millisecond*int(time.Millisecond), loc)
+	if !ok {
+		return ComparisonWindow{}, false
+	}
+	return ComparisonWindow{
+		fromDay: rawFrom,
+		toDay:   rawTo,
+		through: through,
+		from:    from,
+		cutoff:  cutoff,
+	}, true
+}
+
+func (w ComparisonWindow) FromDay() string { return w.fromDay }
+func (w ComparisonWindow) ToDay() string   { return w.toDay }
+func (w ComparisonWindow) Through() string { return w.through }
+
+func (w ComparisonWindow) Days() int {
+	from, errFrom := time.Parse(DayFormat, w.fromDay)
+	to, errTo := time.Parse(DayFormat, w.toDay)
+	if errFrom != nil || errTo != nil {
+		return 0
+	}
+	return int(to.Sub(from).Hours()/24) + 1
+}
+
+// HoldsSession reports whether a raw session contributes positive active
+// time to this span.
+func (w ComparisonWindow) HoldsSession(ses store.Session) bool {
+	ms, ok := comparisonSessionMillis(ses, w)
+	return ok && ms > 0
+}
+
+// SpanMinutes sums one comparison span from a coherent statistics snapshot.
+//
+// Raw sessions can be divided at the cutoff because their original
+// timestamps remain available. A rollup on or after the partial last day
+// cannot prove whether one of its sessions crossed the cutoff, so the whole
+// comparison is refused rather than approximated.
+func SpanMinutes(snap store.StatsSnapshot, win ComparisonWindow, loc *time.Location) (float64, bool) {
+	var total int64
+	add := func(ms int64) bool {
+		if ms < 0 || total > math.MaxInt64-ms {
+			return false
+		}
+		total += ms
+		return true
+	}
+	for _, ses := range snap.Sessions {
+		ms, ok := comparisonSessionMillis(ses, win)
+		if !ok || !add(ms) {
+			return 0, false
+		}
+	}
+	for _, rollup := range snap.Rollups {
+		if _, err := time.Parse(DayFormat, rollup.Day); err != nil {
+			return 0, false
+		}
+		if rollup.ActiveSeconds <= 0 {
+			continue
+		}
+		if rollup.AttributionVersion != 2 || rollup.Timezone == "" {
+			if rollup.Day < win.fromDay {
+				continue
+			}
+			return 0, false
+		}
+		if rollup.Timezone != snap.Timezone {
+			rollupLoc, err := time.LoadLocation(rollup.Timezone)
+			if err != nil {
+				return 0, false
+			}
+			day, _ := time.Parse(DayFormat, rollup.Day)
+			_, rollupEnd := DayWindow(day, day, rollupLoc).SessionBounds(win.cutoff, rollupLoc)
+			if !rollupEnd.After(win.from) {
+				continue
+			}
+			return 0, false
+		}
+		if rollup.Day < win.fromDay {
+			continue
+		}
+		if rollup.Day >= win.toDay {
+			return 0, false
+		}
+		if rollup.ComparisonActiveMs == nil || *rollup.ComparisonActiveMs < 0 {
+			return 0, false
+		}
+		ms := *rollup.ComparisonActiveMs
+		if !add(ms) {
+			return 0, false
+		}
+	}
+	return float64(total) / 60_000, true
+}
+
+func comparisonSessionMillis(ses store.Session, win ComparisonWindow) (int64, bool) {
+	if ses.EndedAt.Before(ses.StartedAt) {
+		return 0, true
+	}
+	active, ok := sessionActiveMilliseconds(ses)
+	if !ok || active <= 0 || ses.EndedAt.Before(win.from) {
+		return 0, ok
+	}
+	if !ses.EndedAt.After(win.cutoff) {
+		return active, true
+	}
+	if !ses.StartedAt.Before(win.cutoff) {
+		return 0, true
+	}
+	extent := ses.EndedAt.UnixMilli() - ses.StartedAt.UnixMilli()
+	elapsed := win.cutoff.UnixMilli() - ses.StartedAt.UnixMilli()
+	if extent <= 0 || elapsed <= 0 {
+		return 0, true
+	}
+	counted := math.Round(float64(active) * float64(elapsed) / float64(extent))
+	if counted <= 0 {
+		return 0, true
+	}
+	if counted > float64(math.MaxInt64) {
+		return 0, false
+	}
+	return int64(counted), true
+}
+
+func sessionActiveMilliseconds(ses store.Session) (int64, bool) {
+	if ses.ActiveMs != nil {
+		if *ses.ActiveMs < 0 {
+			return 0, false
+		}
+		return *ses.ActiveMs, true
+	}
+	span := ses.EndedAt.UnixMilli() - ses.StartedAt.UnixMilli()
+	if span <= ses.IdleMs {
+		return 0, true
+	}
+	return span - ses.IdleMs, true
+}
+
+func parseComparisonTime(raw string) (hour, minute, second, millisecond int, normalized string, ok bool) {
+	if len(raw) != 5 && len(raw) != 8 && (len(raw) < 10 || len(raw) > 12) {
+		return 0, 0, 0, 0, "", false
+	}
+	if raw[2] != ':' || (len(raw) > 5 && raw[5] != ':') || (len(raw) > 8 && raw[8] != '.') {
+		return 0, 0, 0, 0, "", false
+	}
+	digit := func(i int) (int, bool) {
+		if raw[i] < '0' || raw[i] > '9' {
+			return 0, false
+		}
+		return int(raw[i] - '0'), true
+	}
+	pair := func(i int) (int, bool) {
+		a, aok := digit(i)
+		b, bok := digit(i + 1)
+		return a*10 + b, aok && bok
+	}
+	var valid bool
+	if hour, valid = pair(0); !valid {
+		return 0, 0, 0, 0, "", false
+	}
+	if minute, valid = pair(3); !valid {
+		return 0, 0, 0, 0, "", false
+	}
+	if hour > 23 || minute > 59 {
+		return 0, 0, 0, 0, "", false
+	}
+	if len(raw) == 5 {
+		second, millisecond = 0, 0
+	} else if second, valid = pair(6); !valid || second > 59 {
+		return 0, 0, 0, 0, "", false
+	} else if len(raw) == 8 {
+		millisecond = 0
+	} else {
+		fraction := 0
+		for i := 9; i < len(raw); i++ {
+			value, valid := digit(i)
+			if !valid {
+				return 0, 0, 0, 0, "", false
+			}
+			fraction = fraction*10 + value
+		}
+		switch len(raw) - 9 {
+		case 1:
+			millisecond = fraction * 100
+		case 2:
+			millisecond = fraction * 10
+		case 3:
+			millisecond = fraction
+		default:
+			return 0, 0, 0, 0, "", false
+		}
+	}
+	at := time.Date(0, 1, 1, hour, minute, second, millisecond*int(time.Millisecond), time.UTC)
+	return hour, minute, second, millisecond, at.Format(ComparisonTimeFormat), true
+}
+
+func resolveWallTime(day time.Time, hour, minute, second, nanosecond int, loc *time.Location) (time.Time, bool) {
+	naive := time.Date(day.Year(), day.Month(), day.Day(), hour, minute, second, nanosecond, time.UTC)
+	offsets := make(map[int]bool)
+	guess := time.Date(day.Year(), day.Month(), day.Day(), hour, minute, second, nanosecond, loc)
+	for probe := guess.Add(-48 * time.Hour); !probe.After(guess.Add(48 * time.Hour)); probe = probe.Add(15 * time.Minute) {
+		_, offset := probe.In(loc).Zone()
+		offsets[offset] = true
+	}
+	match := func(wall time.Time) (time.Time, bool) {
+		var earliest time.Time
+		for offset := range offsets {
+			candidate := wall.Add(-time.Duration(offset) * time.Second)
+			local := candidate.In(loc)
+			if local.Year() != wall.Year() || local.Month() != wall.Month() || local.Day() != wall.Day() ||
+				local.Hour() != wall.Hour() || local.Minute() != wall.Minute() ||
+				local.Second() != wall.Second() || local.Nanosecond() != wall.Nanosecond() {
+				continue
+			}
+			if earliest.IsZero() || candidate.Before(earliest) {
+				earliest = candidate
+			}
+		}
+		return earliest, !earliest.IsZero()
+	}
+	if instant, ok := match(naive); ok {
+		return instant, true
+	}
+	values := make([]int, 0, len(offsets))
+	for offset := range offsets {
+		values = append(values, offset)
+	}
+	sort.Ints(values)
+	for i := 0; i < len(values); i++ {
+		for j := i + 1; j < len(values); j++ {
+			gap := values[j] - values[i]
+			if gap <= 0 {
+				continue
+			}
+			if instant, ok := match(naive.Add(time.Duration(gap) * time.Second)); ok {
+				return instant, true
+			}
+		}
+	}
+	return time.Time{}, false
+}

--- a/internal/insights/comparison_test.go
+++ b/internal/insights/comparison_test.go
@@ -1,0 +1,242 @@
+package insights
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+func TestSpanMinutesProratesAndRoundsLikeKotlin(t *testing.T) {
+	win, ok := NewComparisonWindow("2026-09-01", "2026-09-02", "12:00:00", time.UTC)
+	if !ok {
+		t.Fatal("comparison window did not parse")
+	}
+	active := int64(1001)
+	straddlingActive := int64(1400)
+	exactCutoffActive := int64(250)
+	snap := store.StatsSnapshot{
+		Timezone: "UTC",
+		Sessions: []store.Session{
+			{
+				StartedAt: time.Date(2026, 9, 2, 11, 0, 0, 0, time.UTC),
+				EndedAt:   time.Date(2026, 9, 2, 13, 0, 0, 0, time.UTC),
+				ActiveMs:  &active,
+			},
+			{
+				StartedAt: time.Date(2026, 9, 1, 23, 59, 59, 0, time.UTC),
+				EndedAt:   time.Date(2026, 9, 2, 0, 0, 1, 0, time.UTC),
+				IdleMs:    500,
+			},
+			{
+				StartedAt: time.Date(2026, 9, 2, 11, 0, 0, 0, time.UTC),
+				EndedAt:   time.Date(2026, 9, 3, 1, 0, 0, 0, time.UTC),
+				ActiveMs:  &straddlingActive,
+			},
+			{
+				StartedAt: time.Date(2026, 9, 2, 11, 59, 59, 0, time.UTC),
+				EndedAt:   time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC),
+				ActiveMs:  &exactCutoffActive,
+			},
+			{
+				StartedAt: time.Date(2026, 9, 2, 12, 0, 0, 0, time.UTC),
+				EndedAt:   time.Date(2026, 9, 2, 12, 1, 0, 0, time.UTC),
+				ActiveMs:  &active,
+			},
+		},
+	}
+	got, exact := SpanMinutes(snap, win, time.UTC)
+	if !exact {
+		t.Fatal("raw sessions should be exact")
+	}
+	// 1001 ms at a half-way cutoff rounds to 501 ms, and the fallback
+	// session contributes its full 1500 ms. The sitting ending after
+	// midnight still contributes the 100 ms earned before the cutoff.
+	if want := float64(2351) / 60_000; math.Abs(got-want) > 1e-12 {
+		t.Fatalf("minutes: got %.12f, want %.12f", got, want)
+	}
+}
+
+func TestComparisonWindowUsesJavaDSTResolution(t *testing.T) {
+	paris := mustLoad("Europe/Paris")
+	repeat, ok := NewComparisonWindow("2026-10-25", "2026-10-25", "02:30:00", paris)
+	if !ok {
+		t.Fatal("repeated wall time did not parse")
+	}
+	if want := time.Date(2026, 10, 25, 0, 30, 0, 0, time.UTC); !repeat.cutoff.Equal(want) {
+		t.Fatalf("repeat chose %s, want earlier occurrence %s", repeat.cutoff, want)
+	}
+	repeatActive := int64(time.Hour / time.Millisecond)
+	repeatMinutes, exact := SpanMinutes(store.StatsSnapshot{
+		Timezone: "Europe/Paris",
+		Sessions: []store.Session{{
+			StartedAt: time.Date(2026, 10, 25, 0, 0, 0, 0, time.UTC),
+			EndedAt:   time.Date(2026, 10, 25, 1, 0, 0, 0, time.UTC),
+			ActiveMs:  &repeatActive,
+		}},
+	}, repeat, paris)
+	if !exact || repeatMinutes != 30 {
+		t.Fatalf("repeat proration: got %v exact=%v, want 30", repeatMinutes, exact)
+	}
+
+	newYork := mustLoad("America/New_York")
+	gap, ok := NewComparisonWindow("2026-03-08", "2026-03-08", "02:30:00", newYork)
+	if !ok {
+		t.Fatal("skipped wall time did not parse")
+	}
+	if want := time.Date(2026, 3, 8, 7, 30, 0, 0, time.UTC); !gap.cutoff.Equal(want) {
+		t.Fatalf("gap resolved to %s, want shifted-forward instant %s", gap.cutoff, want)
+	}
+	if gap.Through() != "02:30:00.000" {
+		t.Fatalf("cutoff was not normalized to milliseconds: %q", gap.Through())
+	}
+	gapActive := int64(2 * time.Hour / time.Millisecond)
+	gapMinutes, exact := SpanMinutes(store.StatsSnapshot{
+		Timezone: "America/New_York",
+		Sessions: []store.Session{{
+			StartedAt: time.Date(2026, 3, 8, 6, 30, 0, 0, time.UTC),
+			EndedAt:   time.Date(2026, 3, 8, 8, 30, 0, 0, time.UTC),
+			ActiveMs:  &gapActive,
+		}},
+	}, gap, newYork)
+	if !exact || gapMinutes != 60 {
+		t.Fatalf("gap proration: got %v exact=%v, want 60", gapMinutes, exact)
+	}
+}
+
+func TestComparisonWindowPreservesDateWhenMidnightIsSkipped(t *testing.T) {
+	santiago := mustLoad("America/Santiago")
+	win, ok := NewComparisonWindow("2026-09-06", "2026-09-06", "01:30", santiago)
+	if !ok {
+		t.Fatal("midnight-gap comparison did not parse")
+	}
+	if win.FromDay() != "2026-09-06" || win.ToDay() != "2026-09-06" {
+		t.Fatalf("date labels moved across midnight gap: %s..%s", win.FromDay(), win.ToDay())
+	}
+	want := time.Date(2026, 9, 6, 4, 0, 0, 0, time.UTC)
+	if !win.from.Equal(want) {
+		t.Fatalf("day start resolved to %s, want first valid instant %s", win.from, want)
+	}
+	headline := DayWindow(
+		time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 9, 6, 0, 0, 0, 0, time.UTC),
+		santiago,
+	)
+	if headline.FromDay() != "2026-09-06" || headline.ToDay() != "2026-09-06" {
+		t.Fatalf("headline date labels moved across midnight gap: %s..%s", headline.FromDay(), headline.ToDay())
+	}
+	if from, _ := headline.SessionBounds(time.Now(), santiago); !from.Equal(want) {
+		t.Fatalf("headline day start resolved to %s, want %s", from, want)
+	}
+}
+
+func TestSpanMinutesRollupEvidence(t *testing.T) {
+	win, ok := NewComparisonWindow("2026-09-01", "2026-09-03", "12:00:00.250", time.UTC)
+	if !ok {
+		t.Fatal("comparison window did not parse")
+	}
+	exact := int64(60_001)
+	base := store.StatsSnapshot{
+		Timezone: "UTC",
+		Rollups: []store.SessionRollup{{
+			Day: "2026-09-02", Timezone: "UTC", AttributionVersion: 2,
+			ActiveSeconds: 60.001, ComparisonActiveMs: &exact,
+		}},
+	}
+	got, complete := SpanMinutes(base, win, time.UTC)
+	if !complete || math.Abs(got-60.001/60) > 1e-12 {
+		t.Fatalf("whole rollup day: got %v exact=%v", got, complete)
+	}
+	for _, tc := range []struct {
+		name   string
+		rollup store.SessionRollup
+	}{
+		{
+			name: "partial last day",
+			rollup: store.SessionRollup{
+				Day: "2026-09-03", Timezone: "UTC", AttributionVersion: 2,
+				ActiveSeconds: 60, ComparisonActiveMs: &exact,
+			},
+		},
+		{
+			name: "later day may hide midnight straddler",
+			rollup: store.SessionRollup{
+				Day: "2026-09-04", Timezone: "UTC", AttributionVersion: 2,
+				ActiveSeconds: 60, ComparisonActiveMs: &exact,
+			},
+		},
+		{
+			name: "legacy rollup",
+			rollup: store.SessionRollup{
+				Day: "2026-09-02", ActiveSeconds: 60,
+			},
+		},
+		{
+			name: "different timezone",
+			rollup: store.SessionRollup{
+				Day: "2026-09-02", Timezone: "Europe/Paris", AttributionVersion: 2, ActiveSeconds: 60,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snap := base
+			snap.Rollups = append(append([]store.SessionRollup{}, base.Rollups...), tc.rollup)
+			if _, exact := SpanMinutes(snap, win, time.UTC); exact {
+				t.Fatal("comparison claimed exact without timestamp evidence")
+			}
+		})
+	}
+	withoutExact := base
+	withoutExact.Rollups = append([]store.SessionRollup(nil), base.Rollups...)
+	withoutExact.Rollups[0].ComparisonActiveMs = nil
+	if _, exact := SpanMinutes(withoutExact, win, time.UTC); exact {
+		t.Fatal("pre-migration rollup claimed exact millisecond evidence")
+	}
+	withIrrelevantLegacy := base
+	withIrrelevantLegacy.Rollups = append(append([]store.SessionRollup{}, base.Rollups...), store.SessionRollup{
+		Day: "2020-01-01", ActiveSeconds: 60,
+	})
+	if got, exact := SpanMinutes(withIrrelevantLegacy, win, time.UTC); !exact || math.Abs(got-60.001/60) > 1e-12 {
+		t.Fatalf("irrelevant legacy history disabled comparison: got %v exact=%v", got, exact)
+	}
+}
+
+func TestSpanMinutesDoesNotSkipIntersectingOldTimezoneDay(t *testing.T) {
+	kiritimati := mustLoad("Pacific/Kiritimati")
+	win, ok := NewComparisonWindow("2026-09-02", "2026-09-02", "12:00", kiritimati)
+	if !ok {
+		t.Fatal("comparison window did not parse")
+	}
+	exact := int64(60_000)
+	snap := store.StatsSnapshot{
+		Timezone: "Pacific/Kiritimati",
+		Rollups: []store.SessionRollup{{
+			Day: "2026-09-01", Timezone: "UTC", AttributionVersion: 2,
+			ActiveSeconds: 60, ComparisonActiveMs: &exact,
+		}},
+	}
+	if _, complete := SpanMinutes(snap, win, kiritimati); complete {
+		t.Fatal("old-timezone day intersecting the comparison was skipped by its stored date")
+	}
+}
+
+func TestComparisonWindowRejectsSubMillisecondAndMalformedTimes(t *testing.T) {
+	for _, through := range []string{"", "8:00:00", "24:00:00", "12:60:00", "12:00:60", "12:00:00.0000"} {
+		if _, ok := NewComparisonWindow("2026-09-01", "2026-09-02", through, time.UTC); ok {
+			t.Errorf("accepted through=%q", through)
+		}
+	}
+	for raw, want := range map[string]string{
+		"08:48":        "08:48:00.000",
+		"08:48:42":     "08:48:42.000",
+		"08:48:42.1":   "08:48:42.100",
+		"08:48:42.12":  "08:48:42.120",
+		"08:48:42.123": "08:48:42.123",
+	} {
+		win, ok := NewComparisonWindow("2026-09-01", "2026-09-02", raw, time.UTC)
+		if !ok || win.Through() != want {
+			t.Errorf("through=%q: got %q ok=%v, want %q", raw, win.Through(), ok, want)
+		}
+	}
+}

--- a/internal/insights/window.go
+++ b/internal/insights/window.go
@@ -173,13 +173,21 @@ func (w Window) EachDay(earliest string, now time.Time, loc *time.Location, fn f
 // DayWindow builds the window covering firstDay through lastDay
 // inclusive, in loc.
 func DayWindow(firstDay, lastDay time.Time, loc *time.Location) Window {
-	from := time.Date(firstDay.Year(), firstDay.Month(), firstDay.Day(), 0, 0, 0, 0, loc)
-	last := time.Date(lastDay.Year(), lastDay.Month(), lastDay.Day(), 0, 0, 0, 0, loc)
+	firstDate := time.Date(firstDay.Year(), firstDay.Month(), firstDay.Day(), 0, 0, 0, 0, time.UTC)
+	lastDate := time.Date(lastDay.Year(), lastDay.Month(), lastDay.Day(), 0, 0, 0, 0, time.UTC)
+	from, ok := resolveWallTime(firstDate, 0, 0, 0, 0, loc)
+	if !ok {
+		from = time.Date(firstDay.Year(), firstDay.Month(), firstDay.Day(), 0, 0, 0, 0, loc)
+	}
+	to, ok := resolveWallTime(lastDate.AddDate(0, 0, 1), 0, 0, 0, 0, loc)
+	if !ok {
+		to = time.Date(lastDay.Year(), lastDay.Month(), lastDay.Day(), 0, 0, 0, 0, loc).AddDate(0, 0, 1)
+	}
 	return Window{
 		from:    from,
-		to:      last.AddDate(0, 0, 1),
-		fromDay: from.Format(DayFormat),
-		toDay:   last.Format(DayFormat),
+		to:      to,
+		fromDay: firstDate.Format(DayFormat),
+		toDay:   lastDate.Format(DayFormat),
 	}
 }
 
@@ -200,8 +208,8 @@ func DayWindow(firstDay, lastDay time.Time, loc *time.Location) Window {
 // the caller never asked for either way.
 func ParseWindow(rawFrom, rawTo, rawRange, def string, loc *time.Location, now time.Time) Window {
 	if rawFrom != "" && rawTo != "" {
-		from, errFrom := time.ParseInLocation(DayFormat, rawFrom, loc)
-		to, errTo := time.ParseInLocation(DayFormat, rawTo, loc)
+		from, errFrom := time.Parse(DayFormat, rawFrom)
+		to, errTo := time.Parse(DayFormat, rawTo)
 		if errFrom == nil && errTo == nil && !to.Before(from) {
 			return DayWindow(from, to, loc)
 		}

--- a/internal/store/postgres/migrate_test.go
+++ b/internal/store/postgres/migrate_test.go
@@ -112,7 +112,7 @@ func TestBackfillLeavesAConfiguredServerAlone(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			reset(t, s)
-			for i, m := range migrations[:len(migrations)-2] {
+			for i, m := range migrations[:len(migrations)-3] {
 				if _, err := s.db.ExecContext(ctx, m); err != nil {
 					t.Fatal(err)
 				}

--- a/internal/store/postgres/rollups.go
+++ b/internal/store/postgres/rollups.go
@@ -69,26 +69,36 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 		}
 	}
 	if len(v2) > 0 {
-		if err := store.ValidateRollupContributions(v2, proofs); err != nil {
+		if err := store.PrepareRollupContributions(v2, proofs); err != nil {
 			return err
 		}
 	}
+	exact := make(map[string]*int64, len(v2))
+	for _, r := range v2 {
+		exact[r.WorkID+"\x00"+r.Day+"\x00"+r.Timezone] = r.ComparisonActiveMs
+	}
 	for _, r := range rollups {
 		if rollupAttributionVersion(r) == 2 {
+			comparisonActiveMs := exact[r.WorkID+"\x00"+r.Day+"\x00"+r.Timezone]
 			if _, err := tx.ExecContext(ctx, q(
 				`INSERT INTO session_rollups_v2 (user_id, work_id, day, timezone, attribution_version,
 				                              active_seconds, pages, prog_delta, session_count,
-				                              measured_active_seconds, measured_prog_delta)
-				 VALUES (?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?)
+				                              measured_active_seconds, measured_prog_delta, comparison_active_ms)
+				 VALUES (?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?, ?)
 				 ON CONFLICT(user_id, work_id, day, timezone) DO UPDATE SET
 				     active_seconds          = session_rollups_v2.active_seconds + excluded.active_seconds,
 				     pages                   = session_rollups_v2.pages + excluded.pages,
 				     prog_delta              = session_rollups_v2.prog_delta + excluded.prog_delta,
 				     session_count           = session_rollups_v2.session_count + excluded.session_count,
 				     measured_active_seconds = session_rollups_v2.measured_active_seconds + excluded.measured_active_seconds,
-				     measured_prog_delta     = session_rollups_v2.measured_prog_delta + excluded.measured_prog_delta`),
+				     measured_prog_delta     = session_rollups_v2.measured_prog_delta + excluded.measured_prog_delta,
+				     comparison_active_ms    = CASE
+				         WHEN session_rollups_v2.comparison_active_ms IS NULL OR excluded.comparison_active_ms IS NULL THEN NULL
+				         WHEN session_rollups_v2.comparison_active_ms > 9223372036854775807 - excluded.comparison_active_ms THEN NULL
+				         ELSE session_rollups_v2.comparison_active_ms + excluded.comparison_active_ms
+				     END`),
 				userID, r.WorkID, r.Day, r.Timezone, r.ActiveSeconds, r.Pages, r.ProgDelta,
-				r.SessionCount, r.MeasuredActiveSeconds, r.MeasuredProgDelta); err != nil {
+				r.SessionCount, r.MeasuredActiveSeconds, r.MeasuredProgDelta, comparisonActiveMs); err != nil {
 				return err
 			}
 			continue
@@ -111,12 +121,13 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 			if _, err := tx.ExecContext(ctx, q(
 				`INSERT INTO session_tombstones (user_id, session_id, fingerprint, work_id, day, timezone,
 				                                attribution_version, present, active_seconds, pages,
-				                                prog_delta, measured_active_seconds, measured_prog_delta)
-				 VALUES (?, ?, ?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?)
+				                                prog_delta, measured_active_seconds, measured_prog_delta, comparison_active_ms)
+				 VALUES (?, ?, ?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?, ?)
 				 ON CONFLICT(user_id, session_id) DO NOTHING`),
 				userID, ses.SessionID, store.SessionFingerprint(ses), archived.WorkID, archived.Day,
 				archived.Timezone, archived.Present, archived.ActiveSeconds, archived.Pages,
-				archived.ProgDelta, archived.MeasuredActiveSeconds, archived.MeasuredProgDelta); err != nil {
+				archived.ProgDelta, archived.MeasuredActiveSeconds, archived.MeasuredProgDelta,
+				archived.ComparisonActiveMs); err != nil {
 				return err
 			}
 		} else {
@@ -184,6 +195,14 @@ func archivedContribution(ctx context.Context, tx *sql.Tx, userID string, ses st
 			ActiveSeconds:      sessionActiveSeconds(ses),
 			ProgDelta:          sessionProgDelta(ses),
 		}
+		exact := ses.EndedAt.UnixMilli() - ses.StartedAt.UnixMilli() - ses.IdleMs
+		if ses.ActiveMs != nil {
+			exact = *ses.ActiveMs
+		}
+		if exact < 0 {
+			exact = 0
+		}
+		proof.ComparisonActiveMs = &exact
 		pages, err := sessionPages(ctx, tx, userID, ses, proof.ProgDelta, pageCounts)
 		if err != nil {
 			return store.ArchivedSession{}, err
@@ -246,11 +265,12 @@ func sessionPages(ctx context.Context, tx *sql.Tx, userID string, ses store.Sess
 func (s *Store) RollupsInRange(ctx context.Context, userID, fromDay, toDay string) ([]store.SessionRollup, error) {
 	rows, err := s.db.QueryContext(ctx, q(
 		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta,
+		        NULL::BIGINT AS comparison_active_ms
 		 FROM session_rollups WHERE user_id = ? AND day >= ? AND day <= ?
 		 UNION ALL
 		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta, comparison_active_ms
 		 FROM session_rollups_v2 WHERE user_id = ? AND day >= ? AND day <= ?
 		 ORDER BY day, work_id, attribution_version`), userID, fromDay, toDay, userID, fromDay, toDay)
 	if err != nil {
@@ -263,11 +283,12 @@ func (s *Store) RollupsInRange(ctx context.Context, userID, fromDay, toDay strin
 func (s *Store) RollupsForWork(ctx context.Context, userID, workID string) ([]store.SessionRollup, error) {
 	rows, err := s.db.QueryContext(ctx, q(
 		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta,
+		        NULL::BIGINT AS comparison_active_ms
 		 FROM session_rollups WHERE user_id = ? AND work_id = ?
 		 UNION ALL
 		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta, comparison_active_ms
 		 FROM session_rollups_v2 WHERE user_id = ? AND work_id = ?
 		 ORDER BY day, attribution_version`), userID, workID, userID, workID)
 	if err != nil {
@@ -281,10 +302,14 @@ func scanRollups(rows *sql.Rows) ([]store.SessionRollup, error) {
 	var out []store.SessionRollup
 	for rows.Next() {
 		var r store.SessionRollup
+		var comparisonActiveMs sql.NullInt64
 		if err := rows.Scan(&r.UserID, &r.WorkID, &r.Day, &r.ActiveSeconds, &r.Pages, &r.ProgDelta,
 			&r.SessionCount, &r.Timezone, &r.AttributionVersion, &r.MeasuredActiveSeconds,
-			&r.MeasuredProgDelta); err != nil {
+			&r.MeasuredProgDelta, &comparisonActiveMs); err != nil {
 			return nil, err
+		}
+		if comparisonActiveMs.Valid {
+			r.ComparisonActiveMs = &comparisonActiveMs.Int64
 		}
 		out = append(out, r)
 	}

--- a/internal/store/postgres/rollups.go
+++ b/internal/store/postgres/rollups.go
@@ -309,7 +309,8 @@ func scanRollups(rows *sql.Rows) ([]store.SessionRollup, error) {
 			return nil, err
 		}
 		if comparisonActiveMs.Valid {
-			r.ComparisonActiveMs = &comparisonActiveMs.Int64
+			value := comparisonActiveMs.Int64
+			r.ComparisonActiveMs = &value
 		}
 		out = append(out, r)
 	}

--- a/internal/store/postgres/schema.go
+++ b/internal/store/postgres/schema.go
@@ -651,8 +651,13 @@ CREATE TRIGGER stats_revisions_editions_update AFTER UPDATE ON editions FOR EACH
 CREATE TRIGGER stats_revisions_editions_delete AFTER DELETE ON editions FOR EACH ROW EXECUTE FUNCTION bump_stats_revision_old();
 `
 
+const comparisonRollupEvidence = `
+ALTER TABLE session_rollups_v2 ADD COLUMN comparison_active_ms BIGINT;
+ALTER TABLE session_tombstones ADD COLUMN comparison_active_ms BIGINT;
+`
+
 // migrations is append-only, for the reason the SQLite copy gives.
 var migrations = []string{
 	schema, claimRevisions, folderUploads, folderAccess, annotationSync,
-	folderBackfill, statisticsStorage,
+	folderBackfill, statisticsStorage, comparisonRollupEvidence,
 }

--- a/internal/store/postgres/stats.go
+++ b/internal/store/postgres/stats.go
@@ -51,11 +51,12 @@ func (s *Store) StatisticsSnapshot(ctx context.Context, userID string, candidate
 
 	rows, err = tx.QueryContext(ctx, q(
 		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta,
+		        NULL::BIGINT AS comparison_active_ms
 		   FROM session_rollups WHERE user_id = ?
 		  UNION ALL
 		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta, comparison_active_ms
 		   FROM session_rollups_v2 WHERE user_id = ?
 		  ORDER BY day, work_id, attribution_version, timezone`), userID, userID)
 	if err != nil {
@@ -166,7 +167,8 @@ func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []
 		}
 		rows, err := tx.QueryContext(ctx,
 			`SELECT session_id, fingerprint, work_id, day, timezone, attribution_version, present,
-			        active_seconds, pages, prog_delta, measured_active_seconds, measured_prog_delta
+			        active_seconds, pages, prog_delta, measured_active_seconds, measured_prog_delta,
+			        comparison_active_ms
 			   FROM session_tombstones WHERE user_id = $1 AND session_id IN (`+strings.Join(parts, ",")+`)`, args...)
 		if err != nil {
 			return err
@@ -175,9 +177,10 @@ func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []
 			var id string
 			var a store.ArchivedSession
 			var workID, day, timezone *string
+			var comparisonActiveMs *int64
 			if err := rows.Scan(&id, &a.Fingerprint, &workID, &day, &timezone, &a.AttributionVersion,
 				&a.Present, &a.ActiveSeconds, &a.Pages, &a.ProgDelta, &a.MeasuredActiveSeconds,
-				&a.MeasuredProgDelta); err != nil {
+				&a.MeasuredProgDelta, &comparisonActiveMs); err != nil {
 				rows.Close()
 				return err
 			}
@@ -190,6 +193,7 @@ func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []
 			if timezone != nil {
 				a.Timezone = *timezone
 			}
+			a.ComparisonActiveMs = comparisonActiveMs
 			out[id] = a
 		}
 		if err := rows.Err(); err != nil {

--- a/internal/store/rollups.go
+++ b/internal/store/rollups.go
@@ -6,9 +6,25 @@ import "math"
 // will be archived. Sum in session order, as the materializer does, so a stale
 // edition snapshot cannot commit different totals from its retained proofs.
 func ValidateRollupContributions(rollups []SessionRollup, proofs []ArchivedSession) error {
+	return prepareRollupContributions(rollups, proofs, false)
+}
+
+// PrepareRollupContributions validates v2 buckets and fills their exact
+// per-session millisecond totals. Existing rollups created before this
+// evidence was stored remain nil and cannot certify a comparison.
+func PrepareRollupContributions(rollups []SessionRollup, proofs []ArchivedSession) error {
+	return prepareRollupContributions(rollups, proofs, true)
+}
+
+func prepareRollupContributions(rollups []SessionRollup, proofs []ArchivedSession, fill bool) error {
 	type key struct{ workID, day, timezone string }
 	totals := make(map[key]SessionRollup)
+	exactTotals := make(map[key]int64)
+	exactComplete := make(map[key]bool)
 	for _, p := range proofs {
+		if p.ComparisonActiveMs == nil {
+			return ErrConflict
+		}
 		k := key{p.WorkID, p.Day, p.Timezone}
 		r := totals[k]
 		r.ActiveSeconds += p.ActiveSeconds
@@ -17,9 +33,23 @@ func ValidateRollupContributions(rollups []SessionRollup, proofs []ArchivedSessi
 		r.SessionCount++
 		r.MeasuredActiveSeconds += p.MeasuredActiveSeconds
 		r.MeasuredProgDelta += p.MeasuredProgDelta
+		if _, seen := exactComplete[k]; !seen {
+			exactComplete[k] = true
+		}
+		if *p.ComparisonActiveMs < 0 {
+			return ErrConflict
+		}
+		if exactComplete[k] {
+			if exactTotals[k] > math.MaxInt64-*p.ComparisonActiveMs {
+				exactComplete[k] = false
+			} else {
+				exactTotals[k] += *p.ComparisonActiveMs
+			}
+		}
 		totals[k] = r
 	}
-	for _, r := range rollups {
+	for i := range rollups {
+		r := &rollups[i]
 		k := key{r.WorkID, r.Day, r.Timezone}
 		total, ok := totals[k]
 		if !ok || r.SessionCount != total.SessionCount {
@@ -35,6 +65,17 @@ func ValidateRollupContributions(rollups []SessionRollup, proofs []ArchivedSessi
 			if pair[0] != pair[1] || math.IsNaN(pair[0]) || math.IsInf(pair[0], 0) {
 				return ErrConflict
 			}
+		}
+		var exact *int64
+		if exactComplete[k] {
+			value := exactTotals[k]
+			exact = &value
+		}
+		if r.ComparisonActiveMs != nil && (exact == nil || *r.ComparisonActiveMs != *exact) {
+			return ErrConflict
+		}
+		if fill {
+			r.ComparisonActiveMs = exact
 		}
 		delete(totals, k)
 	}

--- a/internal/store/sqlite/migrate_test.go
+++ b/internal/store/sqlite/migrate_test.go
@@ -125,7 +125,7 @@ func TestBackfillLeavesAConfiguredServerAlone(t *testing.T) {
 			t.Cleanup(func() { s.Close() })
 			// Everything up to but not including the backfill, which is
 			// where a server running the broken image sits.
-			for i, m := range migrations[:len(migrations)-2] {
+			for i, m := range migrations[:len(migrations)-3] {
 				if _, err := s.db.ExecContext(ctx, m); err != nil {
 					t.Fatal(err)
 				}

--- a/internal/store/sqlite/rollups.go
+++ b/internal/store/sqlite/rollups.go
@@ -67,25 +67,35 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 		}
 	}
 	if len(v2) > 0 {
-		if err := store.ValidateRollupContributions(v2, proofs); err != nil {
+		if err := store.PrepareRollupContributions(v2, proofs); err != nil {
 			return err
 		}
 	}
+	exact := make(map[string]*int64, len(v2))
+	for _, r := range v2 {
+		exact[r.WorkID+"\x00"+r.Day+"\x00"+r.Timezone] = r.ComparisonActiveMs
+	}
 	for _, r := range rollups {
 		if rollupAttributionVersion(r) == 2 {
+			comparisonActiveMs := exact[r.WorkID+"\x00"+r.Day+"\x00"+r.Timezone]
 			if _, err := tx.ExecContext(ctx, `INSERT INTO session_rollups_v2 (user_id, work_id, day, timezone, attribution_version,
 				                              active_seconds, pages, prog_delta, session_count,
-				                              measured_active_seconds, measured_prog_delta)
-				 VALUES (?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?)
+				                              measured_active_seconds, measured_prog_delta, comparison_active_ms)
+				 VALUES (?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?, ?)
 				 ON CONFLICT(user_id, work_id, day, timezone) DO UPDATE SET
 				     active_seconds          = session_rollups_v2.active_seconds + excluded.active_seconds,
 				     pages                   = session_rollups_v2.pages + excluded.pages,
 				     prog_delta              = session_rollups_v2.prog_delta + excluded.prog_delta,
 				     session_count           = session_rollups_v2.session_count + excluded.session_count,
 				     measured_active_seconds = session_rollups_v2.measured_active_seconds + excluded.measured_active_seconds,
-				     measured_prog_delta     = session_rollups_v2.measured_prog_delta + excluded.measured_prog_delta`,
+				     measured_prog_delta     = session_rollups_v2.measured_prog_delta + excluded.measured_prog_delta,
+				     comparison_active_ms    = CASE
+				         WHEN session_rollups_v2.comparison_active_ms IS NULL OR excluded.comparison_active_ms IS NULL THEN NULL
+				         WHEN session_rollups_v2.comparison_active_ms > 9223372036854775807 - excluded.comparison_active_ms THEN NULL
+				         ELSE session_rollups_v2.comparison_active_ms + excluded.comparison_active_ms
+				     END`,
 				userID, r.WorkID, r.Day, r.Timezone, r.ActiveSeconds, r.Pages, r.ProgDelta,
-				r.SessionCount, r.MeasuredActiveSeconds, r.MeasuredProgDelta); err != nil {
+				r.SessionCount, r.MeasuredActiveSeconds, r.MeasuredProgDelta, comparisonActiveMs); err != nil {
 				return err
 			}
 			continue
@@ -106,12 +116,13 @@ func (s *Store) ApplyRollups(ctx context.Context, userID string, rollups []store
 			archived := proofs[i]
 			if _, err := tx.ExecContext(ctx, `INSERT INTO session_tombstones (user_id, session_id, fingerprint, work_id, day, timezone,
 				                                attribution_version, present, active_seconds, pages,
-				                                prog_delta, measured_active_seconds, measured_prog_delta)
-				 VALUES (?, ?, ?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?)
+				                                prog_delta, measured_active_seconds, measured_prog_delta, comparison_active_ms)
+				 VALUES (?, ?, ?, ?, ?, ?, 2, ?, ?, ?, ?, ?, ?, ?)
 				 ON CONFLICT(user_id, session_id) DO NOTHING`,
 				userID, ses.SessionID, store.SessionFingerprint(ses), archived.WorkID, archived.Day,
 				archived.Timezone, b2i(archived.Present), archived.ActiveSeconds, archived.Pages,
-				archived.ProgDelta, archived.MeasuredActiveSeconds, archived.MeasuredProgDelta); err != nil {
+				archived.ProgDelta, archived.MeasuredActiveSeconds, archived.MeasuredProgDelta,
+				archived.ComparisonActiveMs); err != nil {
 				return err
 			}
 		} else {
@@ -177,6 +188,14 @@ func archivedContribution(ctx context.Context, tx *sql.Tx, userID string, ses st
 			ActiveSeconds:      sessionActiveSeconds(ses),
 			ProgDelta:          sessionProgDelta(ses),
 		}
+		exact := ses.EndedAt.UnixMilli() - ses.StartedAt.UnixMilli() - ses.IdleMs
+		if ses.ActiveMs != nil {
+			exact = *ses.ActiveMs
+		}
+		if exact < 0 {
+			exact = 0
+		}
+		proof.ComparisonActiveMs = &exact
 		pages, err := sessionPages(ctx, tx, userID, ses, proof.ProgDelta, pageCounts)
 		if err != nil {
 			return store.ArchivedSession{}, err
@@ -237,11 +256,12 @@ func sessionPages(ctx context.Context, tx *sql.Tx, userID string, ses store.Sess
 
 func (s *Store) RollupsInRange(ctx context.Context, userID, fromDay, toDay string) ([]store.SessionRollup, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta,
+		        NULL AS comparison_active_ms
 		 FROM session_rollups WHERE user_id = ? AND day >= ? AND day <= ?
 		 UNION ALL
 		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta, comparison_active_ms
 		 FROM session_rollups_v2 WHERE user_id = ? AND day >= ? AND day <= ?
 		 ORDER BY day, work_id, attribution_version`, userID, fromDay, toDay, userID, fromDay, toDay)
 	if err != nil {
@@ -253,11 +273,12 @@ func (s *Store) RollupsInRange(ctx context.Context, userID, fromDay, toDay strin
 
 func (s *Store) RollupsForWork(ctx context.Context, userID, workID string) ([]store.SessionRollup, error) {
 	rows, err := s.db.QueryContext(ctx, `SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta,
+		        NULL AS comparison_active_ms
 		 FROM session_rollups WHERE user_id = ? AND work_id = ?
 		 UNION ALL
 		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta, comparison_active_ms
 		 FROM session_rollups_v2 WHERE user_id = ? AND work_id = ?
 		 ORDER BY day, attribution_version`, userID, workID, userID, workID)
 	if err != nil {
@@ -271,10 +292,14 @@ func scanRollups(rows *sql.Rows) ([]store.SessionRollup, error) {
 	var out []store.SessionRollup
 	for rows.Next() {
 		var r store.SessionRollup
+		var comparisonActiveMs sql.NullInt64
 		if err := rows.Scan(&r.UserID, &r.WorkID, &r.Day, &r.ActiveSeconds, &r.Pages, &r.ProgDelta,
 			&r.SessionCount, &r.Timezone, &r.AttributionVersion, &r.MeasuredActiveSeconds,
-			&r.MeasuredProgDelta); err != nil {
+			&r.MeasuredProgDelta, &comparisonActiveMs); err != nil {
 			return nil, err
+		}
+		if comparisonActiveMs.Valid {
+			r.ComparisonActiveMs = &comparisonActiveMs.Int64
 		}
 		out = append(out, r)
 	}

--- a/internal/store/sqlite/rollups.go
+++ b/internal/store/sqlite/rollups.go
@@ -299,7 +299,8 @@ func scanRollups(rows *sql.Rows) ([]store.SessionRollup, error) {
 			return nil, err
 		}
 		if comparisonActiveMs.Valid {
-			r.ComparisonActiveMs = &comparisonActiveMs.Int64
+			value := comparisonActiveMs.Int64
+			r.ComparisonActiveMs = &value
 		}
 		out = append(out, r)
 	}

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -797,10 +797,15 @@ BEGIN
 END;
 `
 
+const comparisonRollupEvidence = `
+ALTER TABLE session_rollups_v2 ADD COLUMN comparison_active_ms INTEGER;
+ALTER TABLE session_tombstones ADD COLUMN comparison_active_ms INTEGER;
+`
+
 // migrations is append-only: entry n is applied to a database that has
 // applied n-1 of them, so an entry that has shipped is never edited
 // again — the baseline included.
 var migrations = []string{
 	schema, claimRevisions, folderUploads, folderAccess, annotationSync,
-	folderBackfill, statisticsStorage,
+	folderBackfill, statisticsStorage, comparisonRollupEvidence,
 }

--- a/internal/store/sqlite/stats.go
+++ b/internal/store/sqlite/stats.go
@@ -201,7 +201,8 @@ func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []
 			}
 			a.Present = present != 0
 			if comparisonActiveMs.Valid {
-				a.ComparisonActiveMs = &comparisonActiveMs.Int64
+				value := comparisonActiveMs.Int64
+				a.ComparisonActiveMs = &value
 			}
 			out[id] = a
 		}

--- a/internal/store/sqlite/stats.go
+++ b/internal/store/sqlite/stats.go
@@ -50,11 +50,12 @@ func (s *Store) StatisticsSnapshot(ctx context.Context, userID string, candidate
 
 	rows, err = tx.QueryContext(ctx,
 		`SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta
+		        '' AS timezone, 0 AS attribution_version, 0 AS measured_active_seconds, 0 AS measured_prog_delta,
+		        NULL AS comparison_active_ms
 		   FROM session_rollups WHERE user_id = ?
 		  UNION ALL
 		 SELECT user_id, work_id, day, active_seconds, pages, prog_delta, session_count,
-		        timezone, attribution_version, measured_active_seconds, measured_prog_delta
+		        timezone, attribution_version, measured_active_seconds, measured_prog_delta, comparison_active_ms
 		   FROM session_rollups_v2 WHERE user_id = ?
 		  ORDER BY day, work_id, attribution_version, timezone`, userID, userID)
 	if err != nil {
@@ -171,7 +172,8 @@ func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []
 		}
 		rows, err := tx.QueryContext(ctx,
 			`SELECT session_id, fingerprint, work_id, day, timezone, attribution_version, present,
-			        active_seconds, pages, prog_delta, measured_active_seconds, measured_prog_delta
+			        active_seconds, pages, prog_delta, measured_active_seconds, measured_prog_delta,
+			        comparison_active_ms
 			   FROM session_tombstones WHERE user_id = ? AND session_id IN (`+placeholders+`)`, args...)
 		if err != nil {
 			return err
@@ -180,10 +182,11 @@ func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []
 			var id string
 			var a store.ArchivedSession
 			var workID, day, timezone sql.NullString
+			var comparisonActiveMs sql.NullInt64
 			var present int
 			if err := rows.Scan(&id, &a.Fingerprint, &workID, &day, &timezone, &a.AttributionVersion,
 				&present, &a.ActiveSeconds, &a.Pages, &a.ProgDelta, &a.MeasuredActiveSeconds,
-				&a.MeasuredProgDelta); err != nil {
+				&a.MeasuredProgDelta, &comparisonActiveMs); err != nil {
 				rows.Close()
 				return err
 			}
@@ -197,6 +200,9 @@ func loadArchivedSnapshot(ctx context.Context, tx *sql.Tx, userID string, ids []
 				a.Timezone = timezone.String
 			}
 			a.Present = present != 0
+			if comparisonActiveMs.Valid {
+				a.ComparisonActiveMs = &comparisonActiveMs.Int64
+			}
 			out[id] = a
 		}
 		if err := rows.Err(); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1144,6 +1144,7 @@ type SessionRollup struct {
 	AttributionVersion    int
 	MeasuredActiveSeconds float64
 	MeasuredProgDelta     float64
+	ComparisonActiveMs    *int64
 }
 
 // OpResult is the per-item outcome of a batch push.
@@ -1160,6 +1161,7 @@ type ArchivedSession struct {
 	ProgDelta             float64
 	MeasuredActiveSeconds float64
 	MeasuredProgDelta     float64
+	ComparisonActiveMs    *int64
 }
 
 // StatsSnapshot is the coherent store input for statistics aggregation.

--- a/internal/store/storetest/rollups.go
+++ b/internal/store/storetest/rollups.go
@@ -64,6 +64,8 @@ func RollupsRejectStaleEditionPageCount(t *testing.T, s store.Store, updatePages
 				AttributionVersion: 2, ActiveSeconds: 960, Pages: pages, ProgDelta: 0.625,
 				SessionCount: 3, MeasuredActiveSeconds: 360, MeasuredProgDelta: 0.5,
 			}
+			exactActiveMs := int64(960000)
+			rollup.ComparisonActiveMs = &exactActiveMs
 			if err := updatePages(user.ID, edition.SHA256, tc.fresh); err != nil {
 				t.Fatal(err)
 			}
@@ -104,7 +106,7 @@ func RollupsRejectStaleEditionPageCount(t *testing.T, s store.Store, updatePages
 				t.Fatalf("fresh bucket differs from archived contributions: %v", err)
 			}
 			got := after.Rollups[len(after.Rollups)-1]
-			if got != rollup {
+			if !reflect.DeepEqual(got, rollup) {
 				t.Fatalf("fresh bucket: got %+v, want %+v", got, rollup)
 			}
 			now = now.Add(24 * time.Hour)
@@ -113,6 +115,21 @@ func RollupsRejectStaleEditionPageCount(t *testing.T, s store.Store, updatePages
 }
 
 func testV2RollupsRejectMismatchedContributions(t *testing.T, open OpenFunc) {
+	first, second := int64(math.MaxInt64-1), int64(2)
+	overflowing := []store.SessionRollup{{
+		WorkID: "work", Day: "2026-09-04", Timezone: "UTC",
+		AttributionVersion: 2, SessionCount: 2,
+	}}
+	if err := store.PrepareRollupContributions(overflowing, []store.ArchivedSession{
+		{WorkID: "work", Day: "2026-09-04", Timezone: "UTC", ComparisonActiveMs: &first},
+		{WorkID: "work", Day: "2026-09-04", Timezone: "UTC", ComparisonActiveMs: &second},
+	}); err != nil {
+		t.Fatalf("overflowing optional evidence blocked compaction: %v", err)
+	}
+	if overflowing[0].ComparisonActiveMs != nil {
+		t.Fatalf("overflowing exact evidence was retained: %+v", overflowing[0])
+	}
+
 	s := open(t)
 	ctx := t.Context()
 	user := MkUser(t, s, "rollup-contributions")
@@ -183,5 +200,17 @@ func testV2RollupsRejectMismatchedContributions(t *testing.T, open OpenFunc) {
 	}
 	if err := s.ApplyRollups(ctx, user.ID, []store.SessionRollup{rollup}, []store.Session{ses}); err != nil {
 		t.Fatalf("matching contributions must compact: %v", err)
+	}
+	after, err := s.StatisticsSnapshot(ctx, user.ID, []string{ses.SessionID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(after.Rollups) != 1 || after.Rollups[0].ComparisonActiveMs == nil ||
+		*after.Rollups[0].ComparisonActiveMs != 9 {
+		t.Fatalf("rollup lost per-session millisecond evidence: %+v", after.Rollups)
+	}
+	proof := after.Archived[ses.SessionID]
+	if proof.ComparisonActiveMs == nil || *proof.ComparisonActiveMs != 9 {
+		t.Fatalf("archive proof lost per-session millisecond evidence: %+v", proof)
 	}
 }

--- a/internal/store/storetest/statistics_regressions.go
+++ b/internal/store/storetest/statistics_regressions.go
@@ -103,6 +103,8 @@ func testReconcileCalibrePreservesV2RollupHistoryAndArchiveProof(t *testing.T, o
 		AttributionVersion: 2, ActiveSeconds: 300, Pages: 12.5, ProgDelta: 0.25,
 		SessionCount: 1, MeasuredActiveSeconds: 300, MeasuredProgDelta: 0.25,
 	}
+	exactActiveMs := int64(300000)
+	rollup.ComparisonActiveMs = &exactActiveMs
 	if err := s.ApplyRollups(ctx, user.ID, []store.SessionRollup{rollup}, []store.Session{ses}); err != nil {
 		t.Fatal(err)
 	}
@@ -111,6 +113,7 @@ func testReconcileCalibrePreservesV2RollupHistoryAndArchiveProof(t *testing.T, o
 		Timezone: rollup.Timezone, AttributionVersion: 2, Present: true,
 		ActiveSeconds: 300, Pages: 12.5, ProgDelta: 0.25,
 		MeasuredActiveSeconds: 300, MeasuredProgDelta: 0.25,
+		ComparisonActiveMs: &exactActiveMs,
 	}
 	assertHistory := func() {
 		t.Helper()
@@ -118,10 +121,10 @@ func testReconcileCalibrePreservesV2RollupHistoryAndArchiveProof(t *testing.T, o
 		if err != nil {
 			t.Fatal(err)
 		}
-		if len(snap.Sessions) != 0 || len(snap.Rollups) != 1 || snap.Rollups[0] != rollup {
+		if len(snap.Sessions) != 0 || len(snap.Rollups) != 1 || !reflect.DeepEqual(snap.Rollups[0], rollup) {
 			t.Fatalf("want only the intact v2 rollup, got raw=%+v rollups=%+v", snap.Sessions, snap.Rollups)
 		}
-		if proof, ok := snap.Archived[ses.SessionID]; !ok || proof != wantProof {
+		if proof, ok := snap.Archived[ses.SessionID]; !ok || !reflect.DeepEqual(proof, wantProof) {
 			t.Fatalf("archive proof changed: got %+v (exists=%v), want %+v", proof, ok, wantProof)
 		}
 		if _, err := s.WorkByID(ctx, user.ID, work.ID); err != nil {


### PR DESCRIPTION
## Summary

Adds one-snapshot reading comparisons across every device. The server now
returns current and previous period totals at the same time-of-day cutoff,
along with the overlap needed to avoid counting this device twice.

The response stays compatible with older clients. If retained data cannot
support the partial-day calculation, the server omits only the comparison
while keeping the main statistics available.

Companion Android change: chmouel/liseur#168.

## Changes

- Advertise support for cross-device comparisons in insights capabilities.
- Accept optional current and previous periods in snapshot requests.
- Prorate sessions at the shared wall-clock cutoff and return overlap totals.
- Preserve headline statistics when comparison evidence is incomplete.
- Store enough rollup evidence for future comparisons.
- Document and test the API for SQLite and PostgreSQL.

## Testing

- [ ] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [ ] If `.templ` files changed: `go tool templ generate ./internal/webui/` and committed generated output
- [x] If `docs/openapi.yaml` changed: `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish`
- [x] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable

Focused race tests passed for insights, API, SQLite, PostgreSQL, and the
non-browser web UI tests. The full race suite reached the browser tests, which
time out in this headless environment.

## Screenshots, logs, or API examples

The Android companion was connected to this server on an emulator and showed
the all-device comparison. Disconnecting the server restored the device-only
fallback.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.
