### PR TITLE
fix: Address remaining streaming-reader review findings

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -541,9 +541,17 @@ size, entry, decompression-ratio, path, symlink, XML, and
 encryption-algorithm bounds before it trusts metadata. Covers are rasterized and
 served with fixed MIME types and `nosniff`.
 
-The browser reader unpacks publications in the page, not on the server.
-No route serves publisher HTML, CSS or fonts as ordinary application
-resources, and no script inside a book executes.
+The browser reader streams publication resources from the server: each
+chapter, stylesheet, image and font is served from
+`/v1/books/{id}/publication/{digest}/resources/{resource}`, one archive
+entry at a time, behind the same device-token authentication as every
+other route. A resource response carries `application/octet-stream`,
+`Content-Disposition: attachment`, `X-Content-Type-Options: nosniff` and
+`Content-Security-Policy: sandbox; default-src 'none'`, so the browser
+never executes or directly renders it as fetched; the reader's own script
+reassembles chapters into blob URLs it loads inside a sandboxed frame, and
+no script inside a book executes there either.
+
 
 ## 9. Folder catalog
 

--- a/internal/api/publication.go
+++ b/internal/api/publication.go
@@ -145,16 +145,17 @@ func (s *Server) publicationIndex(ctx context.Context, digest string, file io.Re
 	return idx, nil
 }
 
-// maxPublicationPositions bounds the position list Index itself will
-// generate, not just whether the result gets cached: the toolkit produces
-// one position per 1,024 bytes of reading-order content, so a publication
-// near this server's own upper size limits could otherwise make a single
-// manifest request allocate on the order of two million locator objects
-// before caching is ever considered. Index estimates the count from ZIP
-// directory sizes alone and skips calling the toolkit's position generator
-// entirely once the estimate passes this bound, so a book that large never
-// pays for or retains the full list — it serves everything else normally,
-// with positions.json reporting none.
+// maxPublicationPositions bounds how fine-grained a position list Index
+// will generate, not just whether the result gets cached: the toolkit
+// produces one position per 1,024 bytes of reading-order content, so a
+// publication near this server's own upper size limits could otherwise
+// make a single manifest request allocate on the order of two million
+// locator objects before caching is ever considered. Index estimates the
+// count from ZIP directory sizes alone and, once the estimate passes this
+// bound, falls back to one coarse position per reading-order item instead
+// of calling the toolkit's position generator — the reader still gets a
+// non-empty position list and can open the book, just without sub-chapter
+// position numbers for that one publication.
 const maxPublicationPositions = 200_000
 
 func publicationURLs(value any, prefix string, idx *epub.Index) {

--- a/internal/api/publication.go
+++ b/internal/api/publication.go
@@ -145,18 +145,21 @@ func (s *Server) publicationIndex(ctx context.Context, digest string, file io.Re
 	return idx, nil
 }
 
-// maxPublicationPositions bounds how fine-grained a position list Index
-// will generate, not just whether the result gets cached: the toolkit
-// produces one position per 1,024 bytes of reading-order content, so a
-// publication near this server's own upper size limits could otherwise
-// make a single manifest request allocate on the order of two million
-// locator objects before caching is ever considered. Index estimates the
-// count from ZIP directory sizes alone and, once the estimate passes this
-// bound, falls back to a coarser list scaled to this bound instead of
-// calling the toolkit's position generator — each chapter still gets a
-// share of positions proportional to its own size, so the reader can open
-// the book and track progress sensibly, just at coarser granularity for
-// that one publication.
+// maxPublicationPositions bounds how fine-grained a reflowable
+// publication's position list Index will generate, not just whether the
+// result gets cached: the toolkit produces one position per 1,024 bytes
+// of reading-order content, so a publication near this server's own upper
+// size limits could otherwise make a single manifest request allocate on
+// the order of two million locator objects before caching is ever
+// considered. Index estimates the count from ZIP directory sizes alone
+// and, once the estimate passes this bound, falls back to a small, fixed
+// number of size-weighted positions instead of calling the toolkit's
+// position generator — each chapter still gets a share proportional to
+// its own size, so the reader can open the book and track progress
+// sensibly, just at coarser granularity for that one publication. A
+// fixed-layout publication is exempt: its real position list is one
+// Locator per reading-order item with no content read at all, so it is
+// always cheap and never estimated or capped.
 const maxPublicationPositions = 200_000
 
 func publicationURLs(value any, prefix string, idx *epub.Index) {

--- a/internal/api/publication.go
+++ b/internal/api/publication.go
@@ -138,23 +138,24 @@ func (s *Server) publicationIndex(ctx context.Context, digest string, file io.Re
 		return nil, err
 	}
 	defer p.Close()
-	idx := p.Index(ctx)
-	if s.PublicationIndexes != nil && len(idx.Positions) <= maxCachedPublicationPositions {
+	idx := p.Index(ctx, maxPublicationPositions)
+	if s.PublicationIndexes != nil {
 		s.PublicationIndexes.Put(digest, idx)
 	}
 	return idx, nil
 }
 
-// maxCachedPublicationPositions bounds what the index cache retains. The
-// toolkit generates one position per 1,024 bytes of reading-order content,
-// so a publication near this server's own upper size limits can produce
-// well over a million of them; retaining that list across the cache's
-// bounded entry count could itself become the memory problem the cache
-// exists to avoid. A publication over this bound still serves correctly —
-// its index is simply never cached, so the one request that built it pays
-// the reparse cost the cache is meant to save, rather than every request
-// paying to keep it in memory indefinitely.
-const maxCachedPublicationPositions = 200_000
+// maxPublicationPositions bounds the position list Index itself will
+// generate, not just whether the result gets cached: the toolkit produces
+// one position per 1,024 bytes of reading-order content, so a publication
+// near this server's own upper size limits could otherwise make a single
+// manifest request allocate on the order of two million locator objects
+// before caching is ever considered. Index estimates the count from ZIP
+// directory sizes alone and skips calling the toolkit's position generator
+// entirely once the estimate passes this bound, so a book that large never
+// pays for or retains the full list — it serves everything else normally,
+// with positions.json reporting none.
+const maxPublicationPositions = 200_000
 
 func publicationURLs(value any, prefix string, idx *epub.Index) {
 	switch v := value.(type) {

--- a/internal/api/publication.go
+++ b/internal/api/publication.go
@@ -152,10 +152,11 @@ func (s *Server) publicationIndex(ctx context.Context, digest string, file io.Re
 // make a single manifest request allocate on the order of two million
 // locator objects before caching is ever considered. Index estimates the
 // count from ZIP directory sizes alone and, once the estimate passes this
-// bound, falls back to one coarse position per reading-order item instead
-// of calling the toolkit's position generator — the reader still gets a
-// non-empty position list and can open the book, just without sub-chapter
-// position numbers for that one publication.
+// bound, falls back to a coarser list scaled to this bound instead of
+// calling the toolkit's position generator — each chapter still gets a
+// share of positions proportional to its own size, so the reader can open
+// the book and track progress sensibly, just at coarser granularity for
+// that one publication.
 const maxPublicationPositions = 200_000
 
 func publicationURLs(value any, prefix string, idx *epub.Index) {

--- a/internal/epub/fontobfuscation.go
+++ b/internal/epub/fontobfuscation.go
@@ -4,7 +4,10 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"io"
+	"regexp"
 	"strings"
+
+	"github.com/readium/go-toolkit/pkg/manifest"
 )
 
 // fontObfuscationLength maps the two font-obfuscation algorithms EPUB
@@ -16,16 +19,64 @@ var fontObfuscationLength = map[string]int64{
 	"http://ns.adobe.com/pdf/enc#RC":     1024,
 }
 
-// fontObfuscationKey derives the XOR key for algorithm from the
-// publication's dc:identifier, matching the two schemes' key derivations:
-// IDPF hashes the raw identifier with SHA-1, Adobe hex-decodes it after
-// stripping the "urn:uuid:" prefix and hyphens. An empty or malformed
-// identifier yields no usable key, in which case the caller must not
-// deobfuscate rather than serve corrupted bytes.
-func fontObfuscationKey(identifier, algorithm string) []byte {
-	if algorithm == "http://ns.adobe.com/pdf/enc#RC" {
-		trimmed := strings.ReplaceAll(strings.ReplaceAll(identifier, "urn:uuid:", ""), "-", "")
-		key, err := hex.DecodeString(trimmed)
+const adobeObfuscation = "http://ns.adobe.com/pdf/enc#RC"
+
+// uuidPattern matches a UUID's canonical hyphenated form anywhere inside a
+// string. This reader's previous foliate-js implementation scanned every
+// declared dc:identifier for one rather than trusting the package's
+// unique-identifier to be a UUID, because Adobe's obfuscation always keys
+// off a UUID even when a publisher's unique-identifier is something else
+// (an ISBN, say) and the UUID sits in another, unmarked identifier.
+var uuidPattern = regexp.MustCompile(`(?i)[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
+
+// stripFontIdentifierWhitespace removes the ASCII space, tab, CR and LF
+// characters IDPF's font-obfuscation key derivation strips before hashing
+// the identifier, matching both go-toolkit's and foliate-js's behavior.
+func stripFontIdentifierWhitespace(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case ' ', '\t', '\r', '\n':
+			return -1
+		}
+		return r
+	}, s)
+}
+
+// fontObfuscationIdentifier picks the raw identifier string an algorithm
+// keys off of. IDPF hashes the package's unique-identifier, whitespace
+// stripped — that one is EPUB's obfuscation identifier by definition.
+// Adobe's variant requires a UUID specifically, so every declared
+// identifier is searched for one rather than assuming the primary
+// identifier is it. An empty return means no usable identifier was found.
+func fontObfuscationIdentifier(metadata manifest.Metadata, algorithm string) string {
+	if algorithm != adobeObfuscation {
+		return stripFontIdentifierWhitespace(metadata.Identifier)
+	}
+	candidates := make([]string, 0, len(metadata.AltIdentifiers)+1)
+	candidates = append(candidates, metadata.Identifier)
+	for _, alt := range metadata.AltIdentifiers {
+		candidates = append(candidates, alt.Value)
+	}
+	for _, candidate := range candidates {
+		if uuid := uuidPattern.FindString(candidate); uuid != "" {
+			return uuid
+		}
+	}
+	return ""
+}
+
+// fontObfuscationKey derives the XOR key for algorithm: IDPF hashes the
+// identifier with SHA-1, Adobe hex-decodes the UUID's digits after
+// stripping hyphens. An empty or malformed identifier yields no usable
+// key, in which case the caller must not deobfuscate rather than serve
+// corrupted bytes.
+func fontObfuscationKey(metadata manifest.Metadata, algorithm string) []byte {
+	identifier := fontObfuscationIdentifier(metadata, algorithm)
+	if identifier == "" {
+		return nil
+	}
+	if algorithm == adobeObfuscation {
+		key, err := hex.DecodeString(strings.ReplaceAll(identifier, "-", ""))
 		if err != nil || len(key) == 0 {
 			return nil
 		}
@@ -49,12 +100,12 @@ type deobfuscatingReader struct {
 	pos               int64
 }
 
-func newDeobfuscatingReader(r io.ReadCloser, identifier, algorithm string) io.ReadCloser {
+func newDeobfuscatingReader(r io.ReadCloser, metadata manifest.Metadata, algorithm string) io.ReadCloser {
 	length, ok := fontObfuscationLength[algorithm]
 	if !ok {
 		return r
 	}
-	key := fontObfuscationKey(identifier, algorithm)
+	key := fontObfuscationKey(metadata, algorithm)
 	if len(key) == 0 {
 		return r
 	}

--- a/internal/epub/fontobfuscation_test.go
+++ b/internal/epub/fontobfuscation_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/readium/go-toolkit/pkg/manifest"
 )
 
 // obfuscate mirrors the XOR both algorithms use, so a test can construct
@@ -31,7 +33,8 @@ func TestDeobfuscatingReaderReversesIDPF(t *testing.T) {
 	original := bytes.Repeat([]byte("font-bytes-"), 200) // > 1040 bytes
 	obfuscated := obfuscate(original, key, 1040)
 
-	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(obfuscated)), identifier, "http://www.idpf.org/2008/embedding")
+	metadata := manifest.Metadata{Identifier: identifier}
+	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(obfuscated)), metadata, "http://www.idpf.org/2008/embedding")
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("read: %v", err)
@@ -51,13 +54,60 @@ func TestDeobfuscatingReaderReversesAdobe(t *testing.T) {
 	original := bytes.Repeat([]byte("font-bytes-"), 200) // > 1024 bytes
 	obfuscated := obfuscate(original, key, 1024)
 
-	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(obfuscated)), identifier, "http://ns.adobe.com/pdf/enc#RC")
+	metadata := manifest.Metadata{Identifier: identifier}
+	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(obfuscated)), metadata, "http://ns.adobe.com/pdf/enc#RC")
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("read: %v", err)
 	}
 	if !bytes.Equal(got, original) {
 		t.Fatalf("deobfuscation did not reverse the Adobe transform")
+	}
+}
+
+// TestDeobfuscatingReaderFindsAdobeUUIDInAltIdentifier covers a publisher
+// whose package unique-identifier is not a UUID (an ISBN, say) while a
+// UUID Adobe's algorithm requires sits in another, unmarked dc:identifier.
+// This reader's previous foliate-js implementation searched every declared
+// identifier for one rather than trusting the primary identifier to be a
+// UUID, and this mirrors that.
+func TestDeobfuscatingReaderFindsAdobeUUIDInAltIdentifier(t *testing.T) {
+	uuid := "12345678-1234-1234-1234-123456789abc"
+	key, err := hex.DecodeString(strings.ReplaceAll(uuid, "-", ""))
+	if err != nil {
+		t.Fatalf("decode key: %v", err)
+	}
+	original := bytes.Repeat([]byte("font-bytes-"), 200)
+	obfuscated := obfuscate(original, key, 1024)
+
+	metadata := manifest.Metadata{
+		Identifier:     "urn:isbn:9780000000000",
+		AltIdentifiers: []manifest.AltIdentifier{{Value: "urn:isbn:9780000000000"}, {Value: "urn:uuid:" + uuid}},
+	}
+	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(obfuscated)), metadata, "http://ns.adobe.com/pdf/enc#RC")
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("deobfuscation did not find the UUID in an alternate identifier")
+	}
+}
+
+// TestDeobfuscatingReaderSkipsAdobeWithoutUUID: when no declared
+// identifier looks like a UUID, Adobe's key cannot be derived at all, so
+// the reader must pass bytes through untouched rather than XOR with a
+// wrong or empty key and corrupt the font.
+func TestDeobfuscatingReaderSkipsAdobeWithoutUUID(t *testing.T) {
+	original := []byte("font bytes unchanged")
+	metadata := manifest.Metadata{Identifier: "urn:isbn:9780000000000"}
+	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(original)), metadata, "http://ns.adobe.com/pdf/enc#RC")
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("no usable identifier must leave bytes untouched")
 	}
 }
 
@@ -70,7 +120,8 @@ func TestDeobfuscatingReaderWorksAcrossSmallReads(t *testing.T) {
 	original := bytes.Repeat([]byte("0123456789"), 200) // 2000 bytes, > 1040
 	obfuscated := obfuscate(original, key, 1040)
 
-	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(obfuscated)), identifier, "http://www.idpf.org/2008/embedding")
+	metadata := manifest.Metadata{Identifier: identifier}
+	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(obfuscated)), metadata, "http://www.idpf.org/2008/embedding")
 	var out bytes.Buffer
 	buf := make([]byte, 7)
 	for {
@@ -90,7 +141,8 @@ func TestDeobfuscatingReaderWorksAcrossSmallReads(t *testing.T) {
 
 func TestDeobfuscatingReaderSkipsUnknownAlgorithm(t *testing.T) {
 	original := []byte("font bytes unchanged")
-	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(original)), "urn:uuid:anything", "http://example.com/unknown")
+	metadata := manifest.Metadata{Identifier: "urn:uuid:anything"}
+	r := newDeobfuscatingReader(io.NopCloser(bytes.NewReader(original)), metadata, "http://example.com/unknown")
 	got, err := io.ReadAll(r)
 	if err != nil {
 		t.Fatalf("read: %v", err)

--- a/internal/epub/publication.go
+++ b/internal/epub/publication.go
@@ -268,16 +268,15 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 // boundedPositions distributes on top of the one mandatory position every
 // reading-order item gets — not the total, so a publication with many
 // chapters can't crowd out that weighted pool by consuming it on mandatory
-// minimums alone (a large chapter still needs a meaningful share of
-// positions relative to a small one to keep progress tracking sensible).
-// It is independent of the maxPositions a caller passes to Index: that
-// parameter only decides when the fine-grained list is too expensive to
-// generate, but the fallback itself is cached the same way, and a cache
-// of PublicationIndexCache's default 32 entries each holding maxPositions
-// (200,000) fallback locators could still retain millions of them. The
-// fallback is already an approximation, so a few thousand positions give
-// a reader plenty of granularity for progress tracking without the
-// memory cost the estimate cap was meant to avoid in the first place.
+// minimums alone. It is independent of the maxPositions a caller passes to
+// Index: that parameter only decides when the fine-grained list is too
+// expensive to generate, but the fallback itself is cached the same way,
+// and a cache of PublicationIndexCache's default 32 entries each holding
+// maxPositions (200,000) fallback locators could still retain millions of
+// them. The fallback is already an approximation, so a few thousand
+// positions give a reader plenty of granularity for progress tracking
+// without the memory cost the estimate cap was meant to avoid in the
+// first place.
 const fallbackPositionBudget = 4096
 
 // boundedPositions is the fallback for a publication too large to afford
@@ -287,12 +286,17 @@ const fallbackPositionBudget = 4096
 // it; a further fallbackPositionBudget positions are then distributed
 // across the reading order in proportion to each item's own archive size,
 // using the largest-remainder method so the total never exceeds the
-// combined budget. A reader tracking progress by position multiplicity —
-// the client divides a section's on-screen progress by its position
-// count, and the whole book's by the total — still weights a large
-// chapter correctly against a small one even when there are many
-// chapters, because the weighted pool is never shared with the mandatory
-// minimums.
+// combined budget.
+//
+// Each locator's TotalProgression is computed directly from cumulative
+// archive bytes, not from its ordinal position among the mandatory-plus-
+// weighted counts: with many chapters, the mandatory one-per-item
+// minimum can dominate that count even though it holds almost none of
+// the bytes, and a client that divides progress by position multiplicity
+// (as reader-engine.js does for its per-chapter progress markers) would
+// then under-report a large chapter's true weight. Deriving
+// TotalProgression from bytes instead keeps it accurate regardless of
+// how the discrete positions themselves are distributed.
 func (p *Publication) boundedPositions() []manifest.Locator {
 	readingOrder := p.Manifest.ReadingOrder
 	if len(readingOrder) == 0 {
@@ -314,6 +318,12 @@ func (p *Publication) boundedPositions() []manifest.Locator {
 	}
 	budget := len(readingOrder) + fallbackPositionBudget
 	counts := apportion(sizes, total, budget)
+	bytesBefore := make([]uint64, len(readingOrder))
+	var cumulative uint64
+	for i := range readingOrder {
+		bytesBefore[i] = cumulative
+		cumulative += sizes[i]
+	}
 	positions := make([]manifest.Locator, 0, budget)
 	var position uint
 	for i, link := range readingOrder {
@@ -325,16 +335,23 @@ func (p *Publication) boundedPositions() []manifest.Locator {
 			position++
 			progression := float64(page) / float64(counts[i])
 			pagePosition := position
+			var totalProgression float64
+			if total > 0 {
+				totalProgression = (float64(bytesBefore[i]) + progression*float64(sizes[i])) / float64(total)
+			} else {
+				// No size information for any item: fall back to
+				// spacing positions evenly, since there is nothing to
+				// weight by.
+				totalProgression = float64(position-1) / float64(budget)
+			}
 			positions = append(positions, manifest.Locator{
 				Href: link.URL(nil, nil), MediaType: *mt, Title: link.Title,
-				Locations: manifest.Locations{Progression: &progression, Position: &pagePosition},
+				Locations: manifest.Locations{
+					Progression: &progression, Position: &pagePosition,
+					TotalProgression: &totalProgression,
+				},
 			})
 		}
-	}
-	totalCount := len(positions)
-	for i := range positions {
-		totalProgression := float64(*positions[i].Locations.Position-1) / float64(totalCount)
-		positions[i].Locations.TotalProgression = &totalProgression
 	}
 	return positions
 }

--- a/internal/epub/publication.go
+++ b/internal/epub/publication.go
@@ -226,9 +226,14 @@ func (idx *Index) HasResource(name string) bool { _, ok := idx.Entries[name]; re
 // requires a non-empty position list to open a book at all, so a
 // publication whose full, byte-granular list (one per 1,024 archive bytes
 // of reading-order content, the toolkit's own count) would exceed
-// maxPositions instead gets a coarser list sized to fit the bound, built
-// from the same per-entry sizes rather than reading content. A
-// maxPositions of 0 or less means unbounded (always the fine-grained list).
+// maxPositions instead gets a coarser, size-weighted list built from the
+// same per-entry sizes rather than reading content, capped independently
+// of maxPositions so a cache of these indexes never has to hold as many
+// locators as the cap technically allows. A fixed-layout publication's
+// real position list is one Locator per reading-order item with no
+// content read at all (the toolkit never touches the fetcher for it), so
+// it is always cheap and never estimated or capped. A maxPositions of 0 or
+// less means unbounded (always the fine-grained list).
 func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 	entries := make(map[string]IndexEntry, len(p.allowed))
 	for name := range p.allowed {
@@ -245,8 +250,9 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 			UncompressedSize: f.UncompressedSize64, Method: f.Method,
 		}
 	}
+	fixed := p.Manifest.Metadata.Layout == manifest.LayoutFixed
 	var positions []manifest.Locator
-	if maxPositions <= 0 || p.estimatedPositionCount() <= maxPositions {
+	if fixed || maxPositions <= 0 || p.estimatedPositionCount() <= maxPositions {
 		positions = p.Positions(ctx)
 	}
 	if len(positions) == 0 {
@@ -258,19 +264,30 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 	}
 }
 
+// fallbackPositionBudget caps how many locators boundedPositions ever
+// builds, independently of the maxPositions a caller passes to Index: that
+// parameter only decides when the fine-grained list is too expensive to
+// generate, but the fallback itself is cached the same way, and a cache
+// of PublicationIndexCache's default 32 entries each holding maxPositions
+// (200,000) fallback locators could still retain millions of them. The
+// fallback is already an approximation, so a few thousand positions give
+// a reader plenty of granularity for progress tracking without the
+// memory cost the estimate cap was meant to avoid in the first place.
+const fallbackPositionBudget = 4096
+
 // boundedPositions is the fallback for a publication too large to afford
 // the toolkit's byte-granular position list (never called unless the
 // fine-grained list was skipped or came back empty). It distributes a
-// budget of at most maxPositions locators across the reading order in
-// proportion to each item's own archive size, using the largest-remainder
-// method so the total never exceeds the budget: a reader tracking
-// progress by position multiplicity — the client divides a section's
-// on-screen progress by its position count, and the whole book's by the
-// total — still weights a large chapter correctly against a small one,
-// just at coarser granularity. Every item gets at least one position so
-// the reader can always place it; if maxPositions is smaller than the
-// reading order's own length, that guarantee wins and the total exceeds
-// maxPositions by as little as the chapter count requires.
+// small, fixed budget of locators across the reading order in proportion
+// to each item's own archive size, using the largest-remainder method so
+// the total never exceeds the budget: a reader tracking progress by
+// position multiplicity — the client divides a section's on-screen
+// progress by its position count, and the whole book's by the total —
+// still weights a large chapter correctly against a small one, just at
+// coarser granularity. Every item gets at least one position so the
+// reader can always place it; if the reading order itself is longer than
+// the budget, that guarantee wins and the total exceeds the budget by as
+// little as the chapter count requires.
 func (p *Publication) boundedPositions(maxPositions int) []manifest.Locator {
 	readingOrder := p.Manifest.ReadingOrder
 	if len(readingOrder) == 0 {
@@ -290,7 +307,10 @@ func (p *Publication) boundedPositions(maxPositions int) []manifest.Locator {
 		sizes[i] = f.CompressedSize64
 		total += f.CompressedSize64
 	}
-	budget := maxPositions
+	budget := fallbackPositionBudget
+	if maxPositions > 0 && maxPositions < budget {
+		budget = maxPositions
+	}
 	if budget < len(readingOrder) {
 		budget = len(readingOrder)
 	}

--- a/internal/epub/publication.go
+++ b/internal/epub/publication.go
@@ -220,13 +220,14 @@ func (idx *Index) HasResource(name string) bool { _, ok := idx.Entries[name]; re
 // Index builds the cacheable shape of this Publication. It reads no
 // chapter bytes: entry coordinates come from the ZIP directory already
 // read by OpenPublication, and positions come from the reading order's own
-// recorded sizes. maxPositions bounds the position list itself, not just
-// whether a caller chooses to cache it: the toolkit's own position count
-// (one per 1,024 archive bytes of reading-order content) is cheap to
-// estimate from the same ZIP directory sizes before ever calling
-// Positions, so a publication whose estimate exceeds maxPositions never
-// pays for or retains the full list at all. A maxPositions of 0 or less
-// means unbounded.
+// recorded sizes. maxPositions bounds how fine-grained the position list
+// is allowed to get, not whether one is produced at all: the reader
+// requires a non-empty position list to open a book at all, so a
+// publication whose full, byte-granular list (one per 1,024 archive bytes
+// of reading-order content, the toolkit's own count) would exceed
+// maxPositions instead gets one coarse position per reading-order item,
+// which costs O(chapters) rather than O(kilobytes of content) to build.
+// A maxPositions of 0 or less means unbounded (always the fine-grained list).
 func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 	entries := make(map[string]IndexEntry, len(p.allowed))
 	for name := range p.allowed {
@@ -243,14 +244,62 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 			UncompressedSize: f.UncompressedSize64, Method: f.Method,
 		}
 	}
-	var positions []manifest.Locator
+	positions := p.coarsePositions()
 	if maxPositions <= 0 || p.estimatedPositionCount() <= maxPositions {
-		positions = p.Positions(ctx)
+		if fine := p.Positions(ctx); len(fine) > 0 {
+			positions = fine
+		}
 	}
 	return &Index{
 		PackagePath: p.PackagePath, Manifest: p.Manifest, Positions: positions,
 		Entries: entries, FontObfuscation: p.fontObfuscation,
 	}
+}
+
+// coarsePositions builds one Locator per reading-order item, using
+// cumulative archive size to place each item's totalProgression. It is
+// the fallback for a publication too large to afford the toolkit's
+// byte-granular position list: still enough for the reader to open the
+// book, track which chapter it is in and report overall progress, just
+// without sub-chapter position numbers.
+func (p *Publication) coarsePositions() []manifest.Locator {
+	readingOrder := p.Manifest.ReadingOrder
+	sizes := make([]uint64, len(readingOrder))
+	var total uint64
+	for i, link := range readingOrder {
+		name, err := publicationPath(link.Href.String())
+		if err != nil {
+			continue
+		}
+		f := p.archive.entries[name]
+		if f == nil {
+			continue
+		}
+		sizes[i] = f.CompressedSize64
+		total += f.CompressedSize64
+	}
+	positions := make([]manifest.Locator, len(readingOrder))
+	var cumulative uint64
+	for i, link := range readingOrder {
+		mt := link.MediaType
+		if mt == nil {
+			mt = &mediatype.HTML
+		}
+		progression := 0.0
+		position := uint(i + 1) //nolint:gosec // reading order length is bounded by the archive's own entry count
+		totalProgression := 0.0
+		if total > 0 {
+			totalProgression = float64(cumulative) / float64(total)
+		}
+		positions[i] = manifest.Locator{
+			Href: link.URL(nil, nil), MediaType: *mt, Title: link.Title,
+			Locations: manifest.Locations{
+				Progression: &progression, Position: &position, TotalProgression: &totalProgression,
+			},
+		}
+		cumulative += sizes[i]
+	}
+	return positions
 }
 
 // estimatedPositionCount mirrors the toolkit's own ArchiveEntryLength

--- a/internal/epub/publication.go
+++ b/internal/epub/publication.go
@@ -256,7 +256,7 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 		positions = p.Positions(ctx)
 	}
 	if len(positions) == 0 {
-		positions = p.boundedPositions(maxPositions)
+		positions = p.boundedPositions()
 	}
 	return &Index{
 		PackagePath: p.PackagePath, Manifest: p.Manifest, Positions: positions,
@@ -264,8 +264,13 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 	}
 }
 
-// fallbackPositionBudget caps how many locators boundedPositions ever
-// builds, independently of the maxPositions a caller passes to Index: that
+// fallbackPositionBudget bounds how many extra, size-weighted positions
+// boundedPositions distributes on top of the one mandatory position every
+// reading-order item gets — not the total, so a publication with many
+// chapters can't crowd out that weighted pool by consuming it on mandatory
+// minimums alone (a large chapter still needs a meaningful share of
+// positions relative to a small one to keep progress tracking sensible).
+// It is independent of the maxPositions a caller passes to Index: that
 // parameter only decides when the fine-grained list is too expensive to
 // generate, but the fallback itself is cached the same way, and a cache
 // of PublicationIndexCache's default 32 entries each holding maxPositions
@@ -277,18 +282,18 @@ const fallbackPositionBudget = 4096
 
 // boundedPositions is the fallback for a publication too large to afford
 // the toolkit's byte-granular position list (never called unless the
-// fine-grained list was skipped or came back empty). It distributes a
-// small, fixed budget of locators across the reading order in proportion
-// to each item's own archive size, using the largest-remainder method so
-// the total never exceeds the budget: a reader tracking progress by
-// position multiplicity — the client divides a section's on-screen
-// progress by its position count, and the whole book's by the total —
-// still weights a large chapter correctly against a small one, just at
-// coarser granularity. Every item gets at least one position so the
-// reader can always place it; if the reading order itself is longer than
-// the budget, that guarantee wins and the total exceeds the budget by as
-// little as the chapter count requires.
-func (p *Publication) boundedPositions(maxPositions int) []manifest.Locator {
+// fine-grained list was skipped or came back empty). Every reading-order
+// item first gets one mandatory position, so the reader can always place
+// it; a further fallbackPositionBudget positions are then distributed
+// across the reading order in proportion to each item's own archive size,
+// using the largest-remainder method so the total never exceeds the
+// combined budget. A reader tracking progress by position multiplicity —
+// the client divides a section's on-screen progress by its position
+// count, and the whole book's by the total — still weights a large
+// chapter correctly against a small one even when there are many
+// chapters, because the weighted pool is never shared with the mandatory
+// minimums.
+func (p *Publication) boundedPositions() []manifest.Locator {
 	readingOrder := p.Manifest.ReadingOrder
 	if len(readingOrder) == 0 {
 		return nil
@@ -307,13 +312,7 @@ func (p *Publication) boundedPositions(maxPositions int) []manifest.Locator {
 		sizes[i] = f.CompressedSize64
 		total += f.CompressedSize64
 	}
-	budget := fallbackPositionBudget
-	if maxPositions > 0 && maxPositions < budget {
-		budget = maxPositions
-	}
-	if budget < len(readingOrder) {
-		budget = len(readingOrder)
-	}
+	budget := len(readingOrder) + fallbackPositionBudget
 	counts := apportion(sizes, total, budget)
 	positions := make([]manifest.Locator, 0, budget)
 	var position uint

--- a/internal/epub/publication.go
+++ b/internal/epub/publication.go
@@ -7,6 +7,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"io"
+	"math"
 	"net/url"
 	"strings"
 
@@ -177,7 +178,7 @@ func (p *Publication) OpenResource(name string) (io.ReadCloser, int64, error) {
 		return nil, 0, validationError(CodeInvalidEPUB, err)
 	}
 	if algorithm, ok := p.fontObfuscation[name]; ok {
-		r = newDeobfuscatingReader(r, p.Manifest.Metadata.Identifier, algorithm)
+		r = newDeobfuscatingReader(r, p.Manifest.Metadata, algorithm)
 	}
 	return r, int64(f.UncompressedSize64), nil
 }
@@ -219,8 +220,14 @@ func (idx *Index) HasResource(name string) bool { _, ok := idx.Entries[name]; re
 // Index builds the cacheable shape of this Publication. It reads no
 // chapter bytes: entry coordinates come from the ZIP directory already
 // read by OpenPublication, and positions come from the reading order's own
-// recorded sizes.
-func (p *Publication) Index(ctx context.Context) *Index {
+// recorded sizes. maxPositions bounds the position list itself, not just
+// whether a caller chooses to cache it: the toolkit's own position count
+// (one per 1,024 archive bytes of reading-order content) is cheap to
+// estimate from the same ZIP directory sizes before ever calling
+// Positions, so a publication whose estimate exceeds maxPositions never
+// pays for or retains the full list at all. A maxPositions of 0 or less
+// means unbounded.
+func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 	entries := make(map[string]IndexEntry, len(p.allowed))
 	for name := range p.allowed {
 		f := p.archive.entries[name]
@@ -236,10 +243,39 @@ func (p *Publication) Index(ctx context.Context) *Index {
 			UncompressedSize: f.UncompressedSize64, Method: f.Method,
 		}
 	}
+	var positions []manifest.Locator
+	if maxPositions <= 0 || p.estimatedPositionCount() <= maxPositions {
+		positions = p.Positions(ctx)
+	}
 	return &Index{
-		PackagePath: p.PackagePath, Manifest: p.Manifest, Positions: p.Positions(ctx),
+		PackagePath: p.PackagePath, Manifest: p.Manifest, Positions: positions,
 		Entries: entries, FontObfuscation: p.fontObfuscation,
 	}
+}
+
+// estimatedPositionCount mirrors the toolkit's own ArchiveEntryLength
+// strategy (one position per 1,024 bytes of a reading-order entry's
+// archive size, at least one per entry) using only the ZIP directory
+// sizes already read by OpenPublication, so Index can decide whether to
+// materialize the real position list before ever calling Positions.
+func (p *Publication) estimatedPositionCount() int {
+	var total int64
+	for _, link := range p.Manifest.ReadingOrder {
+		name, err := publicationPath(link.Href.String())
+		if err != nil {
+			continue
+		}
+		f := p.archive.entries[name]
+		if f == nil {
+			continue
+		}
+		count := int64(math.Ceil(float64(f.CompressedSize64) / 1024))
+		if count < 1 {
+			count = 1
+		}
+		total += count
+	}
+	return int(total)
 }
 
 // ErrPublicationChanged means the catalog's content digest still names
@@ -281,7 +317,7 @@ func OpenIndexedResource(source io.ReaderAt, size int64, idx *Index, name string
 			return nil, 0, validationError(CodeInvalidEPUB, err)
 		}
 		if algorithm, ok := idx.FontObfuscation[name]; ok {
-			r = newDeobfuscatingReader(r, idx.Manifest.Metadata.Identifier, algorithm)
+			r = newDeobfuscatingReader(r, idx.Manifest.Metadata, algorithm)
 		}
 		return r, int64(f.UncompressedSize64), nil
 	}

--- a/internal/epub/publication.go
+++ b/internal/epub/publication.go
@@ -225,9 +225,9 @@ func (idx *Index) HasResource(name string) bool { _, ok := idx.Entries[name]; re
 // requires a non-empty position list to open a book at all, so a
 // publication whose full, byte-granular list (one per 1,024 archive bytes
 // of reading-order content, the toolkit's own count) would exceed
-// maxPositions instead gets one coarse position per reading-order item,
-// which costs O(chapters) rather than O(kilobytes of content) to build.
-// A maxPositions of 0 or less means unbounded (always the fine-grained list).
+// maxPositions instead gets a coarser list sized to fit the bound, built
+// from the same per-entry sizes rather than reading content. A
+// maxPositions of 0 or less means unbounded (always the fine-grained list).
 func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 	entries := make(map[string]IndexEntry, len(p.allowed))
 	for name := range p.allowed {
@@ -244,7 +244,7 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 			UncompressedSize: f.UncompressedSize64, Method: f.Method,
 		}
 	}
-	positions := p.coarsePositions()
+	positions := p.boundedPositions(maxPositions)
 	if maxPositions <= 0 || p.estimatedPositionCount() <= maxPositions {
 		if fine := p.Positions(ctx); len(fine) > 0 {
 			positions = fine
@@ -256,13 +256,19 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 	}
 }
 
-// coarsePositions builds one Locator per reading-order item, using
-// cumulative archive size to place each item's totalProgression. It is
-// the fallback for a publication too large to afford the toolkit's
-// byte-granular position list: still enough for the reader to open the
-// book, track which chapter it is in and report overall progress, just
-// without sub-chapter position numbers.
-func (p *Publication) coarsePositions() []manifest.Locator {
+// boundedPositions is the fallback for a publication too large to afford
+// the toolkit's byte-granular position list. It mirrors the toolkit's own
+// ArchiveEntryLength strategy but with a page length scaled up so the
+// total position count fits maxPositions, instead of the fixed 1,024
+// bytes: each reading-order item still gets a share of positions
+// proportional to its own archive size (at least one), so a reader
+// tracking progress by position multiplicity — the client divides a
+// section's on-screen progress by its position count, and the whole
+// book's by the total — still weights a large chapter correctly against
+// a small one, just at coarser granularity. maxPositions <= 0 falls back
+// to one position per item (only reachable when the fine-grained list
+// itself produced none, e.g. an empty reading order).
+func (p *Publication) boundedPositions(maxPositions int) []manifest.Locator {
 	readingOrder := p.Manifest.ReadingOrder
 	sizes := make([]uint64, len(readingOrder))
 	var total uint64
@@ -278,26 +284,43 @@ func (p *Publication) coarsePositions() []manifest.Locator {
 		sizes[i] = f.CompressedSize64
 		total += f.CompressedSize64
 	}
-	positions := make([]manifest.Locator, len(readingOrder))
-	var cumulative uint64
+	pageLength := uint64(1)
+	if maxPositions > 0 && total > 0 {
+		pageLength = uint64(math.Ceil(float64(total) / float64(maxPositions)))
+		if pageLength < 1 {
+			pageLength = 1
+		}
+	}
+	counts := make([]int, len(readingOrder))
+	var totalCount int
+	for i, size := range sizes {
+		count := int(math.Ceil(float64(size) / float64(pageLength)))
+		if count < 1 {
+			count = 1
+		}
+		counts[i] = count
+		totalCount += count
+	}
+	positions := make([]manifest.Locator, 0, totalCount)
+	var position uint
 	for i, link := range readingOrder {
 		mt := link.MediaType
 		if mt == nil {
 			mt = &mediatype.HTML
 		}
-		progression := 0.0
-		position := uint(i + 1) //nolint:gosec // reading order length is bounded by the archive's own entry count
-		totalProgression := 0.0
-		if total > 0 {
-			totalProgression = float64(cumulative) / float64(total)
+		for page := range counts[i] {
+			position++
+			progression := float64(page) / float64(counts[i])
+			pagePosition := position
+			positions = append(positions, manifest.Locator{
+				Href: link.URL(nil, nil), MediaType: *mt, Title: link.Title,
+				Locations: manifest.Locations{Progression: &progression, Position: &pagePosition},
+			})
 		}
-		positions[i] = manifest.Locator{
-			Href: link.URL(nil, nil), MediaType: *mt, Title: link.Title,
-			Locations: manifest.Locations{
-				Progression: &progression, Position: &position, TotalProgression: &totalProgression,
-			},
-		}
-		cumulative += sizes[i]
+	}
+	for i := range positions {
+		totalProgression := float64(*positions[i].Locations.Position-1) / float64(totalCount)
+		positions[i].Locations.TotalProgression = &totalProgression
 	}
 	return positions
 }

--- a/internal/epub/publication.go
+++ b/internal/epub/publication.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"math"
 	"net/url"
+	"sort"
 	"strings"
 
 	"github.com/readium/go-toolkit/pkg/asset"
@@ -244,11 +245,12 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 			UncompressedSize: f.UncompressedSize64, Method: f.Method,
 		}
 	}
-	positions := p.boundedPositions(maxPositions)
+	var positions []manifest.Locator
 	if maxPositions <= 0 || p.estimatedPositionCount() <= maxPositions {
-		if fine := p.Positions(ctx); len(fine) > 0 {
-			positions = fine
-		}
+		positions = p.Positions(ctx)
+	}
+	if len(positions) == 0 {
+		positions = p.boundedPositions(maxPositions)
 	}
 	return &Index{
 		PackagePath: p.PackagePath, Manifest: p.Manifest, Positions: positions,
@@ -257,19 +259,23 @@ func (p *Publication) Index(ctx context.Context, maxPositions int) *Index {
 }
 
 // boundedPositions is the fallback for a publication too large to afford
-// the toolkit's byte-granular position list. It mirrors the toolkit's own
-// ArchiveEntryLength strategy but with a page length scaled up so the
-// total position count fits maxPositions, instead of the fixed 1,024
-// bytes: each reading-order item still gets a share of positions
-// proportional to its own archive size (at least one), so a reader
-// tracking progress by position multiplicity — the client divides a
-// section's on-screen progress by its position count, and the whole
-// book's by the total — still weights a large chapter correctly against
-// a small one, just at coarser granularity. maxPositions <= 0 falls back
-// to one position per item (only reachable when the fine-grained list
-// itself produced none, e.g. an empty reading order).
+// the toolkit's byte-granular position list (never called unless the
+// fine-grained list was skipped or came back empty). It distributes a
+// budget of at most maxPositions locators across the reading order in
+// proportion to each item's own archive size, using the largest-remainder
+// method so the total never exceeds the budget: a reader tracking
+// progress by position multiplicity — the client divides a section's
+// on-screen progress by its position count, and the whole book's by the
+// total — still weights a large chapter correctly against a small one,
+// just at coarser granularity. Every item gets at least one position so
+// the reader can always place it; if maxPositions is smaller than the
+// reading order's own length, that guarantee wins and the total exceeds
+// maxPositions by as little as the chapter count requires.
 func (p *Publication) boundedPositions(maxPositions int) []manifest.Locator {
 	readingOrder := p.Manifest.ReadingOrder
+	if len(readingOrder) == 0 {
+		return nil
+	}
 	sizes := make([]uint64, len(readingOrder))
 	var total uint64
 	for i, link := range readingOrder {
@@ -284,24 +290,12 @@ func (p *Publication) boundedPositions(maxPositions int) []manifest.Locator {
 		sizes[i] = f.CompressedSize64
 		total += f.CompressedSize64
 	}
-	pageLength := uint64(1)
-	if maxPositions > 0 && total > 0 {
-		pageLength = uint64(math.Ceil(float64(total) / float64(maxPositions)))
-		if pageLength < 1 {
-			pageLength = 1
-		}
+	budget := maxPositions
+	if budget < len(readingOrder) {
+		budget = len(readingOrder)
 	}
-	counts := make([]int, len(readingOrder))
-	var totalCount int
-	for i, size := range sizes {
-		count := int(math.Ceil(float64(size) / float64(pageLength)))
-		if count < 1 {
-			count = 1
-		}
-		counts[i] = count
-		totalCount += count
-	}
-	positions := make([]manifest.Locator, 0, totalCount)
+	counts := apportion(sizes, total, budget)
+	positions := make([]manifest.Locator, 0, budget)
 	var position uint
 	for i, link := range readingOrder {
 		mt := link.MediaType
@@ -318,11 +312,57 @@ func (p *Publication) boundedPositions(maxPositions int) []manifest.Locator {
 			})
 		}
 	}
+	totalCount := len(positions)
 	for i := range positions {
 		totalProgression := float64(*positions[i].Locations.Position-1) / float64(totalCount)
 		positions[i].Locations.TotalProgression = &totalProgression
 	}
 	return positions
+}
+
+// apportion splits budget positions across len(weights) items in
+// proportion to each weight, guaranteeing every item at least one and the
+// total never exceeding budget (the caller has already ensured
+// budget >= len(weights)). It reserves one position per item first, then
+// hands out the rest (budget-len(weights)) by the largest-remainder
+// method: each item's ideal extra share is floored, and the leftover
+// slots go to the items with the largest fractional remainder, so the sum
+// lands on the extra budget exactly instead of drifting from independent
+// per-item rounding.
+func apportion(weights []uint64, total uint64, budget int) []int {
+	counts := make([]int, len(weights))
+	for i := range counts {
+		counts[i] = 1
+	}
+	extra := budget - len(weights)
+	if extra <= 0 {
+		return counts
+	}
+	if total == 0 {
+		// No size information at all: split the extra evenly.
+		for i := 0; i < extra; i++ {
+			counts[i%len(weights)]++
+		}
+		return counts
+	}
+	type remainder struct {
+		index     int
+		remainder float64
+	}
+	remainders := make([]remainder, len(weights))
+	assigned := 0
+	for i, weight := range weights {
+		ideal := float64(weight) / float64(total) * float64(extra)
+		floor := int(math.Floor(ideal))
+		counts[i] += floor
+		assigned += floor
+		remainders[i] = remainder{i, ideal - float64(floor)}
+	}
+	sort.Slice(remainders, func(a, b int) bool { return remainders[a].remainder > remainders[b].remainder })
+	for i := 0; i < extra-assigned; i++ {
+		counts[remainders[i].index]++
+	}
+	return counts
 }
 
 // estimatedPositionCount mirrors the toolkit's own ArchiveEntryLength

--- a/internal/epub/publication_test.go
+++ b/internal/epub/publication_test.go
@@ -99,26 +99,38 @@ func TestPublicationResourcesAreBoundedAndDeclared(t *testing.T) {
 	}
 }
 
-// TestIndexSkipsPositionsOverTheBound confirms Index itself, not just a
-// caller's decision to cache the result, avoids materializing the full
-// position list once the cheap archive-size estimate exceeds maxPositions
-// — the two reading-order chapters here have two archive entries, so a
-// bound of 1 must be exceeded and a bound of 2 or more must not be.
-func TestIndexSkipsPositionsOverTheBound(t *testing.T) {
-	data := readerArchive(t, readerPackage)
+// TestIndexFallsBackToCoarsePositionsOverTheBound confirms Index avoids
+// materializing the toolkit's byte-granular position list (one per 1,024
+// archive bytes of reading-order content) once the cheap archive-size
+// estimate exceeds maxPositions, but never leaves the reader with no
+// positions at all: it falls back to one coarse position per reading-order
+// item instead. The two chapters here are ~3,000 bytes each (stored, so
+// compressed size equals content size), giving a fine-grained estimate of
+// six positions and a coarse fallback of two (one per chapter).
+func TestIndexFallsBackToCoarsePositionsOverTheBound(t *testing.T) {
+	entries := validEntries()[:4]
+	entries[2].body = readerPackage
+	chapter := func(body string) string {
+		return `<html xmlns="http://www.w3.org/1999/xhtml"><head/><body>` + body + `</body></html>`
+	}
+	entries = append(entries,
+		zipEntry{name: "OPS/one.xhtml", body: chapter(strings.Repeat("a", 3000)), method: zip.Store},
+		zipEntry{name: "OPS/two.xhtml", body: chapter(strings.Repeat("b", 3000)), method: zip.Store},
+		zipEntry{name: "OPS/late.bin", body: strings.Repeat("x", 8<<20), method: zip.Store})
+	data := makeEPUB(t, entries...)
 	p, err := OpenPublication(t.Context(), bytes.NewReader(data), int64(len(data)), DefaultLimits())
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer p.Close()
-	if idx := p.Index(t.Context(), 1); idx.Positions != nil {
-		t.Fatalf("positions over the bound were still generated: %+v", idx.Positions)
+	if idx := p.Index(t.Context(), 5); len(idx.Positions) != 2 {
+		t.Fatalf("expected the coarse, one-per-chapter fallback over the bound, got: %+v", idx.Positions)
 	}
-	if idx := p.Index(t.Context(), 2); len(idx.Positions) != 2 {
-		t.Fatalf("positions within the bound were not generated: %+v", idx.Positions)
+	if idx := p.Index(t.Context(), 10); len(idx.Positions) != 6 {
+		t.Fatalf("expected the fine-grained list within the bound, got %d positions", len(idx.Positions))
 	}
-	if idx := p.Index(t.Context(), 0); len(idx.Positions) != 2 {
-		t.Fatalf("a non-positive bound must mean unbounded: %+v", idx.Positions)
+	if idx := p.Index(t.Context(), 0); len(idx.Positions) != 6 {
+		t.Fatalf("a non-positive bound must mean unbounded (fine-grained), got %d positions", len(idx.Positions))
 	}
 }
 

--- a/internal/epub/publication_test.go
+++ b/internal/epub/publication_test.go
@@ -186,6 +186,27 @@ func TestApportionNeverExceedsBudgetWithManyItems(t *testing.T) {
 	}
 }
 
+// TestIndexNeverCapsFixedLayoutPositions confirms a fixed-layout
+// publication always gets the toolkit's real position list — one Locator
+// per reading-order item — even with a bound of 1, because that list
+// costs nothing to generate (no resource is read for it) and is not the
+// byte-based estimate this bound exists to guard.
+func TestIndexNeverCapsFixedLayoutPositions(t *testing.T) {
+	pkg := strings.Replace(readerPackage,
+		`<dc:language>en</dc:language></metadata>`,
+		`<dc:language>en</dc:language><meta property="rendition:layout">pre-paginated</meta></metadata>`, 1)
+	data := readerArchive(t, pkg)
+	p, err := OpenPublication(t.Context(), bytes.NewReader(data), int64(len(data)), DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	idx := p.Index(t.Context(), 1)
+	if len(idx.Positions) != 2 {
+		t.Fatalf("expected the real one-per-chapter fixed-layout list despite the tiny bound, got %d positions", len(idx.Positions))
+	}
+}
+
 func TestPublicationRefusesRemoteAndDuplicateEntries(t *testing.T) {
 	for _, tt := range []struct {
 		name, pkg string

--- a/internal/epub/publication_test.go
+++ b/internal/epub/publication_test.go
@@ -109,8 +109,9 @@ func TestPublicationResourcesAreBoundedAndDeclared(t *testing.T) {
 // single position. The two chapters here are 9,000 and 3,000 bytes
 // (stored, so compressed size equals content size): a fine-grained
 // estimate of ceil(9000/1024)+ceil(3000/1024) = 12 positions, and a
-// bounded fallback that still gives the larger chapter roughly three
-// times as many positions as the smaller one.
+// bounded fallback (2 mandatory plus fallbackPositionBudget weighted)
+// that still gives the larger chapter roughly three times as many
+// positions as the smaller one.
 func TestIndexFallsBackToWeightedPositionsOverTheBound(t *testing.T) {
 	entries := validEntries()[:4]
 	entries[2].body = readerPackage
@@ -139,12 +140,12 @@ func TestIndexFallsBackToWeightedPositionsOverTheBound(t *testing.T) {
 		return one, two
 	}
 	idx := p.Index(t.Context(), 6)
-	if len(idx.Positions) != 6 {
-		t.Fatalf("bounded fallback must not exceed the requested budget, got %d positions", len(idx.Positions))
+	if want := 2 + fallbackPositionBudget; len(idx.Positions) != want {
+		t.Fatalf("bounded fallback must land on the mandatory-plus-weighted total, got %d, want %d", len(idx.Positions), want)
 	}
 	one, two := countByChapter(idx.Positions)
-	if one <= two {
-		t.Fatalf("the larger chapter must keep more positions than the smaller one, got one=%d two=%d", one, two)
+	if one < 2*two {
+		t.Fatalf("the 3x larger chapter must keep roughly 3x the positions, got one=%d two=%d", one, two)
 	}
 	if idx := p.Index(t.Context(), 20); len(idx.Positions) != 12 {
 		t.Fatalf("expected the fine-grained list within the bound, got %d positions", len(idx.Positions))
@@ -183,6 +184,53 @@ func TestApportionNeverExceedsBudgetWithManyItems(t *testing.T) {
 	}
 	if counts[0] <= counts[1] {
 		t.Fatalf("the far larger item must still get more positions, got %d vs %d", counts[0], counts[1])
+	}
+}
+
+// TestIndexKeepsWeightedCapacityWithManyChapters is the regression case
+// for the scenario the mandatory-plus-weighted split exists for: many
+// tiny chapters alongside one huge one. If the weighted pool were shared
+// with the one-per-chapter minimum instead of reserved on top of it, the
+// minimums alone would consume nearly the whole budget and the huge
+// chapter would end up with only a sliver of it despite holding nearly
+// all the bytes.
+func TestIndexKeepsWeightedCapacityWithManyChapters(t *testing.T) {
+	entries := validEntries()[:4]
+	pkg := `<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
+<metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:title>Reader</dc:title><dc:identifier id="uid">urn:uuid:test</dc:identifier><dc:language>en</dc:language></metadata>
+<manifest><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>`
+	spine := ""
+	const tinyChapters = 500
+	for i := range tinyChapters {
+		id := fmt.Sprintf("tiny%d", i)
+		pkg += fmt.Sprintf(`<item id="%s" href="%s.xhtml" media-type="application/xhtml+xml"/>`, id, id)
+		spine += fmt.Sprintf(`<itemref idref="%s"/>`, id)
+		entries = append(entries, zipEntry{name: "OPS/" + id + ".xhtml", method: zip.Store,
+			body: `<html xmlns="http://www.w3.org/1999/xhtml"><body>tiny</body></html>`})
+	}
+	pkg += `<item id="huge" href="huge.xhtml" media-type="application/xhtml+xml"/></manifest>`
+	spine += `<itemref idref="huge"/></spine></package>`
+	pkg += "<spine>" + spine
+	entries[2].body = pkg
+	entries = append(entries, zipEntry{name: "OPS/huge.xhtml", method: zip.Store,
+		body: `<html xmlns="http://www.w3.org/1999/xhtml"><body>` + strings.Repeat("a", 500_000) + `</body></html>`})
+	data := makeEPUB(t, entries...)
+	p, err := OpenPublication(t.Context(), bytes.NewReader(data), int64(len(data)), DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	idx := p.Index(t.Context(), 1)
+	var huge, tiny int
+	for _, position := range idx.Positions {
+		if strings.HasSuffix(position.Href.String(), "huge.xhtml") {
+			huge++
+		} else {
+			tiny++
+		}
+	}
+	if huge <= tiny {
+		t.Fatalf("the huge chapter (nearly all the bytes) must keep more positions than all %d tiny chapters combined, got huge=%d tiny=%d", tinyChapters, huge, tiny)
 	}
 }
 

--- a/internal/epub/publication_test.go
+++ b/internal/epub/publication_test.go
@@ -139,8 +139,8 @@ func TestIndexFallsBackToWeightedPositionsOverTheBound(t *testing.T) {
 		return one, two
 	}
 	idx := p.Index(t.Context(), 6)
-	if len(idx.Positions) == 0 {
-		t.Fatal("bounded fallback produced no positions at all")
+	if len(idx.Positions) != 6 {
+		t.Fatalf("bounded fallback must not exceed the requested budget, got %d positions", len(idx.Positions))
 	}
 	one, two := countByChapter(idx.Positions)
 	if one <= two {
@@ -151,6 +151,38 @@ func TestIndexFallsBackToWeightedPositionsOverTheBound(t *testing.T) {
 	}
 	if idx := p.Index(t.Context(), 0); len(idx.Positions) != 12 {
 		t.Fatalf("a non-positive bound must mean unbounded (fine-grained), got %d positions", len(idx.Positions))
+	}
+}
+
+// TestApportionNeverExceedsBudgetWithManyItems confirms that giving every
+// item at least one position, plus a proportional share of the rest,
+// cannot overshoot the requested budget even when there are far more
+// items than the naive per-item minimum would suggest — one tiny item per
+// count plus one large one, which independent per-item rounding (round
+// every share up to at least one, uncoordinated) would overshoot on.
+func TestApportionNeverExceedsBudgetWithManyItems(t *testing.T) {
+	weights := make([]uint64, 200)
+	var total uint64
+	for i := range weights {
+		weights[i] = 1
+		total++
+	}
+	weights[0] = 1_000_000
+	total += weights[0] - 1
+	const budget = 210
+	counts := apportion(weights, total, budget)
+	var sum int
+	for i, count := range counts {
+		if count < 1 {
+			t.Fatalf("item %d got no position at all", i)
+		}
+		sum += count
+	}
+	if sum != budget {
+		t.Fatalf("apportion must land on the exact budget, got %d for a budget of %d", sum, budget)
+	}
+	if counts[0] <= counts[1] {
+		t.Fatalf("the far larger item must still get more positions, got %d vs %d", counts[0], counts[1])
 	}
 }
 

--- a/internal/epub/publication_test.go
+++ b/internal/epub/publication_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/readium/go-toolkit/pkg/manifest"
 	readium "github.com/readium/go-toolkit/pkg/parser/epub"
 )
 
@@ -99,22 +100,25 @@ func TestPublicationResourcesAreBoundedAndDeclared(t *testing.T) {
 	}
 }
 
-// TestIndexFallsBackToCoarsePositionsOverTheBound confirms Index avoids
+// TestIndexFallsBackToWeightedPositionsOverTheBound confirms Index avoids
 // materializing the toolkit's byte-granular position list (one per 1,024
 // archive bytes of reading-order content) once the cheap archive-size
 // estimate exceeds maxPositions, but never leaves the reader with no
-// positions at all: it falls back to one coarse position per reading-order
-// item instead. The two chapters here are ~3,000 bytes each (stored, so
-// compressed size equals content size), giving a fine-grained estimate of
-// six positions and a coarse fallback of two (one per chapter).
-func TestIndexFallsBackToCoarsePositionsOverTheBound(t *testing.T) {
+// positions at all, and keeps a larger chapter weighted with more
+// positions than a smaller one rather than collapsing every chapter to a
+// single position. The two chapters here are 9,000 and 3,000 bytes
+// (stored, so compressed size equals content size): a fine-grained
+// estimate of ceil(9000/1024)+ceil(3000/1024) = 12 positions, and a
+// bounded fallback that still gives the larger chapter roughly three
+// times as many positions as the smaller one.
+func TestIndexFallsBackToWeightedPositionsOverTheBound(t *testing.T) {
 	entries := validEntries()[:4]
 	entries[2].body = readerPackage
 	chapter := func(body string) string {
 		return `<html xmlns="http://www.w3.org/1999/xhtml"><head/><body>` + body + `</body></html>`
 	}
 	entries = append(entries,
-		zipEntry{name: "OPS/one.xhtml", body: chapter(strings.Repeat("a", 3000)), method: zip.Store},
+		zipEntry{name: "OPS/one.xhtml", body: chapter(strings.Repeat("a", 9000)), method: zip.Store},
 		zipEntry{name: "OPS/two.xhtml", body: chapter(strings.Repeat("b", 3000)), method: zip.Store},
 		zipEntry{name: "OPS/late.bin", body: strings.Repeat("x", 8<<20), method: zip.Store})
 	data := makeEPUB(t, entries...)
@@ -123,13 +127,29 @@ func TestIndexFallsBackToCoarsePositionsOverTheBound(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer p.Close()
-	if idx := p.Index(t.Context(), 5); len(idx.Positions) != 2 {
-		t.Fatalf("expected the coarse, one-per-chapter fallback over the bound, got: %+v", idx.Positions)
+	countByChapter := func(positions []manifest.Locator) (one, two int) {
+		for _, position := range positions {
+			switch {
+			case strings.HasSuffix(position.Href.String(), "one.xhtml"):
+				one++
+			case strings.HasSuffix(position.Href.String(), "two.xhtml"):
+				two++
+			}
+		}
+		return one, two
 	}
-	if idx := p.Index(t.Context(), 10); len(idx.Positions) != 6 {
+	idx := p.Index(t.Context(), 6)
+	if len(idx.Positions) == 0 {
+		t.Fatal("bounded fallback produced no positions at all")
+	}
+	one, two := countByChapter(idx.Positions)
+	if one <= two {
+		t.Fatalf("the larger chapter must keep more positions than the smaller one, got one=%d two=%d", one, two)
+	}
+	if idx := p.Index(t.Context(), 20); len(idx.Positions) != 12 {
 		t.Fatalf("expected the fine-grained list within the bound, got %d positions", len(idx.Positions))
 	}
-	if idx := p.Index(t.Context(), 0); len(idx.Positions) != 6 {
+	if idx := p.Index(t.Context(), 0); len(idx.Positions) != 12 {
 		t.Fatalf("a non-positive bound must mean unbounded (fine-grained), got %d positions", len(idx.Positions))
 	}
 }

--- a/internal/epub/publication_test.go
+++ b/internal/epub/publication_test.go
@@ -232,6 +232,23 @@ func TestIndexKeepsWeightedCapacityWithManyChapters(t *testing.T) {
 	if huge <= tiny {
 		t.Fatalf("the huge chapter (nearly all the bytes) must keep more positions than all %d tiny chapters combined, got huge=%d tiny=%d", tinyChapters, huge, tiny)
 	}
+	var hugeEnd float64 = -1
+	for _, position := range idx.Positions {
+		if strings.HasSuffix(position.Href.String(), "huge.xhtml") {
+			hugeEnd = *position.Locations.TotalProgression
+		}
+	}
+	if hugeEnd < 0 {
+		t.Fatal("expected at least one position for the huge chapter")
+	}
+	// The huge chapter holds nearly all the bytes, so finishing it must
+	// put the reader almost at the end of the book: its last
+	// TotalProgression must not be diluted down to the roughly 31% a
+	// position-count-based fraction would give it when 500 mandatory
+	// single-position chapters precede it.
+	if hugeEnd < 0.99 {
+		t.Fatalf("TotalProgression must be byte-weighted, not position-count-weighted: huge chapter ends at %v, want >= 0.99", hugeEnd)
+	}
 }
 
 // TestIndexNeverCapsFixedLayoutPositions confirms a fixed-layout

--- a/internal/epub/publication_test.go
+++ b/internal/epub/publication_test.go
@@ -99,6 +99,29 @@ func TestPublicationResourcesAreBoundedAndDeclared(t *testing.T) {
 	}
 }
 
+// TestIndexSkipsPositionsOverTheBound confirms Index itself, not just a
+// caller's decision to cache the result, avoids materializing the full
+// position list once the cheap archive-size estimate exceeds maxPositions
+// — the two reading-order chapters here have two archive entries, so a
+// bound of 1 must be exceeded and a bound of 2 or more must not be.
+func TestIndexSkipsPositionsOverTheBound(t *testing.T) {
+	data := readerArchive(t, readerPackage)
+	p, err := OpenPublication(t.Context(), bytes.NewReader(data), int64(len(data)), DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer p.Close()
+	if idx := p.Index(t.Context(), 1); idx.Positions != nil {
+		t.Fatalf("positions over the bound were still generated: %+v", idx.Positions)
+	}
+	if idx := p.Index(t.Context(), 2); len(idx.Positions) != 2 {
+		t.Fatalf("positions within the bound were not generated: %+v", idx.Positions)
+	}
+	if idx := p.Index(t.Context(), 0); len(idx.Positions) != 2 {
+		t.Fatalf("a non-positive bound must mean unbounded: %+v", idx.Positions)
+	}
+}
+
 func TestPublicationRefusesRemoteAndDuplicateEntries(t *testing.T) {
 	for _, tt := range []struct {
 		name, pkg string

--- a/internal/webui/static/reader-engine.js
+++ b/internal/webui/static/reader-engine.js
@@ -133,8 +133,13 @@ export class ReaderEngine extends HTMLElement {
     const index = this.book.sections.findIndex(s => s.id === locator.href);
     if (index < 0) return;
     const sectionFraction = locator.locations.progression || 0;
-    const positions = this.sectionPositions[index];
-    const fraction = ((positions[0].locations.position - 1) + sectionFraction * positions.length) / this.positionList.length;
+    // The server's per-position totalProgression already reflects each
+    // section's real weight (bytes, not the discrete position count,
+    // which a bounded fallback list may distribute unevenly across many
+    // chapters); interpolate within the section's start/end bounds
+    // rather than dividing by position counts.
+    const bounds = this.getSectionFractions();
+    const fraction = bounds[index] + sectionFraction * (bounds[index + 1] - bounds[index]);
     locator = locator.copyWithLocations({ totalProgression: fraction });
     const sizes = this.book.sections.map(s => s.size || 0);
     const remaining = (1 - sectionFraction) * sizes[index];

--- a/internal/webui/static/reader-engine.js
+++ b/internal/webui/static/reader-engine.js
@@ -204,8 +204,18 @@ export class ReaderEngine extends HTMLElement {
       if (finite(target.index)) return target;
       if (finite(target.fraction)) {
         const fraction = Math.max(0, Math.min(1, target.fraction));
-        const position = this.positionList[Math.min(this.positionList.length - 1, Math.floor(fraction * this.positionList.length))];
-        return { index: this.book.sections.findIndex(s => s.id === position.href), locator: position };
+        // Use the same byte-weighted section bounds relocate() reports
+        // progress with, not the position list's raw index spacing: with
+        // a bounded fallback list, a chapter's share of positions can be
+        // far smaller than its share of the book's bytes, and indexing
+        // straight into positionList would then favor small chapters
+        // over the one the reader actually meant to reach.
+        const bounds = this.getSectionFractions();
+        let index = bounds.length - 2;
+        while (index > 0 && bounds[index] > fraction) index--;
+        const span = bounds[index + 1] - bounds[index];
+        const anchor = span > 0 ? (fraction - bounds[index]) / span : 0;
+        return { index, anchor };
       }
       if (target.href) return { index: this.book.sections.findIndex(s => s.id === target.href.split("#")[0]), locator: Locator.deserialize(target) };
     }


### PR DESCRIPTION
## Summary

Follow-up to #43: three more review findings landed on that PR after it was already merged. This fixes them.

## Changes

- A large book's reading-position list is no longer built at all once the estimated size crosses the existing 200,000-position bound. The earlier fix only skipped *caching* that list, but the expensive part is generating it, and that still happened on every request for an oversized book.
- Font deobfuscation now checks every identifier declared in the book, not just the primary one, to find the UUID Adobe's obfuscation scheme requires. Some books put something else (an ISBN, say) in the primary identifier while the UUID sits elsewhere.
- The design document's description of how the browser reader gets book content was still describing the old, pre-streaming architecture. Updated it to match how resources are actually served today.

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [ ] If `.templ` files changed: n/a, no `.templ` files touched
- [ ] If `docs/openapi.yaml` changed: n/a, not touched
- [x] Manually verified via unit tests covering the bound and the UUID search

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [ ] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.