### PR TITLE
Preserve web reader progress across reconnects

### DIFF
--- a/internal/webui/static/offline-storage.js
+++ b/internal/webui/static/offline-storage.js
@@ -264,7 +264,10 @@ export async function saveOfflinePosition({
             return;
           }
           const outbox = tx.objectStore(OUTBOX);
-          const queued = outbox.getAll();
+          const queued = outbox.index("account").getAll(IDBKeyRange.bound(
+            [partition, account, "", 0],
+            [partition, account, "\uffff", Number.MAX_SAFE_INTEGER],
+          ));
           queued.onsuccess = () => {
             const records = queued.result.filter(row => row.partition === partition && row.account === account);
             const existing = records.find(row => row.kind === "position" && row.id === op.op_id);

--- a/internal/webui/static/offline-storage.js
+++ b/internal/webui/static/offline-storage.js
@@ -1,4 +1,5 @@
 import { decodeText, publicationHref, stripPublicationCode } from "./reader-publication.js";
+import { latestReadablePosition } from "./reader-sync.js";
 
 export const OFFLINE_DB_NAME = "liseur-sync-offline";
 export const OFFLINE_DB_VERSION = 3;
@@ -262,13 +263,27 @@ export async function saveOfflinePosition({
             fail(new OfflineStorageError("This book is not available offline.", "missing"));
             return;
           }
-          current.localPosition = op;
-          snapshots.put(current);
-          tx.objectStore(OUTBOX).put({
-            key: keyForOutbox({ partition, account, kind: "position", id: op.op_id }),
-            partition, account, epoch, deviceID: deviceID || current.deviceID, bookID, kind: "position", id: op.op_id,
-            payload: op, state: "pending", createdAt: Date.now(), attempts: 0,
-          });
+          const outbox = tx.objectStore(OUTBOX);
+          const queued = outbox.getAll();
+          queued.onsuccess = () => {
+            const records = queued.result.filter(row => row.partition === partition && row.account === account);
+            const existing = records.find(row => row.kind === "position" && row.id === op.op_id);
+            if (existing) {
+              if (JSON.stringify(existing.payload) !== JSON.stringify(op))
+                fail(new OfflineStorageError("A queued position cannot change its payload.", "conflict"));
+              return;
+            }
+            // Wall clocks can move backwards and two page turns can share a
+            // millisecond. Transaction order, not UUID order, decides the head.
+            const createdAt = records.reduce((latest, row) => Math.max(latest, (row.createdAt || 0) + 1), Date.now());
+            current.localPosition = op;
+            snapshots.put(current);
+            outbox.put({
+              key: keyForOutbox({ partition, account, kind: "position", id: op.op_id }),
+              partition, account, epoch, deviceID: deviceID || current.deviceID, bookID, kind: "position", id: op.op_id,
+              payload: op, state: "pending", createdAt, attempts: 0,
+            });
+          };
         };
       });
     } catch (error) {
@@ -585,7 +600,7 @@ export async function reconcileOfflineBook(context, book, request, current = () 
   if (!book.workID) return;
   const base = "v1/works/" + encodeURIComponent(book.workID);
   const [positions, annotations] = await Promise.all([
-    request(base + "/positions?limit=1"), request(base + "/annotations"),
+    request(base + "/positions?limit=20"), request(base + "/annotations"),
   ]);
   if (!positions.ok || !annotations.ok) throw new OfflineStorageError("Reading state could not be refreshed.");
   const [positionData, annotationData] = await Promise.all([positions.json(), annotations.json()]);
@@ -604,7 +619,7 @@ export async function reconcileOfflineBook(context, book, request, current = () 
         const position = pending.filter(value => value.kind === "position")
           .sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0))[0];
         for (const copy of copies.result) {
-          copy.localPosition = position ? position.payload : positionData.ops[0] || null;
+          copy.localPosition = position ? position.payload : latestReadablePosition(positionData.ops, book.workID) || copy.localPosition || null;
           snapshots.put(copy);
         }
       };

--- a/internal/webui/static/offline-sync.js
+++ b/internal/webui/static/offline-sync.js
@@ -8,15 +8,23 @@ import {
 
 export async function drainOfflineOutbox(context, request) {
   const records = await listOfflineOutbox({ ...context });
+  const blockedWorks = new Set();
   for (const queued of records) {
     if (queued.deviceID !== context.deviceID) continue;
+    const positionWork = queued.payload.work_id || queued.bookID;
+    if (queued.kind === "position" && blockedWorks.has(positionWork)) continue;
     const record = await attemptOfflineRecord(context, queued.key);
     if (!record) continue;
     const options = { method: "POST", headers: { "Content-Type": "application/json" } };
     const done = () => removeOfflineOutbox({ ...context, kind: record.kind, id: record.id });
-    const failed = (state, error, details = null) => markOfflineOutbox({
-      ...context, kind: record.kind, id: record.id, state, error, details,
-    });
+    const failed = (state, error, details = null) => {
+      // Sending the next page before this one is acknowledged lets a later
+      // retry of the older page become the server's newest position.
+      if (record.kind === "position" && state === "pending") blockedWorks.add(positionWork);
+      return markOfflineOutbox({
+        ...context, kind: record.kind, id: record.id, state, error, details,
+      });
+    };
     if (record.kind === "session") {
       await uploadSessions([record.payload], {
         canSend: () => true,
@@ -68,7 +76,8 @@ export async function drainOfflineOutbox(context, request) {
       } else await done();
     } else if (result.status === "conflict") {
       await failed("conflict", result.reason || "revision conflict", result.server || result);
-    } else await failed("failed", result.reason || "change rejected", result);
+    } else await failed(result.status === "invalid" ? "failed" : "pending",
+      result.reason || "change not acknowledged", result);
   }
 }
 
@@ -77,6 +86,7 @@ export function offlineSync({ context, base, onChange = () => {}, onStatus = () 
   const auth = readerAuth({ apiBase: base, tokenURL: base + "ui/reader/token",
     csrf: () => csrf, onExhausted: () => {} });
   const authorize = async identity => {
+    if (stopped) throw new Error("Offline synchronization stopped.");
     await assertOfflineContext(context);
     if (identity.account !== context.account || identity.device !== context.deviceID)
       throw new Error("Sign in on the original account and device to sync offline changes.");
@@ -88,12 +98,15 @@ export function offlineSync({ context, base, onChange = () => {}, onStatus = () 
     return response;
   };
   const run = async () => {
+    // A stopped coordinator may still be waiting for another tab's lock.
+    if (stopped || globalThis.document?.hidden || globalThis.navigator?.onLine === false) return false;
     const response = await fetch(base + "ui/offline/account", {
       cache: "no-store", credentials: "same-origin", signal: AbortSignal.timeout(30000),
     });
     if (!response.ok || response.redirected)
       throw new Error("Sign in again to sync offline changes.");
     const account = await response.json();
+    if (stopped) return false;
     if (account.account !== context.account) throw new Error("Sign in as the account that saved these books.");
     if (typeof account.csrf !== "string" || !account.csrf)
       throw new Error("Sign in again to sync offline changes.");
@@ -122,9 +135,12 @@ export function offlineSync({ context, base, onChange = () => {}, onStatus = () 
       onStatus(error.message || "Offline changes are waiting to sync.");
       return true;
     }).then(pending => {
-      if ((pending || again) && !stopped && retries < 4) {
+      if (!stopped) {
+        const delay = pending || again ? [1000, 3000, 10000, 30000][Math.min(retries++, 3)] : 30000;
         again = false;
-        timer = setTimeout(() => trigger(false), [1000, 3000, 10000, 30000][retries++]);
+        // Keep checking in the foreground, including after the network comes
+        // back without an online event and while another device is reading.
+        timer = setTimeout(() => trigger(false), delay);
       }
     }).finally(() => { flight = null; });
     return flight;

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -7,7 +7,7 @@ import { positionTable, pageAt, pageLocation } from "./reader-positions.js";
 import { readerAuth } from "./reader-auth.js";
 import { offlineSync } from "./offline-sync.js";
 import { liveStream } from "./reader-live.js";
-import { catchupState, topicRefresh } from "./reader-sync.js";
+import { catchupState, topicRefresh, latestReadablePosition, positionAcknowledged } from "./reader-sync.js";
 import { annotationCFI, annotationAnchor, annotationRenderer } from "./reader-annotations.js";
 import {
   clearOfflineSessionCheckpoint,
@@ -263,13 +263,13 @@ async function lastPosition() {
   const work = workID;
   const stamp = snapshot();
   const resp = await api(
-    "v1/works/" + encodeURIComponent(work) + "/positions?limit=1",
+    "v1/works/" + encodeURIComponent(work) + "/positions?limit=20",
   );
   if (!resp.ok) return { ok: false };
   stamp.identity = auth.responseIdentity(resp);
   const ops = (await resp.json()).ops || [];
   if (work !== workID || !current(stamp)) return { ok: false };
-  return { ok: true, op: ops.length ? ops[0] : null };
+  return { ok: true, op: latestReadablePosition(ops, work) };
 }
 
 // ------------------------------------------------------------- live
@@ -945,9 +945,8 @@ function sectionProgression(location) {
   return Math.max(0, Math.min(1, (total - lo) / (hi - lo)));
 }
 
-// push records where we are. Failure is deliberately quiet: losing a
-// position update is a smaller harm than an error banner over the page
-// every time a laptop lid closes, and the next page turn retries.
+// push records where we are. Transient failures retain the operation for
+// the next foreground retry, reconnect or page turn.
 //
 // The op log is append-only and idempotent by op id, so a retry of the
 // same position must replay the same op — the whole op, byte for byte,
@@ -956,8 +955,7 @@ function sectionProgression(location) {
 // once and kept until the server confirms it holds it; a different
 // position is a different op and gets a new id. The server answers 200
 // with a status per op: "applied" and "duplicate" both mean the log
-// has it, and "conflict" means this id already belongs to another
-// payload, where replaying is the one thing that cannot help.
+// has it. A refusal is never an acknowledgement.
 let retryOp = null;
 let positionInFlight = null;
 let fractionRetryTimer = null;
@@ -1007,6 +1005,16 @@ function scheduleFractionRetry() {
 }
 
 async function push() {
+  if (positionInFlight) return positionInFlight;
+  const activity = activityGeneration;
+  positionInFlight = pushPosition().finally(() => {
+    positionInFlight = null;
+    if (activity !== activityGeneration && readingDirty) schedulePush();
+  });
+  return positionInFlight;
+}
+
+async function pushPosition() {
   if (!workID || !here || !readingDirty || restoring) return;
   const stamp = snapshot();
   const locator = locatorFor(here);
@@ -1033,7 +1041,7 @@ async function push() {
           locator: locator,
         };
   retryOp = { key, op };
-  if (!cfg.offline) catchup.wrote(op);
+  catchup.wrote(op);
   if (cfg.offline) {
     try {
       await saveOfflinePosition({
@@ -1046,7 +1054,8 @@ async function push() {
       notifyOfflineChange();
       if (retryOp?.op === op) {
         retryOp = null;
-        readingDirty = false;
+        if (locatorFor(here)?.locations.fragments[0] === locator.locations.fragments[0] &&
+            here.fraction === locator.locations.totalProgression) readingDirty = false;
       }
     } catch (err) {
       say(err.message || "Offline position could not be saved.", true);
@@ -1061,22 +1070,13 @@ async function push() {
     keepalive: true,
     body: JSON.stringify({ ops: [op] }),
   });
-  positionInFlight = request;
   try {
     const resp = await request;
     stamp.identity = auth.responseIdentity(resp) || stamp.identity;
     if (!resp.ok || !current(stamp) || !auth.responseCurrent(resp)) return;
     const out = await resp.json().catch(() => null);
     if (!current(stamp) || !auth.responseCurrent(resp)) return;
-    const status =
-      out && out.results && out.results[0] && out.results[0].status;
-    if (
-      status !== "applied" &&
-      status !== "duplicate" &&
-      status !== "conflict"
-    ) {
-      return;
-    }
+    if (!positionAcknowledged(out, op)) return;
     // Only this op's own outcome may clear it: a slower response
     // arriving after the reader has moved on must not discard the op
     // a newer push is still responsible for.
@@ -1088,8 +1088,6 @@ async function push() {
     }
   } catch (err) {
     /* offline: the next page turn replays this exact op */
-  } finally {
-    if (positionInFlight === request) positionInFlight = null;
   }
 }
 
@@ -1120,7 +1118,8 @@ function opID() {
 function schedulePush() {
   if (!readingDirty || restoring) return;
   cancelScheduledPush();
-  pending = setTimeout(push, 1500);
+  // Local durability need not wait for the network debounce.
+  pending = setTimeout(push, cfg.offline ? 0 : 1500);
 }
 
 // ------------------------------------------------------- sessions
@@ -1295,6 +1294,8 @@ document.addEventListener("visibilitychange", () => {
     return;
   }
   catchup.resume();
+  push();
+  pushSession();
   if (ready) startLive();
   beginSession();
   if (here && !finite(here.fraction)) {
@@ -1308,8 +1309,21 @@ window.addEventListener("pagehide", () => {
   refreshes.stop();
   catchup.hide();
   hideCatchup();
+  cancelScheduledPush();
+  push();
   endSession();
 });
+window.addEventListener("online", () => {
+  if (document.hidden) return;
+  push();
+  pushSession();
+  if (ready) startLive();
+});
+setInterval(() => {
+  if (document.hidden || navigator.onLine === false) return;
+  push();
+  pushSession();
+}, 30000);
 
 function cfiOf(op) {
   const fragments =
@@ -2628,7 +2642,9 @@ window.addEventListener("beforeunload", () => {
     let op = cfg.offline ? offlineSnapshot.localPosition || null : null;
     if (cfg.offline) {
       catchup.bind(offlineAccount, workID, offlineSnapshot.deviceID);
-      catchup.baseline(op);
+      // A locally queued wire op omits device_id; the credential supplies it
+      // on upload. Its echo after a reload is still our opening baseline.
+      catchup.baseline(op && { ...op, device_id: op.device_id || offlineSnapshot.deviceID });
     }
     if (!cfg.offline) try {
       workID = await resolveWork();

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -958,6 +958,7 @@ function sectionProgression(location) {
 // has it. A refusal is never an acknowledgement.
 let retryOp = null;
 let positionInFlight = null;
+let positionAgain = false;
 let fractionRetryTimer = null;
 let fractionRetryAttempt = 0;
 const FRACTION_RETRY_DELAYS = [250, 750, 1500, 3000, 6000];
@@ -1005,11 +1006,17 @@ function scheduleFractionRetry() {
 }
 
 async function push() {
-  if (positionInFlight) return positionInFlight;
+  if (positionInFlight) {
+    positionAgain = true;
+    return positionInFlight;
+  }
   const activity = activityGeneration;
   positionInFlight = pushPosition().finally(() => {
     positionInFlight = null;
-    if (activity !== activityGeneration && readingDirty) schedulePush();
+    const again = positionAgain;
+    positionAgain = false;
+    if (again && readingDirty) push();
+    else if (activity !== activityGeneration && readingDirty) schedulePush();
   });
   return positionInFlight;
 }
@@ -1076,6 +1083,12 @@ async function pushPosition() {
     if (!resp.ok || !current(stamp) || !auth.responseCurrent(resp)) return;
     const out = await resp.json().catch(() => null);
     if (!current(stamp) || !auth.responseCurrent(resp)) return;
+    const result = out?.results?.[0];
+    if (result?.op_id === op.op_id && result.status === "conflict") {
+      if (retryOp?.op === op) retryOp = null;
+      say("This position changed while it was syncing. Retrying with a new operation.", true);
+      return;
+    }
     if (!positionAcknowledged(out, op)) return;
     // Only this op's own outcome may clear it: a slower response
     // arriving after the reader has moved on must not discard the op

--- a/internal/webui/static/reader-sync.js
+++ b/internal/webui/static/reader-sync.js
@@ -3,9 +3,7 @@
 export function latestReadablePosition(ops, workID) {
   if (!Array.isArray(ops)) return null;
   const fraction = value => typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
-  return ops.find(op => op?.op_id && op.work_id === workID && fraction(op.progression) &&
-    (!op.locator?.locations || !Object.hasOwn(op.locator.locations, "totalProgression") ||
-      fraction(op.locator.locations.totalProgression))) || null;
+  return ops.find(op => op?.op_id && op.work_id === workID && fraction(op.progression)) || null;
 }
 
 export function positionAcknowledged(body, op) {

--- a/internal/webui/static/reader-sync.js
+++ b/internal/webui/static/reader-sync.js
@@ -1,3 +1,18 @@
+// Match Android's bounded fallback past malformed position records. A real
+// zero is readable; missing, null and out-of-range fractions are not.
+export function latestReadablePosition(ops, workID) {
+  if (!Array.isArray(ops)) return null;
+  const fraction = value => typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+  return ops.find(op => op?.op_id && op.work_id === workID && fraction(op.progression) &&
+    (!op.locator?.locations || !Object.hasOwn(op.locator.locations, "totalProgression") ||
+      fraction(op.locator.locations.totalProgression))) || null;
+}
+
+export function positionAcknowledged(body, op) {
+  const result = body?.results?.[0];
+  return result?.op_id === op.op_id && ["applied", "duplicate"].includes(result.status);
+}
+
 // Coalescing is per topic. An event during a read owes one more read; failure
 // keeps that obligation even if no later event arrives.
 export function topicRefresh({

--- a/internal/webui/testdata/offlinebrowser.test.mjs
+++ b/internal/webui/testdata/offlinebrowser.test.mjs
@@ -227,6 +227,39 @@ async function storageChecks() {
   check((await s.listOfflineOutbox({ ...context, kind: "position" })).length === 2,
     "restoring a replacement snapshot preserves queued operations");
 
+  const positionPosts = [];
+  await drainOfflineOutbox(context, async (path, options) => {
+    if (path !== "v1/ops") return reply({ results: [] });
+    positionPosts.push(JSON.parse(options.body).ops[0].op_id);
+    return reply({ error: "temporary failure" }, "", 503);
+  });
+  check(positionPosts.join(",") === "local-position", "a deferred page blocks newer pages of the same work");
+  const firstPosition = (await s.listOfflineOutbox({ ...context, kind: "position" }))[0];
+  await s.saveOfflinePosition({ ...context, bookID, op: firstPosition.payload });
+  check((await s.listOfflineOutbox({ ...context, kind: "position" }))[0].attempted,
+    "saving a retry does not erase its transmission evidence");
+  check((await s.getReadySnapshot({ ...context, bookID })).localPosition.op_id === latestPosition.op_id,
+    "saving an older retry cannot replace the local head");
+  await rejected(() => s.saveOfflinePosition({ ...context, bookID,
+    op: { ...firstPosition.payload, progression: 0.9 } }), "queued position IDs have immutable payloads");
+  await drainOfflineOutbox(context, async (path, options) => {
+    if (path !== "v1/ops") return reply({ results: [] });
+    const op = JSON.parse(options.body).ops[0];
+    positionPosts.push(op.op_id);
+    return reply({ results: [{ op_id: op.op_id, status: "applied" }] });
+  });
+  check(positionPosts.join(",") === "local-position,local-position,a-newer-position",
+    "recovery sends the old position before the latest, including a deliberate backward move");
+  const originalNow = Date.now;
+  try {
+    Date.now = () => 100;
+    await s.saveOfflinePosition({ ...context, bookID, op: { ...latestPosition, op_id: "z-first" } });
+    Date.now = () => 50;
+    await s.saveOfflinePosition({ ...context, bookID, op: { ...latestPosition, op_id: "a-last" } });
+  } finally { Date.now = originalNow; }
+  check((await s.listOfflineOutbox({ ...context, kind: "position" })).map(row => row.id).join(",") === "z-first,a-last",
+    "a clock moving backwards cannot reorder page turns");
+
   // The coordinator uses actual IndexedDB, Web Locks, account/token handshakes
   // and transport-bound identity checks, with only HTTP replaced by fixtures.
   await s.clearOfflineAccount(partition, account);
@@ -301,9 +334,12 @@ async function storageChecks() {
   const bounded = offlineSync({ context, base: partition });
   try {
     await bounded.trigger();
-    for (let i = 0; i < 4; i++) await scheduled[i].callback();
-    check(scheduled.map(item => item.delay).join(",") === "1000,3000,10000,30000",
-      "foreground retry budget must stop after four bounded retries");
+    for (let i = 0; i < 5; i++) await scheduled[i].callback();
+    check(scheduled.map(item => item.delay).join(",") === "1000,3000,10000,30000,30000,30000",
+      "foreground retries continue at a bounded rate through a long outage");
+    signedIn = true;
+    await scheduled[5].callback();
+    check(posts === 5, "recovery needs neither a page turn nor a new online event");
   } finally {
     bounded.stop();
     globalThis.setTimeout = originalTimeout;

--- a/internal/webui/testdata/offlinereader.mjs
+++ b/internal/webui/testdata/offlinereader.mjs
@@ -120,11 +120,41 @@ try {
   assert.notEqual(inspect.title, 'pwned');
   assert.equal(inspect.hostile, false);
   assert(inspect.nonce, 'offline reader has a script nonce');
+  await offline.evaluate(`document.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }))`);
+  const saved = await wait(offline, `(async () => {
+    const s = await import('../assets/offline-storage.js');
+    const book = await s.getReadySnapshot({ bookID: ${JSON.stringify(book)} });
+    const rows = await s.listOfflineOutbox({ partition: book.partition, account: book.account, kind: 'position' });
+    return book.localPosition?.progression > 0.9 && rows.length ? book.localPosition : null;
+  })()`, 'offline page turn is durably queued');
   await offline.call('Page.reload', { ignoreCache: true });
-  await wait(offline, probe, 'offline reader survives reload');
+  await wait(offline, `(() => {
+    const view = document.querySelector('readium-view');
+    return view?.renderer?.getContents?.().some(({doc}) => doc?.body?.textContent.length > 0) &&
+      parseFloat(document.getElementById('reader-progress-text')?.textContent) >= 90;
+  })()`, 'offline reader restores the saved page after reload');
   assert.notEqual(await offline.evaluate('document.querySelector("script[nonce]")?.nonce'), inspect.nonce,
     'each cached reader navigation receives a fresh nonce');
   console.log('PASS cold /sync/ offline navigation, real positions, inert EPUB script and fresh nonce on reload');
+  await offline.call('Network.emulateNetworkConditions', {
+    offline: false, latency: 0, downloadThroughput: -1, uploadThroughput: -1,
+  });
+  await wait(offline, `(async () => {
+    const s = await import('../assets/offline-storage.js');
+    const book = await s.getReadySnapshot({ bookID: ${JSON.stringify(book)} });
+    return !(await s.listOfflineOutbox({ partition: book.partition, account: book.account, kind: 'position' })).length;
+  })()`, 'reconnection acknowledges the durable position');
+  const remote = await offline.evaluate(`(async () => {
+    const { readerAuth } = await import('../assets/reader-auth.js');
+    const base = ${JSON.stringify(base)};
+    const account = await (await fetch(base + 'ui/offline/account')).json();
+    const auth = readerAuth({ apiBase: base, tokenURL: base + 'ui/reader/token', csrf: account.csrf });
+    return (await (await auth.request('v1/works/' + ${JSON.stringify(saved.work_id)} + '/positions?limit=1')).json()).ops[0];
+  })()`);
+  assert.equal(remote.op_id, saved.op_id, 'reconnect replays the persisted operation ID');
+  assert.equal(remote.progression, saved.progression, 'server receives the page saved before reload');
+  assert.deepEqual(remote.locator, saved.locator, 'exact locator survives offline reload and upload');
+  console.log('PASS offline page turn survives reload and reconnect uploads the identical operation');
 } catch (error) {
   console.error(error, JSON.stringify(diagnostics));
   process.exitCode = 1;

--- a/internal/webui/testdata/readersync.test.mjs
+++ b/internal/webui/testdata/readersync.test.mjs
@@ -1,6 +1,29 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { catchupState, candidateID, topicRefresh } from "../static/reader-sync.js";
+import { catchupState, candidateID, topicRefresh, latestReadablePosition, positionAcknowledged } from "../static/reader-sync.js";
+
+test("position reads skip corrupt heads without inventing a zero", () => {
+  const good = { op_id: "good", work_id: "work", progression: 0.7 };
+  for (const progression of [null, undefined, NaN, Infinity, -0.1, 1.1, "bad"]) {
+    const bad = { ...good, op_id: "bad", progression };
+    assert.deepEqual(latestReadablePosition([bad, good], "work"), good);
+    assert.equal(latestReadablePosition([bad], "work"), null);
+  }
+  assert.equal(latestReadablePosition([{ ...good, work_id: "other" }], "work"), null);
+  assert.equal(latestReadablePosition([{ ...good, locator: { locations: { totalProgression: null } } }, good], "work"), good);
+  assert.equal(latestReadablePosition([{ ...good, progression: 0 }, good], "work").progression, 0);
+});
+
+test("only an acknowledgement of this exact operation settles a position", () => {
+  const op = { op_id: "mine" };
+  for (const status of ["applied", "duplicate"]) {
+    assert.equal(positionAcknowledged({ results: [{ op_id: "mine", status }] }, op), true);
+    assert.equal(positionAcknowledged({ results: [{ op_id: "other", status }] }, op), false);
+  }
+  for (const status of ["conflict", "invalid", undefined])
+    assert.equal(positionAcknowledged({ results: [{ op_id: "mine", status }] }, op), false);
+  assert.equal(positionAcknowledged(null, op), false);
+});
 
 const op = (id, device = "phone", progression = 0.6) => ({
   op_id: id, device_id: device, work_id: "work", progression,

--- a/internal/webui/testdata/readersync.test.mjs
+++ b/internal/webui/testdata/readersync.test.mjs
@@ -10,7 +10,7 @@ test("position reads skip corrupt heads without inventing a zero", () => {
     assert.equal(latestReadablePosition([bad], "work"), null);
   }
   assert.equal(latestReadablePosition([{ ...good, work_id: "other" }], "work"), null);
-  assert.equal(latestReadablePosition([{ ...good, locator: { locations: { totalProgression: null } } }, good], "work"), good);
+  assert.equal(latestReadablePosition([{ ...good, locator: { locations: { totalProgression: null } } }, good], "work").op_id, "good");
   assert.equal(latestReadablePosition([{ ...good, progression: 0 }, good], "work").progression, 0);
 });
 


### PR DESCRIPTION
## Summary

The web reader now keeps offline reading progress safe across retries, reloads, reconnects, and clock changes. This prevents an older queued page from replacing a newer one.

Follow-up work for full Android-level online conflict handling is tracked in #49.

## Changes

- Keep queued position payloads immutable and ordered by transaction time.
- Block newer positions for a book until an older retry is acknowledged.
- Continue foreground retries after long outages.
- Ignore malformed position heads while preserving valid earlier progress.
- Verify reconnect uploads preserve the exact operation and locator.

## Testing

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Node synchronization tests
- [x] Chromium offline storage and reader checks
- [ ] `go test -race ./...` (GitHub CI)

## Checklist

- [x] The change is focused on reader synchronization.
- [x] Regression tests cover the new behavior.
- [x] No API or migration changes are required.
- [x] No secrets or generated build artifacts are included.