### PR TITLE
Make web reading sync durable

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -132,7 +132,28 @@ already have.**
   except in a Calibre folder, where the pass reads a curated catalog and
   a book absent from `metadata.db` is deleted (ADR-0022).
 
-### 3.1 Offline web reader
+### 3.1 Reading state in the browser
+
+The browser reader writes every position, session checkpoint and
+finished sitting to an account- and deployment-partitioned IndexedDB
+outbox before it tries to deliver it, and replays those immutable
+payloads until the server acknowledges them (ADR-0037). One coordinator
+drains that queue for every same-origin page: an ordinary reader tab, a
+second tab and the installed app take turns on one lock named after the
+account's queue, so a stale page cannot overtake a newer one for the
+same work. A page turn is settled by the server's acknowledgement, so a
+tab that closes before one arrives loses nothing.
+
+Each book and device keeps the position it and the server last agreed
+on. A remote position is compared against that baseline. The comparison
+never looks at a clock and never prefers the larger fraction. If only the
+other device moved, the reader is offered the trip and the text stays
+put until they take it. If both moved, the reader is shown both
+positions and asked; the answer settles the disagreement so a reload
+does not raise it again. This mirrors the Android client's merge, less
+its reading `status` dimension, which a web op does not carry.
+
+### 3.2 Offline web reader
 
 The web UI also exposes one multi-book installable PWA under
 `/ui/offline/`; it is not one app per book. The service worker is scoped
@@ -148,7 +169,8 @@ locally before foreground delivery, then use the existing native sync and
 annotation protocols after a same-account reconnect. iOS background
 delivery, storage permanence and remote erasure of already-downloaded
 bytes are not promised. A configured separate reader origin disables this
-same-origin PWA surface rather than weakening the origin isolation.
+same-origin PWA surface, and with it the durable queue above, rather than
+weakening the origin isolation.
 
 ## 4. Identity: works, editions, aliases
 

--- a/docs/adr/0037-durable-online-reading.md
+++ b/docs/adr/0037-durable-online-reading.md
@@ -1,0 +1,122 @@
+# ADR-0037: Durable online reading, and a disagreement the reader answers
+
+**Status:** Accepted
+**Scope:** Now
+**Amends:** [ADR-0007](0007-web-reader.md), [ADR-0030](0030-web-reader-reading-sessions.md), and [ADR-0036](0036-one-bounded-offline-web-reader.md)
+
+## Context
+
+ADR-0036 gave the installed offline reader a durable queue: a position, a
+session checkpoint and a finished sitting are written to IndexedDB before
+anything is sent, and the same bytes are replayed until the server
+acknowledges them. The ordinary online reader never got any of that. It
+held a position in a variable, posted it, and kept a single in-memory
+retry. A closed tab, a crash or a reload before the acknowledgement lost
+the page turn outright, and a sitting that failed to upload went with it.
+
+The catch-up offer had a second problem. It kept a "baseline", but the
+baseline was an identifier held in memory and used only to suppress the
+reader's own echo. It was not a position, it did not survive a reload,
+and it was never compared against anything. When the reader turned a page
+while another device's position was on offer, the offer was folded away
+and forgotten. One side always won, and the reader was never told there
+had been a disagreement.
+
+The Android client already solved this. `ReadingProgress` keeps agreed and
+pending positions, `SyncPeerState` keeps the agreed baseline per book and
+peer, and `ReadingStateMerge` compares baseline, local and remote and
+answers with pull, push, conflict or in-sync. A conflict is kept and
+presented; nothing decides it in the background.
+
+The two clients also disagree about identity in a way that matters here.
+Every browser tab of one account shares a single web device id, because
+op-log heads are keyed by work *and* device. Two tabs are therefore one
+device competing with itself for a single head, and the browser cannot
+fix that on its own.
+
+## Decision
+
+The online reader uses the same durable machinery as the offline one.
+Positions and finished sittings are written to the account-partitioned
+IndexedDB outbox before delivery is attempted, and delivered by
+`drainOfflineOutbox`: the same sender, the same immutable-replay rule,
+the same per-work head blocking that stops a stale page overtaking a
+newer one. Session checkpoints are kept online too, so a crash
+mid-sitting resumes from its last checkpoint rather than losing the
+sitting. A checkpoint names one sitting, so only the page that can claim
+the book keeps one; a second tab on the same book is refused the claim
+and reads on with its own fresh sitting.
+
+The retry ladder, the Web Lock and the wake-up events move into one
+coordinator shared by both modes. The lock is named after the account's
+queue rather than after the page holding it, so an ordinary reader tab, a
+second reader tab and the installed app take turns on one outbox instead
+of racing each other into a reordered op log.
+
+Each book and device gets a durable agreed baseline: the position this
+browser and the server both know. It advances on exactly three events and
+on nothing else: the position read when the book opens, an acknowledged
+local op, and a remote position the reader accepted. A local page turn is
+movement away from the baseline, and it leaves the baseline where it was.
+
+Reconciliation is a port of `ReadingStateMerge`: given the baseline, this
+device's position and the newest remote one, it answers pull, push,
+conflict or in-sync. It never consults a clock and never prefers the
+furthest position, since a wall clock says nothing about which position a
+reader wants and moving backwards through a book is ordinary. Where
+Android compares a reading `status`, the web reader compares the exact
+pointer instead, since a web op carries a progression and a locator and no
+status. Whether this side moved comes from the durable queue, so it
+survives a reload and a crash.
+
+A remote move on its own stays an offer with a button, as before: text
+does not move under a reader's eyes without a click, even though Android
+pulls. A move on both sides extends the same panel to name both
+positions and label each button with where it goes. Answering it settles
+it: the position the reader did not take becomes agreed too, so a reload
+does not ask again. Taking the other device's position withdraws this
+browser's own undelivered pages, because the queue drains oldest first and
+one of them would otherwise land after the answer and reinstate the
+position the reader just refused.
+
+This applies to same-origin deployments only. It is gated on exactly the
+condition that already gates the IndexedDB account marker, its epoch guard
+and the logout wipe, so no new storage appears anywhere those protections
+are absent. A `reader_origin` deployment keeps today's best-effort
+behaviour and ADR-0036's origin boundary.
+
+## Consequences
+
+There are no API, route or database changes. The server's op log and
+session semantics are unchanged and remain authoritative; every retry
+replays identical bytes, so a duplicate is a duplicate and never a
+conflict.
+
+Ordinary online reading now leaves rows in the same private IndexedDB
+store as offline reading, under the same account epoch and the same
+logout wipe. The logout confirmation therefore speaks about reading
+changes waiting on this device rather than about offline changes.
+
+Two tabs are still one device. The lock serializes delivery; it cannot
+stop two tabs authoring divergent heads for the same work. The conflict
+panel is what surfaces that to the reader.
+
+A reader who closes the last tab with a page still queued keeps it: it
+goes out when a reader is next opened on that account, which drains the
+whole queue and not merely that book. Nothing promises delivery while no
+page of the deployment is open.
+
+## Implementation and acceptance
+
+- [x] Write online positions and finished sittings to the outbox before
+      sending them, and keep a session checkpoint in the page that holds
+      the book's reader claim.
+- [x] Drain both modes through one coordinator, one lock and one sender.
+- [x] Persist an agreed baseline per book and device, advanced only by an
+      opening read, an acknowledgement or an accepted offer.
+- [x] Reconcile baseline, local and remote without consulting a clock.
+- [x] Present a disagreement with both positions and per-position buttons,
+      and settle it when it is answered.
+- [x] Keep separate-reader-origin deployments as they were.
+- [x] Cover reconnection, conflict, credential renewal, two windows and a
+      reload with an undelivered queue in the browser suites.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -61,6 +61,7 @@ loose ends that must come before any of it, are in
 | [0034](0034-live-notifications-say-only-that-something-changed.md) | A live notification says only that something changed | Client | Accepted | `GET /v1/events` as topic-only SSE, published post-commit by the store, authorized per topic; correctness stays in the existing feeds; amends [0007](0007-web-reader.md) |
 | [0035](0035-naming-a-shelf-is-one-request.md) | Naming a shelf is one request | Client | Accepted; implemented | `POST /v1/books/resolve` for up to 500 books, one transaction and one answer each, `200` with per-item `not_found`/`ambiguous`; same `library-read` + `sync` pair; amends [0003](0003-catalog-work-identity.md) |
 | [0036](0036-one-bounded-offline-web-reader.md) | One bounded offline web reader | Later | Accepted; implemented pending iOS acceptance | Same-origin multi-book PWA under `/ui/offline/`, private IndexedDB publication/state storage, foreground-only reconnect, and explicit annotation conflict handling; separate reader origins leave it disabled |
+| [0037](0037-durable-online-reading.md) | Durable online reading, and a disagreement the reader answers | Now | Accepted; implemented | The online reader queues positions and sittings to the same IndexedDB outbox, drains through one shared lock and sender, keeps an agreed baseline per book and device, and presents a two-sided move as a conflict; same-origin deployments only; amends [0007](0007-web-reader.md), [0030](0030-web-reader-reading-sessions.md), [0036](0036-one-bounded-offline-web-reader.md) |
 
 ## Convention
 

--- a/internal/webui/offline.go
+++ b/internal/webui/offline.go
@@ -88,6 +88,7 @@ var offlineReaderAssets = map[string]string{
 	"reader-live.js":            "application/javascript; charset=utf-8",
 	"reader-positions.js":       "application/javascript; charset=utf-8",
 	"reader-publication.js":     "application/javascript; charset=utf-8",
+	"reader-reconcile.js":       "application/javascript; charset=utf-8",
 	"reader-session-upload.js":  "application/javascript; charset=utf-8",
 	"reader-session.js":         "application/javascript; charset=utf-8",
 	"reader-sync.js":            "application/javascript; charset=utf-8",

--- a/internal/webui/reader.templ
+++ b/internal/webui/reader.templ
@@ -234,6 +234,9 @@ templ readerPage(v ReaderView, csrf string) {
 				</label>
 				<button type="button" data-annotation-action="cancel">Cancel</button>
 			</div>
+			// Both buttons are relabelled at runtime: an offer says where it
+			// would take the reader, and a disagreement says that for each
+			// side. The label here names the panel, not either position.
 			<aside id="reader-catchup" class="reader-catchup" aria-label="Reading position on another device" hidden>
 				<p id="reader-catchup-text" role="status" aria-live="polite"></p>
 				<div>

--- a/internal/webui/readerlive_ext_test.go
+++ b/internal/webui/readerlive_ext_test.go
@@ -21,3 +21,10 @@ func TestReaderAnnotationReplacement(t *testing.T) {
 func TestOfflinePublicationStorageCore(t *testing.T) {
 	runNodeTests(t, "offline-storage.test.mjs")
 }
+
+// Three-way reconciliation is the whole of the reader's conflict
+// behaviour, and it is pure: it deserves to be pinned on its own,
+// away from a browser.
+func TestReadingStateReconciliation(t *testing.T) {
+	runNodeTests(t, "readerreconcile.test.mjs")
+}

--- a/internal/webui/static/offline-account.js
+++ b/internal/webui/static/offline-account.js
@@ -34,7 +34,7 @@ document.addEventListener("submit", async event => {
   try {
     const pending = await listOfflineOutbox({ partition, account, state: null });
     if (pending.length && !window.confirm(
-      "Offline changes are waiting to sync. Signing out will remove them from this device. Continue?",
+      "Reading changes on this device are waiting to sync. Signing out will remove them. Continue?",
     )) return;
     signingOut = true;
     await clearOfflineAccount(partition, account);

--- a/internal/webui/static/offline-storage.js
+++ b/internal/webui/static/offline-storage.js
@@ -2,13 +2,14 @@ import { decodeText, publicationHref, stripPublicationCode } from "./reader-publ
 import { latestReadablePosition } from "./reader-sync.js";
 
 export const OFFLINE_DB_NAME = "liseur-sync-offline";
-export const OFFLINE_DB_VERSION = 3;
+export const OFFLINE_DB_VERSION = 4;
 const SNAPSHOTS = "snapshots";
 const RESOURCES = "resources";
 const ACCOUNTS = "accounts";
 const OUTBOX = "outbox";
 const CHECKPOINTS = "checkpoints";
 const ANNOTATIONS = "annotations";
+const READING = "reading";
 const separator = "\u001f";
 
 export class OfflineStorageError extends Error {
@@ -107,6 +108,14 @@ export function openOfflineDB() {
         const annotations = db.createObjectStore(ANNOTATIONS, { keyPath: "key" });
         annotations.createIndex("book", ["partition", "account", "bookID"]);
       }
+      // Version 4. Added, never rewritten: an installed app upgrading
+      // from 3 keeps every snapshot, queued change and annotation it
+      // already had, and simply has no agreed baseline until the next
+      // position settles one.
+      if (!db.objectStoreNames.contains(READING)) {
+        const reading = db.createObjectStore(READING, { keyPath: "key" });
+        reading.createIndex("book", ["partition", "account", "bookID"]);
+      }
     };
     request.onsuccess = () => resolve(request.result);
     request.onerror = () => reject(request.error || new OfflineStorageError("Could not open offline storage."));
@@ -149,6 +158,13 @@ function keyForCheckpoint({ partition, account, bookID }) {
 
 function keyForAnnotation({ partition, account, bookID, id }) {
   return [partition, account, bookID, id].join(separator);
+}
+
+// A reading-state record is per device as well as per book: the agreed
+// baseline is what *this* browser and the server last agreed on, and a
+// second device's agreement says nothing about this one's.
+function keyForReading({ partition, account, deviceID, bookID }) {
+  return [partition, account, deviceID || "", bookID].join(separator);
 }
 
 export async function accountVersion(partition) {
@@ -245,24 +261,34 @@ export function notifyOfflineChange(type = "write", partition = storagePartition
   }
 }
 
-export async function saveOfflinePosition({
-  partition = storagePartition(), account, epoch, deviceID, bookID, op,
+// saveReadingPosition queues one position op and records it as this
+// device's local reading state, before anything is sent. It is the same
+// path online and offline: the outbox record is immutable once written,
+// and the op is replayed byte for byte until the server acknowledges it.
+//
+// `requireSnapshot` is what differs. Offline reading has no meaning
+// without downloaded bytes, so a missing snapshot is an error there. An
+// online book has no snapshot at all and must still queue.
+export async function saveReadingPosition({
+  partition = storagePartition(), account, epoch, deviceID, bookID, workID = "", op,
+  requireSnapshot = true,
 } = {}) {
   if (!partition || !account || !bookID || !op?.op_id)
-    throw new OfflineStorageError("An offline position needs an account, book and operation.");
+    throw new OfflineStorageError("A reading position needs an account, book and operation.");
   return withDB(async db => {
     try {
-      await guardedWork(db, [SNAPSHOTS, OUTBOX], { partition, account, epoch }, (tx, _, fail) => {
+      await guardedWork(db, [SNAPSHOTS, OUTBOX, READING], { partition, account, epoch }, (tx, _, fail) => {
         const snapshots = tx.objectStore(SNAPSHOTS);
         const request = snapshots.index("book").getAll([partition, account, bookID]);
         request.onsuccess = () => {
           const current = request.result
             .filter(value => value.state === "ready")
             .sort((a, b) => (b.readyAt || 0) - (a.readyAt || 0))[0];
-          if (!current) {
+          if (!current && requireSnapshot) {
             fail(new OfflineStorageError("This book is not available offline.", "missing"));
             return;
           }
+          const device = deviceID || current?.deviceID || "";
           const outbox = tx.objectStore(OUTBOX);
           const queued = outbox.index("account").getAll(IDBKeyRange.bound(
             [partition, account, "", 0],
@@ -279,13 +305,17 @@ export async function saveOfflinePosition({
             // Wall clocks can move backwards and two page turns can share a
             // millisecond. Transaction order, not UUID order, decides the head.
             const createdAt = records.reduce((latest, row) => Math.max(latest, (row.createdAt || 0) + 1), Date.now());
-            current.localPosition = op;
-            snapshots.put(current);
+            if (current) {
+              current.localPosition = op;
+              snapshots.put(current);
+            }
             outbox.put({
               key: keyForOutbox({ partition, account, kind: "position", id: op.op_id }),
-              partition, account, epoch, deviceID: deviceID || current.deviceID, bookID, kind: "position", id: op.op_id,
+              partition, account, epoch, deviceID: device, bookID, kind: "position", id: op.op_id,
               payload: op, state: "pending", createdAt, attempts: 0,
             });
+            putReadingLocal(tx.objectStore(READING),
+              { partition, account, deviceID: device, bookID }, workID, op, createdAt);
           };
         };
       });
@@ -294,6 +324,70 @@ export async function saveOfflinePosition({
       throw error;
     }
   });
+}
+
+function putReadingLocal(store, identity, workID, op, updatedAt) {
+  const key = keyForReading(identity);
+  const request = store.get(key);
+  request.onsuccess = () => {
+    const record = request.result || { key, ...identity, baseline: null, local: null };
+    // A late write from a slower tab must not resurrect an older page as
+    // this device's local state.
+    if ((record.updatedAt || 0) > updatedAt) return;
+    record.workID = workID || record.workID || "";
+    record.local = op;
+    record.updatedAt = updatedAt;
+    store.put(record);
+  };
+}
+
+/**
+ * readingState returns this device's durable reading state for a book:
+ * the agreed baseline and the last position it authored. Null when the
+ * device has never read the book here.
+ */
+export async function readingState({
+  partition = storagePartition(), account, deviceID, bookID,
+} = {}) {
+  if (!partition || !account || !bookID) return null;
+  return withDB(async db => {
+    const result = await requestResult(db.transaction(READING).objectStore(READING)
+      .get(keyForReading({ partition, account, deviceID, bookID })));
+    return result || null;
+  });
+}
+
+/**
+ * agreeReadingBaseline records the position this device and the server
+ * agree on. It moves on exactly three events: the position read when the
+ * book opens, an acknowledged local op, and a remote position the reader
+ * accepted. Everything else is movement away from it, which is what
+ * makes a three-way comparison possible at all.
+ *
+ * `settled` says this device is at the baseline, not merely aware of
+ * it: an acknowledged page turn, or a remote position the reader chose
+ * to take. Its local op is cleared, because it is no longer movement
+ * away from anything.
+ */
+export async function agreeReadingBaseline({
+  partition = storagePartition(), account, epoch, deviceID, bookID, workID = "", baseline,
+  settled = false,
+} = {}) {
+  if (!partition || !account || !bookID) return;
+  return withDB(db => guardedWork(db, READING, { partition, account, epoch }, tx => {
+    const store = tx.objectStore(READING);
+    const identity = { partition, account, deviceID, bookID };
+    const key = keyForReading(identity);
+    const request = store.get(key);
+    request.onsuccess = () => {
+      const record = request.result || { key, ...identity, baseline: null, local: null };
+      record.workID = workID || record.workID || "";
+      record.baseline = baseline || null;
+      if (settled) record.local = null;
+      record.updatedAt = Date.now();
+      store.put(record);
+    };
+  }));
 }
 
 export async function saveOfflineSessionCheckpoint({
@@ -523,18 +617,43 @@ export async function removeOfflineAnnotation({
 }
 
 export async function removeOfflineOutbox({
-  partition = storagePartition(), account, epoch, kind, id,
+  partition = storagePartition(), account, epoch, kind, id, settle = true,
 } = {}) {
   if (!partition || !account || !kind || !id) return;
   return withDB(async db => {
-    await guardedWork(db, OUTBOX, { partition, account, epoch }, tx => {
+    await guardedWork(db, [OUTBOX, READING], { partition, account, epoch }, tx => {
       const store = tx.objectStore(OUTBOX);
       const key = keyForOutbox({ partition, account, kind, id });
-      if (kind !== "session") { store.delete(key); return; }
       const request = store.get(key);
       request.onsuccess = () => {
-        if (request.result) {
-          const delivered = { ...request.result, state: "delivered" };
+        const record = request.result;
+        // An acknowledged position is now what this device and the
+        // server both know: it is the agreed baseline, and it stops
+        // counting as local movement. This is the one place a position
+        // is known to have landed, online and offline alike.
+        //
+        // `settle: false` is the other way a record leaves the queue:
+        // the reader withdrew it. It is dropped without ever becoming
+        // anything either side agreed on.
+        if (settle && record && kind === "position" && record.payload) {
+          const reading = tx.objectStore(READING);
+          const identity = {
+            partition, account, deviceID: record.deviceID, bookID: record.bookID,
+          };
+          const readingKey = keyForReading(identity);
+          const existing = reading.get(readingKey);
+          existing.onsuccess = () => {
+            const state = existing.result || { key: readingKey, ...identity, local: null };
+            state.workID = state.workID || record.payload.work_id || "";
+            state.baseline = record.payload;
+            if (state.local?.op_id === record.id) state.local = null;
+            state.updatedAt = Date.now();
+            reading.put(state);
+          };
+        }
+        if (kind !== "session") { store.delete(key); return; }
+        if (record) {
+          const delivered = { ...record, state: "delivered" };
           if (delivered.fingerprint) delete delivered.payload;
           store.put(delivered);
         }
@@ -648,15 +767,16 @@ export async function clearOfflineAccount(partition, account) {
   if (!partition || !account) return;
   return withDB(async db => {
     await transactionWork(db, [
-      SNAPSHOTS, RESOURCES, OUTBOX, CHECKPOINTS, ANNOTATIONS, ACCOUNTS,
+      SNAPSHOTS, RESOURCES, OUTBOX, CHECKPOINTS, ANNOTATIONS, READING, ACCOUNTS,
     ], "readwrite", tx => {
       const snapshots = tx.objectStore(SNAPSHOTS);
       const resources = tx.objectStore(RESOURCES);
       const outbox = tx.objectStore(OUTBOX);
       const checkpoints = tx.objectStore(CHECKPOINTS);
       const annotations = tx.objectStore(ANNOTATIONS);
-      let snapshotRecords, outboxRecords, checkpointRecords, annotationRecords;
-      let remaining = 4;
+      const reading = tx.objectStore(READING);
+      let snapshotRecords, outboxRecords, checkpointRecords, annotationRecords, readingRecords;
+      let remaining = 5;
       const clear = () => {
         if (--remaining) return;
         for (const snapshot of snapshotRecords) {
@@ -670,6 +790,7 @@ export async function clearOfflineAccount(partition, account) {
             checkpoints.delete(checkpoint.key);
         }
         for (const annotation of annotationRecords) annotations.delete(annotation.key);
+        for (const record of readingRecords) reading.delete(record.key);
         const marker = tx.objectStore(ACCOUNTS).get(keyForAccount(partition));
         marker.onsuccess = () => {
           if (marker.result?.account === account)
@@ -701,6 +822,13 @@ export async function clearOfflineAccount(partition, account) {
       ));
       annotationRequest.onsuccess = () => {
         annotationRecords = annotationRequest.result;
+        clear();
+      };
+      const readingRequest = reading.index("book").getAll(IDBKeyRange.bound(
+        [partition, account, ""], [partition, account, "\uffff"],
+      ));
+      readingRequest.onsuccess = () => {
+        readingRecords = readingRequest.result;
         clear();
       };
     });

--- a/internal/webui/static/offline-sync.js
+++ b/internal/webui/static/offline-sync.js
@@ -6,7 +6,7 @@ import {
   reconcileOfflineBook,
 } from "./offline-storage.js";
 
-export async function drainOfflineOutbox(context, request) {
+export async function drainOfflineOutbox(context, request, { keepalive = false } = {}) {
   const records = await listOfflineOutbox({ ...context });
   const blockedWorks = new Set();
   for (const queued of records) {
@@ -15,7 +15,7 @@ export async function drainOfflineOutbox(context, request) {
     if (queued.kind === "position" && blockedWorks.has(positionWork)) continue;
     const record = await attemptOfflineRecord(context, queued.key);
     if (!record) continue;
-    const options = { method: "POST", headers: { "Content-Type": "application/json" } };
+    const options = { method: "POST", headers: { "Content-Type": "application/json" }, keepalive };
     const done = () => removeOfflineOutbox({ ...context, kind: record.kind, id: record.id });
     const failed = (state, error, details = null) => {
       // Sending the next page before this one is acknowledged lets a later
@@ -43,7 +43,7 @@ export async function drainOfflineOutbox(context, request) {
     const path = deletion
       ? "v1/annotations/" + encodeURIComponent(record.annotationID) + "?rev=" + record.payload.rev
       : annotation ? "v1/annotations" : "v1/ops";
-    const response = await request(path, deletion ? { method: "DELETE" } : {
+    const response = await request(path, deletion ? { method: "DELETE", keepalive } : {
       ...options, body: JSON.stringify(annotation
         ? { annotations: [record.payload.annotation] } : { ops: [record.payload] }),
     });
@@ -81,12 +81,87 @@ export async function drainOfflineOutbox(context, request) {
   }
 }
 
+/**
+ * syncCoordinator owns the parts of synchronization that have nothing to
+ * do with what is being synchronized: the foreground retry ladder, the
+ * cross-tab lock that keeps one writer at a time, and the events worth
+ * waking up for.
+ *
+ * The lock is named after the account's queue rather than after the page
+ * holding it, so an ordinary reader tab, a second reader tab and the
+ * installed offline app all take turns on the same outbox instead of
+ * racing each other into a reordered op log.
+ *
+ * `run` returns true when work is still owed, which shortens the next
+ * delay; throwing is the same as owing work, with the message shown.
+ */
+export function syncCoordinator({ lock, run, onStatus = () => {}, partition, waiting }) {
+  let stopped = false, flight = null, timer = null, retries = 0, again = false;
+  const trigger = (reset = true) => {
+    if (stopped) return;
+    if (reset) retries = 0;
+    if (flight) { again = true; return flight; }
+    clearTimeout(timer);
+    // A timer-driven retry stays out of a background tab, but something
+    // that actually happened is delivered whether or not the tab is on
+    // screen: hiding it is exactly when a sitting ends.
+    if (globalThis.navigator?.onLine === false) return;
+    if (!reset && globalThis.document?.hidden) return;
+    const locked = () => navigator.locks ? navigator.locks.request(lock, run) : run();
+    let owed = false;
+    flight = Promise.resolve().then(locked).catch(error => {
+      onStatus(error.message || waiting);
+      return true;
+    }).then(pending => { owed = !!pending; }).finally(() => {
+      flight = null;
+      if (stopped) return;
+      // Something arrived while this pass was running. Go again straight
+      // away rather than through the retry timer: the change may have
+      // been a sitting ending as the tab was hidden, which the timer
+      // declines to chase.
+      if (again) { again = false; trigger(); return; }
+      // Keep checking in the foreground, including after the network comes
+      // back without an online event and while another device is reading.
+      const delay = owed ? [1000, 3000, 10000, 30000][Math.min(retries++, 3)] : 30000;
+      timer = setTimeout(() => trigger(false), delay);
+    });
+    return flight;
+  };
+  const changed = event => {
+    if (event.detail?.partition && event.detail.partition !== partition) return;
+    trigger();
+  };
+  const channel = globalThis.BroadcastChannel ? new BroadcastChannel("liseur-offline") : null;
+  if (channel) channel.onmessage = event => changed({ detail: event.data });
+  globalThis.addEventListener?.("online", changed);
+  globalThis.addEventListener?.("offline-change", changed);
+  globalThis.document?.addEventListener("visibilitychange", changed);
+  return {
+    trigger,
+    busy: () => !!flight,
+    stopped: () => stopped,
+    stop() {
+      stopped = true;
+      clearTimeout(timer);
+      channel?.close();
+      globalThis.removeEventListener?.("online", changed);
+      globalThis.removeEventListener?.("offline-change", changed);
+      globalThis.document?.removeEventListener("visibilitychange", changed);
+    },
+  };
+}
+
+// One lock per account queue, shared by every page that can drain it.
+// Exported so a page that edits the queue rather than draining it still
+// takes its turn instead of racing a send already in flight.
+export const outboxLock = context => "offline-sync:" + context.partition + context.account;
+
 export function offlineSync({ context, base, onChange = () => {}, onStatus = () => {} }) {
-  let csrf = "", stopped = false, flight = null, timer = null, retries = 0, again = false;
+  let csrf = "";
   const auth = readerAuth({ apiBase: base, tokenURL: base + "ui/reader/token",
     csrf: () => csrf, onExhausted: () => {} });
   const authorize = async identity => {
-    if (stopped) throw new Error("Offline synchronization stopped.");
+    if (coordinator.stopped()) throw new Error("Offline synchronization stopped.");
     await assertOfflineContext(context);
     if (identity.account !== context.account || identity.device !== context.deviceID)
       throw new Error("Sign in on the original account and device to sync offline changes.");
@@ -99,14 +174,15 @@ export function offlineSync({ context, base, onChange = () => {}, onStatus = () 
   };
   const run = async () => {
     // A stopped coordinator may still be waiting for another tab's lock.
-    if (stopped || globalThis.document?.hidden || globalThis.navigator?.onLine === false) return false;
+    if (coordinator.stopped() || globalThis.document?.hidden ||
+        globalThis.navigator?.onLine === false) return false;
     const response = await fetch(base + "ui/offline/account", {
       cache: "no-store", credentials: "same-origin", signal: AbortSignal.timeout(30000),
     });
     if (!response.ok || response.redirected)
       throw new Error("Sign in again to sync offline changes.");
     const account = await response.json();
-    if (stopped) return false;
+    if (coordinator.stopped()) return false;
     if (account.account !== context.account) throw new Error("Sign in as the account that saved these books.");
     if (typeof account.csrf !== "string" || !account.csrf)
       throw new Error("Sign in again to sync offline changes.");
@@ -123,44 +199,47 @@ export function offlineSync({ context, base, onChange = () => {}, onStatus = () 
     onStatus(pending.length ? `${pending.length} offline change(s) waiting; retry sync or review conflicts.` : "");
     return pending.some(record => record.state === "pending" && record.deviceID === context.deviceID);
   };
-  const trigger = (reset = true) => {
-    if (stopped) return;
-    if (reset) retries = 0;
-    if (flight) { again = true; return flight; }
-    clearTimeout(timer);
-    if (globalThis.document?.hidden || globalThis.navigator?.onLine === false) return;
-    const locked = () => navigator.locks
-      ? navigator.locks.request("offline-sync:" + context.partition + context.account, run) : run();
-    flight = Promise.resolve().then(locked).catch(error => {
-      onStatus(error.message || "Offline changes are waiting to sync.");
-      return true;
-    }).then(pending => {
-      if (!stopped) {
-        const delay = pending || again ? [1000, 3000, 10000, 30000][Math.min(retries++, 3)] : 30000;
-        again = false;
-        // Keep checking in the foreground, including after the network comes
-        // back without an online event and while another device is reading.
-        timer = setTimeout(() => trigger(false), delay);
-      }
-    }).finally(() => { flight = null; });
-    return flight;
+  const coordinator = syncCoordinator({
+    lock: outboxLock(context), run, onStatus, partition: context.partition,
+    waiting: "Offline changes are waiting to sync.",
+  });
+  return { trigger: coordinator.trigger, stop() { coordinator.stop(); auth.stop(); } };
+}
+
+/**
+ * readingSync drains the same queue for an online reader.
+ *
+ * The reader writes every position and finished sitting to the outbox
+ * before anything is sent, and this is the only thing that sends them.
+ * A page turn that was never acknowledged is therefore still on disk
+ * after a crash, a reload or a closed tab, and goes out under the next
+ * credential rather than being lost — which is the whole difference
+ * between this and posting straight from the page.
+ *
+ * `request` is the reader's own authenticated transport, so a token
+ * renewal mid-drain is the auth layer's problem and not a second
+ * credential racing the first.
+ */
+export function readingSync({ context, request, onChange = () => {}, onStatus = () => {} }) {
+  const mine = record => record.deviceID === context.deviceID;
+  const run = async () => {
+    // No hidden-tab check here: a sitting ends when the tab is hidden,
+    // and that is precisely the change worth delivering. The coordinator
+    // is what keeps a background tab from retrying on a timer.
+    if (coordinator.stopped() || globalThis.navigator?.onLine === false) return false;
+    await assertOfflineContext(context);
+    await drainOfflineOutbox(context, request);
+    if (coordinator.stopped()) return false;
+    await onChange();
+    const pending = await listOfflineOutbox({ ...context, state: null });
+    const stuck = pending.filter(record => mine(record) && record.state !== "pending");
+    onStatus(stuck.length
+      ? `${stuck.length} reading change(s) could not be saved; retry sync.` : "");
+    return pending.some(record => record.state === "pending" && mine(record));
   };
-  const changed = event => {
-    if (event.detail?.partition && event.detail.partition !== context.partition) return;
-    trigger();
-  };
-  const channel = globalThis.BroadcastChannel ? new BroadcastChannel("liseur-offline") : null;
-  if (channel) channel.onmessage = event => changed({ detail: event.data });
-  globalThis.addEventListener?.("online", changed);
-  globalThis.addEventListener?.("offline-change", changed);
-  globalThis.document?.addEventListener("visibilitychange", changed);
-  return { trigger, stop() {
-    stopped = true;
-    clearTimeout(timer);
-    auth.stop();
-    channel?.close();
-    globalThis.removeEventListener?.("online", changed);
-    globalThis.removeEventListener?.("offline-change", changed);
-    globalThis.document?.removeEventListener("visibilitychange", changed);
-  } };
+  const coordinator = syncCoordinator({
+    lock: outboxLock(context), run, onStatus, partition: context.partition,
+    waiting: "Reading changes are waiting to sync.",
+  });
+  return coordinator;
 }

--- a/internal/webui/static/offline/sw.js
+++ b/internal/webui/static/offline/sw.js
@@ -25,6 +25,7 @@ const ASSETS = [
   new URL('./assets/reader-live.js', self.location).href,
   new URL('./assets/reader-positions.js', self.location).href,
   new URL('./assets/reader-publication.js', self.location).href,
+  new URL('./assets/reader-reconcile.js', self.location).href,
   new URL('./assets/reader-session-upload.js', self.location).href,
   new URL('./assets/reader-session.js', self.location).href,
   new URL('./assets/reader-sync.js', self.location).href,

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -5,13 +5,16 @@ import { openSession } from "./reader-session.js";
 import { uploadSessions } from "./reader-session-upload.js";
 import { positionTable, pageAt, pageLocation } from "./reader-positions.js";
 import { readerAuth } from "./reader-auth.js";
-import { offlineSync } from "./offline-sync.js";
+import { offlineSync, readingSync, outboxLock } from "./offline-sync.js";
 import { liveStream } from "./reader-live.js";
 import { catchupState, topicRefresh, latestReadablePosition, positionAcknowledged } from "./reader-sync.js";
+import { reconcileReadingState } from "./reader-reconcile.js";
 import { annotationCFI, annotationAnchor, annotationRenderer } from "./reader-annotations.js";
 import {
   clearOfflineSessionCheckpoint,
   accountContext,
+  accountVersion,
+  setActiveAccount,
   claimOfflineReader,
   assertOfflineContext,
   notifyOfflineChange,
@@ -23,7 +26,9 @@ import {
   removeOfflineOutbox,
   queueOfflineAnnotation,
   removeOfflineAnnotation,
-  saveOfflinePosition,
+  saveReadingPosition,
+  readingState,
+  agreeReadingBaseline,
   saveOfflineSessionCheckpoint,
   deploymentPrefix,
   storagePartition,
@@ -111,9 +116,21 @@ let offlineCheckpoint = null;
 let offlineContext = null;
 let offlineCoordinator = null;
 let releaseOfflineReader = null;
+// True when this page holds the book's reader claim, so it owns the
+// single checkpoint slot for the sitting. A second tab reads on with
+// its own fresh sitting rather than adopting this one's.
+let sessionOwner = false;
 let offlineInvalidated = false;
-const offlinePartition = cfg.offline ? storagePartition() : null;
+// An online reader on the deployment's own origin queues its reading
+// state in the same IndexedDB the offline app uses, and drains it
+// through the same lock. The separate reader origin (ADR-0007 phase 3)
+// has no such storage of its own to share, so it keeps posting
+// directly: that boundary is deliberate, not an oversight.
+const durableSync = !cfg.offline && !cfg.detached;
+const offlinePartition = cfg.detached ? null : storagePartition();
 const offlineBase = cfg.offline ? deploymentPrefix() : "";
+let readingCoordinator = null;
+let sendTimer = null;
 
 function say(message, isError) {
   status.textContent = message;
@@ -163,6 +180,13 @@ const auth = readerAuth({
     retryOp = null;
     readingDirty = false;
     cancelScheduledPush();
+    clearTimeout(sendTimer);
+    sendTimer = null;
+    readingCoordinator?.stop();
+    readingCoordinator = null;
+    releaseOfflineReader?.();
+    releaseOfflineReader = null;
+    sessionOwner = false;
     refreshes.stop();
     live.stop();
     catchup.bind(null, null, null);
@@ -209,6 +233,61 @@ function prepareOfflineSync() {
   offlineCoordinator.trigger();
 }
 
+// prepareReadingSync claims the local queue for an online reader.
+//
+// The account marker is written from a credential this page actually
+// holds — the token introspection said whose it is — so a reader opened
+// straight from a bookmark queues durably without having to visit the
+// library first. An unchanged account keeps its epoch, so downloaded
+// books and anything already queued survive.
+async function prepareReadingSync(identity) {
+  if (!durableSync || !identity?.account || !offlinePartition) return;
+  try {
+    const version = await accountVersion(offlinePartition);
+    const epoch = await setActiveAccount(offlinePartition, identity.account, version);
+    offlineContext = {
+      partition: offlinePartition, account: identity.account, epoch, deviceID: identity.device,
+    };
+    offlineAccount = identity.account;
+  } catch (error) {
+    // No local queue is a weaker reader, not a broken one: it posts
+    // straight through the way it always did.
+    console.warn("Reading changes cannot be queued locally:", error);
+    offlineContext = null;
+    return;
+  }
+  readingCoordinator = readingSync({
+    context: offlineContext,
+    request: (path, options) => api(path, options),
+    onChange: async () => { await refreshLocalReadingState(); },
+    onStatus: message => { if (!syncExpired) say(message, !!message); },
+  });
+}
+
+// The durable state is the truth about what this device has said. It is
+// re-read after every drain so an acknowledgement settles the baseline
+// and a still-queued page keeps counting as local movement.
+async function refreshLocalReadingState() {
+  if (!offlineContext || !durableSync) return;
+  const state = await readingState({ ...offlineContext, bookID: cfg.bookID }).catch(() => null);
+  if (!state) return;
+  const queued = await listOfflineOutbox({ ...offlineContext, kind: "position" }).catch(() => []);
+  const dirty = queued.some(record => record.deviceID === offlineContext.deviceID &&
+    record.bookID === cfg.bookID);
+  catchup.baseline(state.baseline);
+  catchup.local(state.local, dirty);
+  if (!dirty && !readingDirty) retryOp = null;
+}
+
+function scheduleSend() {
+  if (!readingCoordinator) return;
+  clearTimeout(sendTimer);
+  sendTimer = setTimeout(() => {
+    sendTimer = null;
+    readingCoordinator?.trigger();
+  }, 1500);
+}
+
 async function checkOfflineAccount() {
   if (!offlineContext || offlineInvalidated) return;
   try { await assertOfflineContext(offlineContext); }
@@ -231,6 +310,8 @@ async function checkOfflineAccount() {
     }
     await annotationDrawing.clear().catch(() => {});
     releaseOfflineReader?.();
+    releaseOfflineReader = null;
+    sessionOwner = false;
     say("Offline access ended. Close this reader and sign in again.", true);
   }
 }
@@ -284,13 +365,32 @@ function hideCatchup() {
   }
 }
 
+const percent = (fraction) =>
+  finite(fraction) ? `${Math.round(fraction * 100)}%` : null;
+
 function showCatchup() {
   const offer = catchup.offer();
   if (!offer || !catchupPanel) return;
-  const fraction = offer.op.progression;
-  catchupText.textContent = finite(fraction)
-    ? `Continue from ${Math.round(fraction * 100)}% read on another device?`
-    : "Continue from the position read on another device?";
+  const there = percent(offer.op.progression);
+  catchupPanel.classList.toggle("conflict", offer.kind === "conflict");
+  if (offer.kind === "conflict") {
+    // Both sides moved since they last agreed. Say what both of them
+    // are; deciding which one the reader meant is not this program's
+    // business. The near side is the page actually on screen, which is
+    // the one the reader can check.
+    const local = percent(here?.fraction) || percent(offer.local?.progression);
+    catchupText.textContent = local && there
+      ? `This device is at ${local}; another device reached ${there}. Which one is where you are?`
+      : "This device and another device are in different places in this book.";
+    catchupAccept.textContent = there ? `Go to ${there}` : "Go to the other position";
+    catchupDismiss.textContent = local ? `Stay at ${local}` : "Stay here";
+  } else {
+    catchupText.textContent = there
+      ? `Continue from ${there} read on another device?`
+      : "Continue from the position read on another device?";
+    catchupAccept.textContent = "Continue there";
+    catchupDismiss.textContent = "Stay here";
+  }
   catchupPanel.hidden = false;
 }
 
@@ -322,15 +422,54 @@ function startLive() {
   live.start();
 }
 
-catchupDismiss?.addEventListener("click", () => {
+// Answering settles the disagreement for good: the position the reader
+// did not take becomes the agreed baseline too, because it has been
+// seen and answered. Without that, every reload asks again.
+function rememberAnswer(op, settled) {
+  if (!op || !offlineContext) return;
+  agreeReadingBaseline({
+    ...offlineContext, bookID: cfg.bookID, workID, baseline: op, settled,
+  }).catch(() => {});
+}
+
+// Taking the other device's position withdraws this device's own
+// undelivered ones. The queue drains oldest first, so a page turn still
+// waiting there would land after the reader's answer and reinstate the
+// position they just refused. Nothing is lost: an op the server never
+// acknowledged is a claim about where the reader was, and they have
+// just said otherwise. It runs under the queue's own lock so a send
+// already in flight finishes before the queue is edited underneath it.
+async function withdrawQueuedPositions() {
+  if (!offlineContext) return;
+  const withdraw = async () => {
+    const queued = await listOfflineOutbox({ ...offlineContext, kind: "position" });
+    for (const record of queued) {
+      if (record.bookID !== cfg.bookID || record.deviceID !== offlineContext.deviceID) continue;
+      await removeOfflineOutbox({
+        ...offlineContext, kind: "position", id: record.id, settle: false,
+      });
+    }
+  };
+  try {
+    if (navigator.locks) await navigator.locks.request(outboxLock(offlineContext), withdraw);
+    else await withdraw();
+  } catch { /* the queue is best-effort; a stale op is not worth an error */ }
+}
+
+// Every way of saying no goes through here: an answered offer settles
+// durably, or the next open raises the same disagreement again.
+function dismissCatchup() {
+  const shown = catchup.shown();
   catchup.dismiss();
   hideCatchup();
-});
+  rememberAnswer(shown?.op, false);
+}
+
+catchupDismiss?.addEventListener("click", dismissCatchup);
 catchupPanel?.addEventListener("keydown", (event) => {
   if (event.key === "Escape") {
     event.preventDefault();
-    catchup.dismiss();
-    hideCatchup();
+    dismissCatchup();
   }
 });
 catchupAccept?.addEventListener("click", async () => {
@@ -350,6 +489,13 @@ catchupAccept?.addEventListener("click", async () => {
   retryOp = null;
   readingDirty = false;
   interactionPending = false;
+  // Withdraw before anything else can drain the queue: ending the
+  // sitting triggers a send, and a page delivered after the answer
+  // would reinstate the position the reader just refused.
+  clearTimeout(sendTimer);
+  sendTimer = null;
+  await withdrawQueuedPositions();
+  if (!current(stamp) || !view) return;
   // Close the old sitting at its actual page, not at the remote destination.
   endSession();
   restoring = true;
@@ -368,6 +514,7 @@ catchupAccept?.addEventListener("click", async () => {
   } finally {
     restoring = false;
     // A restored page starts accounting only when the reader next interacts.
+    rememberAnswer(op, true);
   }
 });
 
@@ -1049,23 +1196,47 @@ async function pushPosition() {
         };
   retryOp = { key, op };
   catchup.wrote(op);
-  if (cfg.offline) {
+  if (cfg.offline || (durableSync && offlineContext)) {
     try {
-      await saveOfflinePosition({
+      await saveReadingPosition({
         ...offlineContext,
-        partition: offlinePartition,
-        account: offlineAccount,
         bookID: cfg.bookID,
+        workID,
         op,
+        requireSnapshot: cfg.offline,
       });
-      notifyOfflineChange();
+      catchup.local(op);
+      if (cfg.offline) notifyOfflineChange();
+      else if (leaving) {
+        // The queue is the guarantee, but an unload is the last moment
+        // this page can speak and another device is probably waiting.
+        // The queued copy carries the same bytes under the same op id,
+        // so a later delivery is a duplicate rather than a second page.
+        api("v1/ops", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          keepalive: true,
+          body: JSON.stringify({ ops: [op] }),
+        }).catch(() => {});
+      } else scheduleSend();
       if (retryOp?.op === op) {
         retryOp = null;
         if (locatorFor(here)?.locations.fragments[0] === locator.locations.fragments[0] &&
             here.fraction === locator.locations.totalProgression) readingDirty = false;
       }
     } catch (err) {
-      say(err.message || "Offline position could not be saved.", true);
+      // An expired local account cannot be queued into. The reader
+      // keeps reading; the credential layer is what says so.
+      if (!cfg.offline && err?.code === "auth") {
+        offlineContext = null;
+        readingCoordinator?.stop();
+        readingCoordinator = null;
+        releaseOfflineReader?.();
+        releaseOfflineReader = null;
+        sessionOwner = false;
+        return;
+      }
+      say(err.message || "This reading position could not be saved on this device.", true);
     }
     return;
   }
@@ -1090,6 +1261,7 @@ async function pushPosition() {
       return;
     }
     if (!positionAcknowledged(out, op)) return;
+    catchup.settled(op);
     // Only this op's own outcome may clear it: a slower response
     // arriving after the reader has moved on must not discard the op
     // a newer push is still responsible for.
@@ -1132,7 +1304,7 @@ function schedulePush() {
   if (!readingDirty || restoring) return;
   cancelScheduledPush();
   // Local durability need not wait for the network debounce.
-  pending = setTimeout(push, cfg.offline ? 0 : 1500);
+  pending = setTimeout(push, cfg.offline || offlineContext ? 0 : 1500);
 }
 
 // ------------------------------------------------------- sessions
@@ -1162,24 +1334,29 @@ function beginSession() {
     supportsActiveMs: cfg.offline
       ? offlineSnapshot?.supportsActiveMs === true
       : auth.identity()?.supportsActiveMs === true,
-    checkpoint: cfg.offline ? offlineCheckpoint : null,
+    checkpoint: cfg.offline || sessionOwner ? offlineCheckpoint : null,
   });
   offlineCheckpoint = null;
   checkpointSession();
 }
 
+// A sitting is checkpointed as it goes, so a browser that is killed
+// mid-page still leaves the reading behind: the next open finds the
+// checkpoint and carries on inside the same sitting instead of
+// discarding the minutes before the crash. Only the page holding the
+// book's reader claim writes one, because a checkpoint names one
+// sitting and two pages finalizing under that name is a refused
+// session, not a longer one.
 function checkpointSession() {
-  if (!cfg.offline || !session || !offlineAccount) return;
+  if (!session || !offlineContext || !(cfg.offline || sessionOwner)) return;
   const checkpoint = session.checkpoint();
   if (!checkpoint) return;
   saveOfflineSessionCheckpoint({
     ...offlineContext,
-    partition: offlinePartition,
-    account: offlineAccount,
     bookID: cfg.bookID,
     checkpoint,
   }).catch(error => say(
-    error.message || "Offline reading progress could not be saved.",
+    error.message || "This reading progress could not be saved on this device.",
     true,
   ));
 }
@@ -1215,6 +1392,13 @@ function noteProgress() {
   }
 }
 
+// True once the page is going away. Only then does a finished sitting go
+// out directly as well as durably: an IndexedDB write cannot finish
+// during an unload, so the keepalive attempt is the only voice left. On
+// any other path the queue is both the guarantee and prompt enough, and
+// posting the same sitting twice at once races itself at the server.
+let leaving = false;
+
 async function endSession() {
   if (!session) return;
   const sessionID = session.checkpoint()?.id;
@@ -1224,13 +1408,19 @@ async function endSession() {
     here && here.fraction,
   );
   session = null;
-  if (cfg.offline) {
+  if (!cfg.offline && offlineContext && payload && leaving) {
+    // On an unload this is the last moment the page can speak, and an
+    // IndexedDB write is not something a closing tab can wait for. The
+    // queued copy below is the guarantee; this is only promptness, and
+    // a session id is an idempotency key, so both landing is harmless.
+    unsent = [payload];
+    pushSession(true);
+  }
+  if (cfg.offline || offlineContext) {
     try {
       if (payload) {
         await finishOfflineSession({
           ...offlineContext,
-          partition: offlinePartition,
-          account: offlineAccount,
           bookID: cfg.bookID,
           payload,
         });
@@ -1238,14 +1428,13 @@ async function endSession() {
         await clearOfflineSessionCheckpoint({
           ...offlineContext,
           sessionID,
-          partition: offlinePartition,
-          account: offlineAccount,
           bookID: cfg.bookID,
         });
       }
-      notifyOfflineChange();
+      if (cfg.offline) notifyOfflineChange();
+      else readingCoordinator?.trigger();
     } catch (error) {
-      say(error.message || "Offline reading session could not be saved.", true);
+      say(error.message || "This reading session could not be saved on this device.", true);
     }
     return;
   }
@@ -1278,7 +1467,18 @@ async function pushSession(closing) {
         return resp;
       },
       responseCurrent: (resp) => current(stamp) && auth.responseCurrent(resp),
-      accepted: (sent) => { unsent = unsent.filter((p) => !sent.includes(p)); },
+      accepted: async (sent) => {
+        unsent = unsent.filter((p) => !sent.includes(p));
+        // The queued copy is what a later drain would replay. Settling
+        // it here keeps the same sitting from going out twice.
+        if (offlineContext) {
+          for (const item of sent) {
+            await removeOfflineOutbox({
+              ...offlineContext, kind: "session", id: item.session_id,
+            }).catch(() => {});
+          }
+        }
+      },
       deferred: (status, code) => console.warn("Reading sessions are waiting to sync:", status, code),
       refused: (item, code) => {
         unsent = unsent.filter((p) => p !== item);
@@ -1309,6 +1509,7 @@ document.addEventListener("visibilitychange", () => {
   catchup.resume();
   push();
   pushSession();
+  readingCoordinator?.trigger();
   if (ready) startLive();
   beginSession();
   if (here && !finite(here.fraction)) {
@@ -1316,8 +1517,10 @@ document.addEventListener("visibilitychange", () => {
     scheduleFractionRetry();
   }
 });
+window.addEventListener("pageshow", () => { leaving = false; });
 window.addEventListener("pagehide", () => {
   lifecycle++;
+  leaving = true;
   live.stop();
   refreshes.stop();
   catchup.hide();
@@ -1330,12 +1533,14 @@ window.addEventListener("online", () => {
   if (document.hidden) return;
   push();
   pushSession();
+  readingCoordinator?.trigger();
   if (ready) startLive();
 });
 setInterval(() => {
   if (document.hidden || navigator.onLine === false) return;
   push();
   pushSession();
+  readingCoordinator?.trigger();
 }, 30000);
 
 function cfiOf(op) {
@@ -2470,8 +2675,7 @@ function handleKeys(e) {
   // it, the same as the drawer above.
   if (catchupPanel && !catchupPanel.hidden && e.key === "Escape") {
     e.preventDefault();
-    catchup.dismiss();
-    hideCatchup();
+    dismissCatchup();
     return;
   }
   // "?" summons the help from anywhere, including from inside a
@@ -2542,6 +2746,7 @@ function handleKeys(e) {
 document.addEventListener("keydown", handleKeys);
 window.addEventListener("beforeunload", () => {
   clearTimeout(pending);
+  leaving = true;
   push();
   endSession();
   view?.destroy().catch(() => {});
@@ -2657,15 +2862,57 @@ window.addEventListener("beforeunload", () => {
       catchup.bind(offlineAccount, workID, offlineSnapshot.deviceID);
       // A locally queued wire op omits device_id; the credential supplies it
       // on upload. Its echo after a reload is still our opening baseline.
-      catchup.baseline(op && { ...op, device_id: op.device_id || offlineSnapshot.deviceID });
+      const stamped = op && { ...op, device_id: op.device_id || offlineSnapshot.deviceID };
+      catchup.baseline(stamped);
+      catchup.local(stamped, false);
     }
     if (!cfg.offline) try {
       workID = await resolveWork();
       const identity = auth.identity();
       catchup.bind(identity?.account, workID, identity?.device);
+      await prepareReadingSync(identity);
+      // A checkpoint names one sitting, so only the page that can claim
+      // this book keeps one. A second tab is refused the claim and reads
+      // on with a fresh sitting, which is what it did before.
+      if (offlineContext) {
+        releaseOfflineReader = await claimOfflineReader(offlineContext, cfg.bookID)
+          .catch(() => null);
+        if (releaseOfflineReader) {
+          sessionOwner = true;
+          offlineCheckpoint = await getOfflineSessionCheckpoint({
+            partition: offlinePartition, account: offlineAccount, bookID: cfg.bookID,
+          }).catch(() => null);
+        }
+      }
+      // What this browser last said, read back from its own disk. A page
+      // turn the server never acknowledged is still where the reader is,
+      // and it is still owed.
+      const stored = offlineContext
+        ? await readingState({ ...offlineContext, bookID: cfg.bookID }).catch(() => null)
+        : null;
+      const queued = offlineContext
+        ? await listOfflineOutbox({ ...offlineContext, kind: "position" }).catch(() => [])
+        : [];
+      const dirty = queued.some(record => record.deviceID === offlineContext?.deviceID &&
+        record.bookID === cfg.bookID);
       const result = await lastPosition();
-      if (result.ok) op = result.op;
-      catchup.baseline(op);
+      const remote = result.ok ? result.op : null;
+      const baseline = stored ? stored.baseline : remote;
+      catchup.baseline(baseline);
+      catchup.local(stored?.local || null, dirty);
+      const { decision } = reconcileReadingState({
+        local: stored?.local || null, remote, baseline, localDirty: dirty,
+      });
+      // A conflict opens where this reader was, never where the other
+      // device went: the trip is offered, not taken for them.
+      op = decision === "push" || decision === "conflict"
+        ? stored?.local || remote : remote || stored?.local || null;
+      if (!stored && remote && offlineContext) {
+        await agreeReadingBaseline({
+          ...offlineContext, bookID: cfg.bookID, workID, baseline: remote,
+        }).catch(() => {});
+      }
+      catchup.observe(remote);
     } catch (err) {
       /* read on without sync */
     }
@@ -2701,6 +2948,13 @@ window.addEventListener("beforeunload", () => {
     if (!cfg.offline && ready && !document.hidden) startLive();
     if (document.hidden) catchup.hide();
     if (!syncExpired) say("");
+    // Opening the book is a moment where a disagreement can be raised
+    // without taking the page out from under anybody.
+    if (!document.hidden) {
+      catchup.present();
+      showCatchup();
+    }
+    if (readingCoordinator) readingCoordinator.trigger();
   } catch (err) {
     releaseOfflineReader?.();
     say((err && err.message) || "this book could not be opened", true);

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -271,7 +271,9 @@ async function refreshLocalReadingState() {
   if (!offlineContext || !durableSync) return;
   const state = await readingState({ ...offlineContext, bookID: cfg.bookID }).catch(() => null);
   if (!state) return;
-  const queued = await listOfflineOutbox({ ...offlineContext, kind: "position" }).catch(() => []);
+  const queued = await listOfflineOutbox({
+    ...offlineContext, kind: "position", state: null,
+  }).catch(() => []);
   const dirty = queued.some(record => record.deviceID === offlineContext.deviceID &&
     record.bookID === cfg.bookID);
   catchup.baseline(state.baseline);
@@ -442,7 +444,9 @@ function rememberAnswer(op, settled) {
 async function withdrawQueuedPositions() {
   if (!offlineContext) return;
   const withdraw = async () => {
-    const queued = await listOfflineOutbox({ ...offlineContext, kind: "position" });
+    const queued = await listOfflineOutbox({
+      ...offlineContext, kind: "position", state: null,
+    });
     for (const record of queued) {
       if (record.bookID !== cfg.bookID || record.deviceID !== offlineContext.deviceID) continue;
       await removeOfflineOutbox({
@@ -463,6 +467,10 @@ function dismissCatchup() {
   catchup.dismiss();
   hideCatchup();
   rememberAnswer(shown?.op, false);
+  if (shown && view && here && finite(here.fraction)) {
+    readingDirty = true;
+    void pushPosition();
+  }
 }
 
 catchupDismiss?.addEventListener("click", dismissCatchup);
@@ -2891,7 +2899,9 @@ window.addEventListener("beforeunload", () => {
         ? await readingState({ ...offlineContext, bookID: cfg.bookID }).catch(() => null)
         : null;
       const queued = offlineContext
-        ? await listOfflineOutbox({ ...offlineContext, kind: "position" }).catch(() => [])
+        ? await listOfflineOutbox({
+          ...offlineContext, kind: "position", state: null,
+        }).catch(() => [])
         : [];
       const dirty = queued.some(record => record.deviceID === offlineContext?.deviceID &&
         record.bookID === cfg.bookID);

--- a/internal/webui/static/reader-reconcile.js
+++ b/internal/webui/static/reader-reconcile.js
@@ -1,0 +1,112 @@
+// Three-way reconciliation of reading positions, the way the Android
+// client does it (`domain/ReadingStateMerge.kt`).
+//
+// Two positions that differ are not evidence of anything on their own.
+// What decides the outcome is which side moved *away from the position
+// both sides last agreed on*: the baseline. Without it, a browser that
+// has read on for ten pages and a phone that has not moved since
+// yesterday look exactly like a browser that has not moved and a phone
+// that read on — and picking either one silently loses somebody's
+// evening.
+//
+// Nothing here consults a clock. A wall clock is not evidence about
+// reading: two devices disagree about it, and the later write is not
+// the one the reader meant. The local side is known to have moved
+// because this browser wrote it; the remote side is compared by
+// distance.
+
+/**
+ * EPSILON is the cross-device tolerance. Another client reports a
+ * progression it computed from its own layout and rounding, so a
+ * difference smaller than this is agreement, not movement.
+ */
+export const EPSILON = 0.005;
+
+/**
+ * LOCAL_EPSILON is deliberately almost zero. A local write is durable
+ * evidence that the reader turned a page here, and one page of a long
+ * book is a far smaller fraction than EPSILON.
+ */
+export const LOCAL_EPSILON = 1e-9;
+
+const fraction = value =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1 ? value : null;
+
+/** anchorOf is the exact pointer in a position, when it carries one. */
+export function anchorOf(state) {
+  const fragments = state?.locator?.locations?.fragments;
+  if (!Array.isArray(fragments)) return null;
+  return fragments.find(value => typeof value === "string" && value.startsWith("epubcfi(")) || null;
+}
+
+// Two exact anchors either name the same spot or they do not; there is
+// no tolerance to apply. Null means neither side offered one, so only
+// the fractions can speak.
+function exactAgreement(one, two) {
+  const here = anchorOf(one), there = anchorOf(two);
+  if (!here || !there) return null;
+  return here === there;
+}
+
+export function sameSpot(one, two) {
+  if (!one || !two) return false;
+  if (one.op_id && one.op_id === two.op_id) return true;
+  const exact = exactAgreement(one, two);
+  if (exact !== null) return exact;
+  const here = fraction(one.progression), there = fraction(two.progression);
+  if (here === null || there === null) return here === there;
+  return Math.abs(here - there) < EPSILON;
+}
+
+/**
+ * movedFrom asks whether a position has left the agreed baseline.
+ *
+ * No baseline at all means everything is movement: nothing has been
+ * agreed, so nothing can be said to have stayed put. An exact pointer
+ * is the strongest evidence either way and is consulted before the
+ * fraction, which is only ever an approximation of a layout.
+ */
+export function movedFrom(baseline, state, tolerance) {
+  if (!baseline) return true;
+  if (!state) return false;
+  if (baseline.op_id && baseline.op_id === state.op_id) return false;
+  const exact = exactAgreement(baseline, state);
+  if (exact !== null) return !exact;
+  const agreed = fraction(baseline.progression);
+  const now = fraction(state.progression);
+  if (agreed === null) return now !== null;
+  if (now === null) return true;
+  return Math.abs(agreed - now) >= tolerance;
+}
+
+/**
+ * reconcileReadingState compares this device's position, another
+ * device's position and the baseline the two last agreed on.
+ *
+ * - `pull`: only the other side moved. The reader is offered the trip.
+ * - `push`: only this side moved. The queued op is the whole answer.
+ * - `conflict`: both moved. Both positions are kept and the reader
+ *   chooses; nothing here decides for them.
+ * - `in-sync`: nothing to do.
+ *
+ * `localDirty` says this browser has a position the server has not
+ * acknowledged. It comes from the durable queue, not from a timestamp,
+ * so it survives a reload and a crash.
+ */
+export function reconcileReadingState({ local, remote, baseline, localDirty = false } = {}) {
+  const settled = { decision: "in-sync", local: local || null, remote: remote || null };
+  if (!local && !remote) return settled;
+  if (!local) return { decision: "pull", local: null, remote };
+  if (!remote) return localDirty ? { decision: "push", local, remote: null } : settled;
+  if (sameSpot(local, remote)) return settled;
+
+  const localMoved = localDirty && movedFrom(baseline, local, LOCAL_EPSILON);
+  const remoteMoved = movedFrom(baseline, remote, EPSILON);
+  if (!localMoved && remoteMoved) return { decision: "pull", local, remote };
+  if (localMoved && !remoteMoved) return { decision: "push", local, remote };
+  if (localMoved && remoteMoved) return { decision: "conflict", local, remote };
+  // Two positions that differ, with neither of them away from what both
+  // sides agreed: rounding, not reading. Saying anything here would be
+  // asking the reader about a difference they cannot see.
+  return settled;
+}

--- a/internal/webui/static/reader-sync.js
+++ b/internal/webui/static/reader-sync.js
@@ -1,3 +1,5 @@
+import { reconcileReadingState } from "./reader-reconcile.js";
+
 // Match Android's bounded fallback past malformed position records. A real
 // zero is readable; missing, null and out-of-range fractions are not.
 export function latestReadablePosition(ops, workID) {
@@ -69,12 +71,56 @@ export function candidateID(account, work, op) {
   return JSON.stringify([account, work, op.op_id, op.device_id]);
 }
 
+/**
+ * catchupState decides what, if anything, to say about a position that
+ * arrived from somewhere else.
+ *
+ * It holds the three sides of the comparison — the agreed baseline, this
+ * device's own position, and the newest remote one — and asks
+ * `reconcileReadingState` which of them moved. A remote move on its own
+ * becomes an offer; a move on both sides becomes a conflict carrying
+ * both positions, because there is no honest way to pick one.
+ *
+ * Baseline, local position and dirtiness are fed in from durable
+ * storage, so a reload does not turn a disagreement back into a bare
+ * offer.
+ *
+ * Presentation is deliberately not immediate. An offer waits for a
+ * moment when the reader is not mid-page: opening the book, or coming
+ * back to the tab. A conflict waits for the same moment rather than
+ * interrupting, which is what the Android client does with a conflict
+ * it has preserved.
+ */
 export function catchupState() {
   let account = null, work = null, device = null, generation = 0;
-  let candidate = null, offer = null, hidden = false, resume = false, baseline = null;
+  let candidate = null, offer = null, hidden = false, resume = false;
+  let baseline = null, remote = null, localOp = null, localDirty = false;
   const authored = new Map();
   const ignored = new Set();
   const identify = (op) => candidateID(account, work, op);
+  const ours = (op) => authored.has(op.op_id) && authored.get(op.op_id) === op.device_id;
+  const evaluate = () => {
+    const id = remote && identify(remote);
+    if (!id || ignored.has(id) || ours(remote)) {
+      candidate = null;
+      return;
+    }
+    const { decision } = reconcileReadingState({
+      // Having authored nothing since the book opened is not having no
+      // position: this device is where the baseline says it is. Without
+      // that, every remote echo of the opening position looks like an
+      // invitation to somewhere else.
+      local: localOp || baseline, remote, baseline, localDirty,
+    });
+    if (decision !== "pull" && decision !== "conflict") {
+      candidate = null;
+      return;
+    }
+    candidate = {
+      id, kind: decision, op: structuredClone(remote),
+      local: structuredClone(localOp || baseline), generation,
+    };
+  };
   return {
     bind(nextAccount, nextWork, nextDevice) {
       const sameBook = account === nextAccount && work === nextWork;
@@ -82,29 +128,43 @@ export function catchupState() {
       generation++; candidate = null; offer = null;
       if (!sameBook) resume = false;
       if (!sameBook) {
-        baseline = null;
+        baseline = null; remote = null; localOp = null; localDirty = false;
         authored.clear(); ignored.clear();
       }
     },
-    baseline(op) { baseline = identify(op); },
+    // The position this device and the server last agreed on.
+    baseline(op) { baseline = op ? structuredClone(op) : null; evaluate(); },
+    // This device's durable position, and whether the server has it.
+    local(op, dirty = !!op) {
+      localOp = op ? structuredClone(op) : null;
+      localDirty = !!op && dirty;
+      evaluate();
+    },
+    // settled folds an acknowledged local op into the baseline: it is
+    // now what both sides know, so it is no longer local movement.
+    settled(op) {
+      if (!op) return;
+      baseline = structuredClone(op);
+      if (localOp?.op_id === op.op_id) localDirty = false;
+      evaluate();
+    },
     wrote(op) {
       authored.set(op.op_id, device);
       if (authored.size > 256) authored.delete(authored.keys().next().value);
     },
     observe(op) {
-      const id = identify(op);
-      if (!id || id === baseline || ignored.has(id) ||
-          (authored.has(op.op_id) && authored.get(op.op_id) === op.device_id)) {
-        candidate = null;
-        return;
-      }
-      candidate = { id, op: structuredClone(op), generation };
+      remote = op ? structuredClone(op) : null;
+      evaluate();
     },
     hide() { hidden = true; resume = false; offer = null; },
     resume() {
       if (!hidden) return;
       hidden = false; resume = true;
     },
+    // present marks a moment where an offer may be shown without
+    // interrupting: the book opening, or a reload landing on a
+    // disagreement that was already there.
+    present() { if (!hidden) resume = true; },
     offer() {
       if (hidden || !resume || offer) return offer;
       resume = false;
@@ -112,14 +172,26 @@ export function catchupState() {
       return offer;
     },
     shown: () => offer,
+    // The reader turned a page. That does not settle the other device's
+    // position — it disagrees with it. The offer comes down, the
+    // knowledge stays, and the next quiet moment presents a conflict.
     moved() {
-      baseline = candidate?.id || offer?.id || baseline;
-      generation++; candidate = null; offer = null; resume = false;
+      offer = null; resume = false;
+      if (!localDirty) {
+        localDirty = true;
+        evaluate();
+      }
     },
     dismiss() {
-      if (offer) ignored.add(offer.id);
+      if (offer) {
+        ignored.add(offer.id);
+        // Choosing to stay is an answer about this remote position, so
+        // it becomes the agreed baseline: it must not be asked again.
+        baseline = structuredClone(offer.op);
+      }
       if (ignored.size > 256) ignored.delete(ignored.values().next().value);
       offer = null; resume = false;
+      evaluate();
     },
     accept(shown) {
       if (!shown || hidden || offer !== shown || shown.generation !== generation ||
@@ -127,7 +199,9 @@ export function catchupState() {
         offer = null;
         return null;
       }
-      baseline = shown.id;
+      baseline = structuredClone(shown.op);
+      localOp = structuredClone(shown.op);
+      localDirty = false;
       candidate = null; offer = null; resume = false;
       return structuredClone(shown.op);
     },

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -1458,3 +1458,7 @@ readium-view .readium-navigator-iframe{width:100%;height:100%;border:0;display:b
 .reader-catchup > div { display: flex; flex-wrap: wrap; gap: 0.75rem; }
 .reader-catchup button { min-height: 2.75rem; }
 .reader-catchup button:focus-visible { outline: 3px solid currentColor; outline-offset: 3px; }
+/* A disagreement is not the same news as an invitation: it says two
+   devices are in different places and needs a decision, so it is marked
+   rather than left looking like an ordinary offer. */
+.reader-catchup.conflict { border-width: 2px; }

--- a/internal/webui/testdata/offlinebrowser.test.mjs
+++ b/internal/webui/testdata/offlinebrowser.test.mjs
@@ -52,7 +52,7 @@ async function annotationChecks() {
 
 async function storageChecks() {
   const s = await import("/offline-storage.js");
-  const { drainOfflineOutbox, offlineSync } = await import("/offline-sync.js");
+  const { drainOfflineOutbox, offlineSync, readingSync } = await import("/offline-sync.js");
   const check = (value, message) => { if (!value) throw new Error(message); };
   const rejected = async (fn, message) => {
     let error;
@@ -207,7 +207,7 @@ async function storageChecks() {
   await queue("local", "local pending", "local");
   remoteAnnotations = [{ ...initialNote, id: "fresh", body: "remote update" }];
   remotePosition = { ...remotePosition, progression: 0.8 };
-  await s.saveOfflinePosition({ ...context, bookID, op: { op_id: "local-position", progression: 0.6 } });
+  await s.saveReadingPosition({ ...context, bookID, op: { op_id: "local-position", progression: 0.6 } });
   await s.reconcileOfflineBook(context, book, publicationRequest);
   local = await s.listOfflineAnnotations({ ...context, bookID });
   check(local.some(row => row.id === "local") && local.some(row => row.id === "fresh") &&
@@ -217,7 +217,7 @@ async function storageChecks() {
   await new Promise(resolve => setTimeout(resolve, 5));
   const latestPosition = { op_id: "a-newer-position", progression: 0.2,
     locator: { href: "chapter.xhtml", locations: { progression: 0.2 } } };
-  await s.saveOfflinePosition({ ...context, bookID, op: latestPosition });
+  await s.saveReadingPosition({ ...context, bookID, op: latestPosition });
   await s.removeBookSnapshots({ ...context, bookID });
   check(!await s.getReadySnapshot({ ...context, bookID }), "removal discards publication snapshots");
   await s.downloadPublication({ ...context, bookID, workID, request: publicationRequest });
@@ -235,12 +235,12 @@ async function storageChecks() {
   });
   check(positionPosts.join(",") === "local-position", "a deferred page blocks newer pages of the same work");
   const firstPosition = (await s.listOfflineOutbox({ ...context, kind: "position" }))[0];
-  await s.saveOfflinePosition({ ...context, bookID, op: firstPosition.payload });
+  await s.saveReadingPosition({ ...context, bookID, op: firstPosition.payload });
   check((await s.listOfflineOutbox({ ...context, kind: "position" }))[0].attempted,
     "saving a retry does not erase its transmission evidence");
   check((await s.getReadySnapshot({ ...context, bookID })).localPosition.op_id === latestPosition.op_id,
     "saving an older retry cannot replace the local head");
-  await rejected(() => s.saveOfflinePosition({ ...context, bookID,
+  await rejected(() => s.saveReadingPosition({ ...context, bookID,
     op: { ...firstPosition.payload, progression: 0.9 } }), "queued position IDs have immutable payloads");
   await drainOfflineOutbox(context, async (path, options) => {
     if (path !== "v1/ops") return reply({ results: [] });
@@ -253,15 +253,90 @@ async function storageChecks() {
   const originalNow = Date.now;
   try {
     Date.now = () => 100;
-    await s.saveOfflinePosition({ ...context, bookID, op: { ...latestPosition, op_id: "z-first" } });
+    await s.saveReadingPosition({ ...context, bookID, op: { ...latestPosition, op_id: "z-first" } });
     Date.now = () => 50;
-    await s.saveOfflinePosition({ ...context, bookID, op: { ...latestPosition, op_id: "a-last" } });
+    await s.saveReadingPosition({ ...context, bookID, op: { ...latestPosition, op_id: "a-last" } });
   } finally { Date.now = originalNow; }
   check((await s.listOfflineOutbox({ ...context, kind: "position" })).map(row => row.id).join(",") === "z-first,a-last",
     "a clock moving backwards cannot reorder page turns");
 
-  // The coordinator uses actual IndexedDB, Web Locks, account/token handshakes
-  // and transport-bound identity checks, with only HTTP replaced by fixtures.
+  // An online book has no downloaded snapshot, and its reading still has
+  // to outlive a closed tab. The durable baseline lives beside it: it is
+  // what makes a later disagreement answerable.
+  const online = "online-book";
+  const page = (id, progression) => ({ op_id: id, work_id: workID, progression });
+  await rejected(() => s.saveReadingPosition({ ...context, bookID: online, workID, op: page("needs-snapshot", 0.3) }),
+    "an offline reader still needs its book on disk");
+  await s.saveReadingPosition({ ...context, bookID: online, workID, requireSnapshot: false, op: page("online-1", 0.3) });
+  let reading = await s.readingState({ ...context, bookID: online });
+  check(reading.local.op_id === "online-1" && !reading.baseline && reading.workID === workID,
+    "a queued online page is this device's position, and nothing is agreed yet");
+  await s.removeOfflineOutbox({ ...context, kind: "position", id: "online-1" });
+  reading = await s.readingState({ ...context, bookID: online });
+  check(reading.baseline.op_id === "online-1" && !reading.local,
+    "an acknowledged page is what both sides now know");
+  await s.saveReadingPosition({ ...context, bookID: online, workID, requireSnapshot: false, op: page("online-2", 0.5) });
+  await s.agreeReadingBaseline({ ...context, bookID: online, workID, baseline: page("elsewhere", 0.7) });
+  reading = await s.readingState({ ...context, bookID: online });
+  check(reading.baseline.op_id === "elsewhere" && reading.local.op_id === "online-2",
+    "answering a disagreement by staying keeps this device's own page owed");
+  await s.agreeReadingBaseline({ ...context, bookID: online, workID, baseline: page("elsewhere", 0.7), settled: true });
+  reading = await s.readingState({ ...context, bookID: online });
+  check(!reading.local, "taking the other position puts this device there too");
+  await s.removeOfflineOutbox({ ...context, kind: "position", id: "online-2", settle: false });
+  reading = await s.readingState({ ...context, bookID: online });
+  check(reading.baseline.op_id === "elsewhere" &&
+    !(await s.listOfflineOutbox({ ...context, kind: "position" })).some(row => row.id === "online-2"),
+    "a withdrawn page leaves the queue without ever being agreed on");
+
+  // Two windows of one account share one queue and one lock. Whichever
+  // holds the lock does the sending; the other finds nothing left to do
+  // rather than putting the same page turn on the wire twice.
+  const handoffWork = "handoff-work";
+  const seen = [];
+  let credential = "old", accepting = true;
+  const readerRequest = async (path, options) => {
+    if (path === "v1/sessions") return reply({ accepted: 1 });
+    if (path.startsWith("v1/annotations")) {
+      const body = options.body ? JSON.parse(options.body).annotations[0] : null;
+      return reply({ results: [{ id: body?.id, status: "applied", rev: 1 }], rev: 1 });
+    }
+    const op = JSON.parse(options.body).ops[0];
+    const applied = reply({ results: [{ op_id: op.op_id, status: "applied" }] });
+    if (op.work_id !== handoffWork) return applied;
+    seen.push(`${credential}:${op.op_id}:${op.progression}`);
+    return accepting ? applied : reply({ error: "The reading credential expired." }, "", 401);
+  };
+  const queuePage = (id, progression) => s.saveReadingPosition({
+    ...context, bookID: "handoff-book", workID: handoffWork, requireSnapshot: false,
+    op: { op_id: id, work_id: handoffWork, progression },
+  });
+  const owed = async () => (await s.listOfflineOutbox({ ...context, kind: "position" }))
+    .filter(row => row.payload.work_id === handoffWork).map(row => row.id).join(",");
+  await queuePage("handoff-1", 0.25);
+  const tabA = readingSync({ context, request: readerRequest });
+  const tabB = readingSync({ context, request: readerRequest });
+  await Promise.all([tabA.trigger(), tabB.trigger()]);
+  check(seen.join(",") === "old:handoff-1:0.25", "two windows take turns on one queue", seen.join(","));
+  check(!(await owed()), "a delivered page leaves the shared queue", await owed());
+
+  // A credential that expires mid-drain is the transport's problem. The
+  // page stays owed with the bytes it was written with, and goes out
+  // under the new credential — from whichever window is still open.
+  accepting = false;
+  await queuePage("handoff-2", 0.4);
+  await tabA.trigger();
+  check(seen.at(-1) === "old:handoff-2:0.4" && await owed() === "handoff-2",
+    "a page the credential could not carry stays owed", seen.join(",") + " | " + await owed());
+  await rejected(() => queuePage("handoff-2", 0.9), "an owed page cannot be rewritten while it waits");
+  credential = "new"; accepting = true;
+  tabA.stop();
+  await tabB.trigger();
+  check(seen.at(-1) === "new:handoff-2:0.4" && !(await owed()),
+    "the renewed credential replays the same bytes from the surviving window", seen.join(","));
+  tabB.stop();
+
+
   await s.clearOfflineAccount(partition, account);
   await s.setActiveAccount(partition, account);
   context = { ...await s.accountContext(partition, account), deviceID };
@@ -346,6 +421,12 @@ async function storageChecks() {
   }
   globalThis.fetch = originalFetch;
 
+  // Reading state is as private as anything else here, so logout has to
+  // take it with everything else.
+  await s.agreeReadingBaseline({ ...context, bookID: online, workID, baseline: page("kept", 0.4) });
+  check((await s.readingState({ ...context, bookID: online })).baseline.op_id === "kept",
+    "reading state survives an ordinary reload");
+
   const old = context;
   const version = await s.accountVersion(partition);
   let releaseDownload, downloading;
@@ -371,7 +452,8 @@ async function storageChecks() {
   await rejected(() => s.downloadPublication({ ...old, bookID, request: publicationRequest }),
     "late download cannot repopulate logout");
   check(!(await s.listOfflineAnnotations({ ...old, bookID })).length &&
-    !(await s.listReadySnapshots(partition, account)).length, "logout leaves no private rows");
+    !(await s.listReadySnapshots(partition, account)).length &&
+    !(await s.readingState({ ...old, bookID: online })), "logout leaves no private rows");
   return "IndexedDB publication, mutation, session, reconciliation, coordinator and logout checks passed";
 }
 

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -1631,12 +1631,14 @@ async function durableGuard(evalIn, check, { pause, wait, remote, visibility, po
   check('a disagreement is marked as one',
     await evalIn("document.getElementById('reader-catchup').classList.contains('conflict')"));
 
-  // Staying is an answer: it settles the other device's position without
-  // giving up the page this browser still owes.
+  // Staying is an answer: it settles the other device's position and
+  // publishes the page this browser still wants to keep.
   await evalIn("document.getElementById('reader-catchup-dismiss').click()");
   await pause(300);
   check('staying keeps this browser where it was', Math.abs(await position() - 0.42) > 0.01);
-  check('staying does not withdraw the page this browser owes', await positions() === owed, await positions());
+  const staying = await positions();
+  check('staying keeps the page this browser chose',
+    staying.startsWith(owed + ',') && staying.split(',').length === 2, staying);
   await visibility(true); await visibility(false);
   await pause(500);
   check('an answered disagreement is not asked again',
@@ -1645,14 +1647,15 @@ async function durableGuard(evalIn, check, { pause, wait, remote, visibility, po
   // The network comes back. Nothing prompts it: the queue drains itself.
   await evalIn('window.__liveBlockOps = false');
   await evalIn("window.dispatchEvent(new Event('online'))");
-  check('the owed page reaches the server once the network returns',
-    await wait(`window.__liveDelivered.includes(${JSON.stringify(owed.split(',')[0])})`),
+  check('the chosen pages reach the server once the network returns',
+    await wait(`window.__liveDelivered.includes(${JSON.stringify(owed.split(',')[0])}) &&
+      window.__liveDelivered.includes(${JSON.stringify(staying.split(',')[1])})`),
     String(await evalIn('JSON.stringify(window.__liveDelivered)')));
   check('a delivered page leaves the queue',
     await wait(`(${drained}).then(n => n === 0)`), String(await positions()));
   reading = JSON.parse(await stored() || 'null');
   check('delivery is what moves the agreed baseline',
-    reading && reading.baseline && reading.baseline.op_id === owed.split(',')[0],
+    reading && reading.baseline && reading.baseline.op_id === staying.split(',')[1],
     JSON.stringify(reading && reading.baseline));
   check('nothing is owed once it has been agreed', !reading.local, JSON.stringify(reading));
 }

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -114,15 +114,23 @@ if (liveMode) {
     window.__liveReads = 0;
     window.__liveStreams = [];
     window.__liveOwnOps = [];
+    window.__liveDelivered = [];
     window.fetch = async function(input, init = {}) {
       const url = typeof input === 'string' ? input : input.url;
       if (init.headers?.Authorization) window.__liveBearer = init.headers.Authorization;
       if (url.endsWith('v1/events')) window.__liveStreams.push(init.signal);
       if (url.endsWith('v1/ops') && init.body) {
         const ops = JSON.parse(init.body).ops || [];
-        window.__liveOwnOps.push(...ops.filter((op) => !op.op_id.startsWith('live-test-')));
+        const mine = ops.filter((op) => !op.op_id.startsWith('live-test-'));
+        window.__liveOwnOps.push(...mine);
+        // Only this browser's own writes go missing: the test's injected
+        // remote pages come from somewhere the outage does not reach.
+        if (window.__liveBlockOps && mine.length) throw new TypeError('Failed to fetch');
       }
       const resp = await original.call(this, input, init);
+      if (url.endsWith('v1/ops') && init.body && resp.ok) {
+        for (const op of JSON.parse(init.body).ops || []) window.__liveDelivered.push(op.op_id);
+      }
       if (url.includes('/positions?') && resp.ok) {
         await resp.clone().json();
         window.__liveReads++;
@@ -1547,7 +1555,106 @@ async function liveGuard(evalIn, check, S) {
   check('accepted restore does not echo a position op', await evalIn('window.__liveOwnOps.length === 0'));
   await evalIn("document.getElementById('reader-next').click()");
   check('a genuine page turn still syncs', await wait('window.__liveOwnOps.length > 0'));
+
+  await durableGuard(evalIn, check, { pause, wait, remote, visibility, position });
   await visibility(true);
+}
+
+// durableGuard covers the online reader's half of issue #49: a page
+// turn is written to this browser's disk before it is sent, it is still
+// owed after a reload, and a page turn on both sides is presented as a
+// disagreement with both positions rather than resolved behind the
+// reader's back.
+async function durableGuard(evalIn, check, { pause, wait, remote, visibility, position }) {
+  const storageModule = `import(document.querySelector('script[type=module][src$="reader-app.js"]')
+    .src.replace('reader-app.js', 'offline-storage.js'))`;
+  // The reader's own IndexedDB, read the way the reader writes it.
+  const inStorage = (body) => evalIn(`(async () => {
+    const s = await ${storageModule};
+    const partition = s.storagePartition();
+    const account = await s.activeAccount(partition);
+    if (!account) return null;
+    const context = { ...await s.accountContext(partition, account), deviceID: window.__liveDevice };
+    return await (${body})(s, context, partition, account);
+  })()`);
+  await evalIn(`(async () => {
+    const base = document.getElementById('reader-config').dataset.apiBase;
+    const resp = await fetch(base + 'v1/token', { headers: { Authorization: window.__liveBearer } });
+    window.__liveDevice = (await resp.json()).device_id;
+    return true;
+  })()`);
+  check('the reader has a device identity to key its own state by',
+    typeof await evalIn('window.__liveDevice') === 'string' && await evalIn('window.__liveDevice.length > 0'));
+
+  const positions = () => inStorage(`async (s, c) => (await s.listOfflineOutbox({ ...c, kind: 'position' })).map(r => r.id).join(',')`);
+  const stored = () => inStorage(`async (s, c) => JSON.stringify(await s.readingState({ ...c, bookID: document.getElementById('reader-config').dataset.book }))`);
+  const drained = `(async () => {
+    const s = await ${storageModule};
+    const partition = s.storagePartition();
+    const account = await s.activeAccount(partition);
+    const context = { ...await s.accountContext(partition, account), deviceID: window.__liveDevice };
+    return (await s.listOfflineOutbox({ ...context, kind: 'position' })).length;
+  })()`;
+
+  check('an acknowledged page turn is agreed, not owed',
+    await wait(`(${drained}).then(n => n === 0)`), String(await positions()));
+  let reading = JSON.parse(await stored() || 'null');
+  check('the reader keeps a durable baseline for this book',
+    reading && reading.baseline && typeof reading.baseline.progression === 'number',
+    JSON.stringify(reading));
+
+  // A page turn the network never carried is still where the reader is.
+  await evalIn('window.__liveBlockOps = true');
+  const beforeTurn = await evalIn('window.__liveDelivered.length');
+  const wasAt = await position();
+  await evalIn("document.getElementById('reader-prev').click()");
+  check('the reader actually moved', await wait(`document.querySelector('readium-view').lastLocation.fraction !== ${wasAt}`),
+    String(await position()));
+  check('an undeliverable page turn is written to this browser first',
+    await wait(`(${drained}).then(n => n > 0)`), String(await positions()));
+  check('a page the network refused is not counted as delivered',
+    await evalIn('window.__liveDelivered.length') === beforeTurn);
+  const owed = await positions();
+
+  // Both sides have now moved since they last agreed, and neither of
+  // them can be discarded.
+  await remote('conflict', 0.42);
+  await visibility(true);
+  await visibility(false);
+  check('a page turn on both sides is presented as a disagreement',
+    await wait("!document.getElementById('reader-catchup').hidden"));
+  const text = await evalIn("document.getElementById('reader-catchup-text').textContent");
+  const accept = await evalIn("document.getElementById('reader-catchup-accept').textContent");
+  const stay = await evalIn("document.getElementById('reader-catchup-dismiss').textContent");
+  check('the disagreement names both positions', text.includes('42%') && /\d+%.*42%|42%.*\d+%/.test(text), text);
+  check('each button says where it goes', accept.includes('42%') && /\d/.test(stay), accept + ' / ' + stay);
+  check('a disagreement is marked as one',
+    await evalIn("document.getElementById('reader-catchup').classList.contains('conflict')"));
+
+  // Staying is an answer: it settles the other device's position without
+  // giving up the page this browser still owes.
+  await evalIn("document.getElementById('reader-catchup-dismiss').click()");
+  await pause(300);
+  check('staying keeps this browser where it was', Math.abs(await position() - 0.42) > 0.01);
+  check('staying does not withdraw the page this browser owes', await positions() === owed, await positions());
+  await visibility(true); await visibility(false);
+  await pause(500);
+  check('an answered disagreement is not asked again',
+    await evalIn("document.getElementById('reader-catchup').hidden"));
+
+  // The network comes back. Nothing prompts it: the queue drains itself.
+  await evalIn('window.__liveBlockOps = false');
+  await evalIn("window.dispatchEvent(new Event('online'))");
+  check('the owed page reaches the server once the network returns',
+    await wait(`window.__liveDelivered.includes(${JSON.stringify(owed.split(',')[0])})`),
+    String(await evalIn('JSON.stringify(window.__liveDelivered)')));
+  check('a delivered page leaves the queue',
+    await wait(`(${drained}).then(n => n === 0)`), String(await positions()));
+  reading = JSON.parse(await stored() || 'null');
+  check('delivery is what moves the agreed baseline',
+    reading && reading.baseline && reading.baseline.op_id === owed.split(',')[0],
+    JSON.stringify(reading && reading.baseline));
+  check('nothing is owed once it has been agreed', !reading.local, JSON.stringify(reading));
 }
 
 // svgGuard proves finding #1 of the streaming-reader review: a spine

--- a/internal/webui/testdata/readerreconcile.test.mjs
+++ b/internal/webui/testdata/readerreconcile.test.mjs
@@ -1,0 +1,130 @@
+// Unit tests for the three-way reading-position merge. These mirror the
+// Android client's ReadingStateMerge tests: the point of the merge is
+// that it decides from *movement away from an agreed baseline*, never
+// from a clock and never from whichever number is larger.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  EPSILON, LOCAL_EPSILON, anchorOf, sameSpot, movedFrom, reconcileReadingState,
+} from "../static/reader-reconcile.js";
+
+let minted = 0;
+const at = (progression, anchor) => ({
+  op_id: `op-${++minted}`,
+  progression,
+  locator: {
+    href: "chapter.xhtml",
+    locations: {
+      totalProgression: progression,
+      fragments: anchor ? [`epubcfi(${anchor})`] : [],
+    },
+  },
+});
+
+const decide = (input) => reconcileReadingState(input).decision;
+
+test("an anchor is the epubcfi fragment, and only that", () => {
+  assert.equal(anchorOf(at(0.5, "/6/2")), "epubcfi(/6/2)");
+  assert.equal(anchorOf(at(0.5)), null);
+  assert.equal(anchorOf({ locator: { locations: { fragments: ["page=12"] } } }), null);
+  assert.equal(anchorOf({ locator: { locations: { fragments: "epubcfi(/6/2)" } } }), null);
+  assert.equal(anchorOf(null), null);
+});
+
+test("two positions are the same spot by identity, by anchor, or within tolerance", () => {
+  const one = at(0.5, "/6/2");
+  assert.equal(sameSpot(one, { ...one }), true);
+  assert.equal(sameSpot(at(0.5, "/6/2"), at(0.9, "/6/2")), true, "a named spot outranks a fraction");
+  assert.equal(sameSpot(at(0.5, "/6/2"), at(0.5, "/6/4")), false, "two named spots do not blur");
+  assert.equal(sameSpot(at(0.5), at(0.5 + EPSILON / 2)), true);
+  assert.equal(sameSpot(at(0.5), at(0.5 + EPSILON * 2)), false);
+  assert.equal(sameSpot(at(0.5), null), false);
+});
+
+test("a corrupt progression is not a position, and cannot be compared as one", () => {
+  for (const bad of [null, undefined, NaN, Infinity, -0.1, 1.1, "0.5"]) {
+    assert.equal(sameSpot(at(bad), at(0.5)), false);
+    assert.equal(movedFrom(at(bad), at(0.5), EPSILON), true);
+    assert.equal(movedFrom(at(0.5), at(bad), EPSILON), true);
+  }
+  assert.equal(sameSpot(at(null), at(undefined)), true, "neither side claims a place");
+});
+
+test("nothing has moved away from a baseline that does not exist, so everything has", () => {
+  assert.equal(movedFrom(null, at(0.5), EPSILON), true);
+  assert.equal(movedFrom(at(0.5), null, EPSILON), false, "an absent position did not move");
+});
+
+test("movement is measured against the baseline, with the tolerance it was asked for", () => {
+  const base = at(0.5);
+  assert.equal(movedFrom(base, at(0.5 + EPSILON / 2), EPSILON), false);
+  assert.equal(movedFrom(base, at(0.5 + EPSILON), EPSILON), true);
+  // A local write is evidence, so its tolerance is effectively nothing.
+  assert.equal(movedFrom(base, at(0.5 + EPSILON / 2), LOCAL_EPSILON), true);
+  assert.equal(movedFrom(base, { ...base }, LOCAL_EPSILON), false, "the same op is the same place");
+  assert.equal(movedFrom(at(0.5, "/6/2"), at(0.9, "/6/2"), LOCAL_EPSILON), false);
+  assert.equal(movedFrom(at(0.5, "/6/2"), at(0.5, "/6/4"), EPSILON), true);
+});
+
+test("with nothing to compare there is nothing to say", () => {
+  assert.equal(decide({}), "in-sync");
+  assert.equal(decide({ local: at(0.5), localDirty: false }), "in-sync");
+  assert.equal(decide({ remote: at(0.5) }), "pull");
+});
+
+test("an unacknowledged local position with no remote counterpart is owed, not resolved", () => {
+  assert.equal(decide({ local: at(0.5), localDirty: true }), "push");
+});
+
+test("the four ways two devices can stand relative to what they agreed", () => {
+  const baseline = at(0.5);
+  const near = at(0.5 + EPSILON / 4);
+  const far = at(0.8);
+  const further = at(0.9);
+  // Neither moved.
+  assert.equal(decide({ baseline, local: baseline, remote: near }), "in-sync");
+  // Only the other device moved.
+  assert.equal(decide({ baseline, local: baseline, remote: far }), "pull");
+  // Only this device moved.
+  assert.equal(decide({ baseline, local: far, remote: baseline, localDirty: true }), "push");
+  // Both moved, and no rule can say which one the reader meant.
+  const both = reconcileReadingState({ baseline, local: far, remote: further, localDirty: true });
+  assert.equal(both.decision, "conflict");
+  assert.equal(both.local, far, "a conflict carries both positions");
+  assert.equal(both.remote, further);
+});
+
+test("a local position the server already acknowledged is not local movement", () => {
+  const baseline = at(0.5);
+  // Same numbers as the conflict above; only the queue has changed.
+  assert.equal(decide({ baseline, local: at(0.8), remote: at(0.9), localDirty: false }), "pull");
+});
+
+test("the furthest position does not win, in either direction", () => {
+  const baseline = at(0.5);
+  // This device read backwards, on purpose, and owes that page turn.
+  assert.equal(decide({ baseline, local: at(0.2), remote: baseline, localDirty: true }), "push");
+  // The other device went backwards and this one did not move.
+  assert.equal(decide({ baseline, local: baseline, remote: at(0.2) }), "pull");
+});
+
+test("no baseline at all is a conflict as soon as both sides have a position", () => {
+  assert.equal(decide({ local: at(0.2), remote: at(0.8), localDirty: true }), "conflict");
+  assert.equal(decide({ local: at(0.2), remote: at(0.8) }), "pull", "a clean local side simply follows");
+  assert.equal(decide({ local: at(0.2), remote: at(0.2), localDirty: true }), "in-sync");
+});
+
+test("two devices at the same named spot never disagree, whatever their fractions say", () => {
+  const baseline = at(0.1, "/6/2");
+  const here = at(0.30, "/6/8");
+  const there = at(0.55, "/6/8");
+  assert.equal(decide({ baseline, local: here, remote: there, localDirty: true }), "in-sync");
+});
+
+test("a clock is never consulted", () => {
+  const baseline = at(0.5);
+  const old = { ...at(0.8), client_ts: "1999-01-01T00:00:00Z" };
+  const fresh = { ...at(0.9), client_ts: "2099-01-01T00:00:00Z" };
+  assert.equal(decide({ baseline, local: old, remote: fresh, localDirty: true }), "conflict");
+  assert.equal(decide({ baseline, local: fresh, remote: old, localDirty: true }), "conflict");
+});

--- a/internal/webui/testdata/readersync.test.mjs
+++ b/internal/webui/testdata/readersync.test.mjs
@@ -25,9 +25,21 @@ test("only an acknowledgement of this exact operation settles a position", () =>
   assert.equal(positionAcknowledged(null, op), false);
 });
 
-const op = (id, device = "phone", progression = 0.6) => ({
+// Distinct operations sit at distinct places. Reconciliation compares
+// positions now, not identities, so two ops at the same spot are the
+// same news however they are named. Pass a progression explicitly when
+// that sameness is the point.
+const places = new Map();
+const place = (id) => {
+  if (!places.has(id)) places.set(id, 0.1 + places.size * 0.05);
+  return places.get(id);
+};
+const op = (id, device = "phone", progression = place(id)) => ({
   op_id: id, device_id: device, work_id: "work", progression,
-  locator: { href: "chapter.xhtml", locations: { totalProgression: progression, fragments: ["epubcfi(/6/2)"] } },
+  locator: {
+    href: "chapter.xhtml",
+    locations: { totalProgression: progression, fragments: [`epubcfi(/6/${Math.round(progression * 1000)})`] },
+  },
 });
 function state() {
   const s = catchupState();
@@ -87,12 +99,63 @@ test("local movement, account/work/token replacement and hidden state invalidate
   }
 });
 
-test("new local page does not rediscover the discarded remote candidate", () => {
+test("a local page turn disagrees with the remote position instead of discarding it", () => {
   const s = state();
   s.observe(op("remote"));
-  s.moved();
   s.hide(); s.resume();
+  assert.equal(s.offer().kind, "pull");
+  s.local(op("mine"), true);
+  s.moved();
+  assert.equal(s.offer(), null); // never mid-page
+  s.hide(); s.resume();
+  const offer = s.offer();
+  assert.equal(offer.kind, "conflict");
+  assert.equal(offer.op.op_id, "remote");
+  assert.equal(offer.local.op_id, "mine");
+});
+
+test("an acknowledged local position is agreement, so a matching remote echo says nothing", () => {
+  const s = state();
+  const mine = op("mine");
+  s.local(mine, true);
+  s.settled(mine);
+  s.observe(mine);
+  s.hide(); s.resume();
+  assert.equal(s.offer(), null);
+});
+
+test("only this side moving is a push, and asks the reader nothing", () => {
+  const s = state();
+  s.local(op("mine"), true);
+  s.observe(op("opening"));
+  s.hide(); s.resume();
+  assert.equal(s.offer(), null);
+});
+
+test("a conflict answered stays answered across a reload of the same state", () => {
+  const s = state();
+  s.local(op("mine"), true);
   s.observe(op("remote"));
+  s.hide(); s.resume();
+  const offer = s.offer();
+  assert.equal(offer.kind, "conflict");
+  assert.deepEqual(s.accept(offer).op_id, "remote");
+  // Accepting agrees on the remote position for both sides, so the
+  // same news arriving again is no longer news.
+  s.observe(op("remote"));
+  s.hide(); s.resume();
+  assert.equal(s.offer(), null);
+});
+
+test("staying put answers the disagreement without moving the baseline of this device", () => {
+  const s = state();
+  s.local(op("mine"), true);
+  s.observe(op("remote"));
+  s.hide(); s.resume();
+  assert.equal(s.offer().kind, "conflict");
+  s.dismiss();
+  s.observe(op("remote"));
+  s.hide(); s.resume();
   assert.equal(s.offer(), null);
 });
 


### PR DESCRIPTION
## Summary

Fixes #49. The online reader now keeps reading changes across reloads, crashes, and reconnects, and shows both positions when devices move independently.

## Changes

- Persist online positions, session checkpoints, and finished sittings before delivery.
- Share the offline queue, retry rules, and Web Lock across reader modes.
- Store a durable per-book baseline and preserve three-way conflicts for the reader to answer.
- Document the behavior in ADR-0037 and add browser coverage for reconnects, conflicts, credential renewal, tab handoff, and reloads.

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [x] `go tool templ generate ./internal/webui/` ran successfully; generated output is ignored by this repository
- [ ] `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish` (docs/openapi.yaml was unchanged)
- [x] Browser tests ran with Chrome, including the full internal/webui suite

## Screenshots, logs, or API examples

No screenshots. This change does not alter API routes or response shapes.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.