### PR TITLE
chore: configure Copilot Go environment

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,24 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Download Go modules
+        run: go mod download


### PR DESCRIPTION
Add a minimal `copilot-setup-steps.yml` for GitHub Copilot cloud agent.

The setup intentionally mirrors the repository's existing Go CI setup rather than duplicating the full test workflow:

- check out the repository
- install the Go version declared by `go.mod`
- enable the standard Go module/build cache
- pre-download Go modules

This is optional for Copilot, but avoids making the agent discover/install the required Go toolchain and dependencies on each task. PostgreSQL, browser tooling, and other task-specific dependencies remain outside the permanent setup.