### PR TITLE
perf: Load the next chapter before the reader turns into it

### DIFF
--- a/internal/webui/static/reader-engine.js
+++ b/internal/webui/static/reader-engine.js
@@ -160,7 +160,42 @@ export class ReaderEngine extends HTMLElement {
     };
     this.dispatchEvent(new CustomEvent("relocate", { detail: this.lastLocation }));
     this.drawAnnotations().catch(() => {});
-    if (index !== this.lastWindowIndex) { this.lastWindowIndex = index; this.releaseOutOfWindow(index); }
+    if (index !== this.lastWindowIndex) {
+      this.lastWindowIndex = index;
+      this.releaseOutOfWindow(index);
+      this.warmNeighbours(index);
+    }
+  }
+
+  // Fetches and builds the chapters on either side of this one while the
+  // reader is still reading this one.
+  //
+  // Readium's frame pool measures its preload window in positions, not in
+  // chapters, and a position is about a kilobyte of text: it does not
+  // reach for the next chapter until the reader is already standing on
+  // the last screen or two of this one, and the turn then waits for the
+  // fetch. Over a real network that wait is the whole complaint in issue
+  // #60. A chapter takes minutes to read and a few hundred milliseconds
+  // to fetch, so there is no reason to spend them at the same moment.
+  //
+  // Only the immediate neighbours, both of which are well inside the
+  // retain window above, so nothing warmed here is released before it is
+  // used. Forward first and on its own: that is the way almost everyone
+  // turns, and the chapter behind should not compete with it for the
+  // link. A fixed-layout book is left alone — its frame pool builds every
+  // spine item up front, so there is nothing to be early for.
+  warmNeighbours(index) {
+    if (this.fixed || !this.resources?.warm) return;
+    const forward = this.book.sections[index + 1];
+    const back = this.book.sections[index - 1];
+    // The reader may have moved on by the time the chapter ahead is
+    // ready; warming behind them then would only evict what they need.
+    const behind = () => {
+      if (back && this.lastWindowIndex === index) this.resources.warm(back.id);
+    };
+    if (!forward) return behind();
+    this.resources.warm(forward.id);
+    this.resources.documents.get(forward.id)?.then(behind, behind);
   }
 
   // Coordinates our own resource cache (raw bytes, decoded blobs) with

--- a/internal/webui/static/reader-publication.js
+++ b/internal/webui/static/reader-publication.js
@@ -92,6 +92,16 @@ export class ReaderPublication {
     this.canonicalEntries = new Map([...this.entries.keys()].map(key => [canonicalize(key), key]));
     this.raw = new Map();
     this.blobs = new Map();
+    // Spine documents already parsed, rewritten and serialised, keyed by
+    // href. Building one costs a fetch, a parse, a walk of every element
+    // and a fetch per asset it names, so it is worth keeping: Readium
+    // rebuilds a frame whenever it re-enters its window, and warm() below
+    // fills this in before the reader ever asks. Released by retain()
+    // together with the blob URLs the serialised document points at.
+    this.documents = new Map();
+    // The build attempt currently owning each entry in `documents`, so a
+    // build still running when its entry is released can detect that.
+    this.builds = new Map();
     this.urls = new Set();
     // Which spine document(s) a cached entry (raw bytes or a derived blob)
     // was reached from. retain() below uses this to release entries no
@@ -124,7 +134,9 @@ export class ReaderPublication {
         return new Uint8Array(bytes);
       })();
       this.raw.set(key, pending);
-      pending.catch(() => this.raw.delete(key));
+      // Only ever forget this attempt. A failure that arrives after the
+      // entry was released and refetched must not delete its successor.
+      pending.catch(() => { if (this.raw.get(key) === pending) this.raw.delete(key); });
     }
     return this.raw.get(key);
   }
@@ -139,6 +151,11 @@ export class ReaderPublication {
       if (key === this.packageHref) continue;
       if ([...referrers].some(root => keepRoots.has(root))) continue;
       this.raw.delete(key);
+      // A serialised spine document names the blob URLs revoked just
+      // below, so it cannot outlive them: keeping it would hand Readium a
+      // chapter whose every image and stylesheet is a dead URL.
+      this.documents.delete(key);
+      this.builds.delete(key);
       const blob = this.blobs.get(key);
       if (blob) {
         this.blobs.delete(key);
@@ -207,7 +224,7 @@ export class ReaderPublication {
         return url;
       })();
       this.blobs.set(key, pending);
-      pending.catch(() => this.blobs.delete(key));
+      pending.catch(() => { if (this.blobs.get(key) === pending) this.blobs.delete(key); });
     }
     return await this.blobs.get(key) + (fragment ? "#" + fragment : "");
   }
@@ -282,18 +299,49 @@ export class ReaderPublication {
     return doc;
   }
 
+  // Builds the frame document for one spine item: the whole fetch, parse,
+  // rewrite and serialise pipeline, memoised so re-entering a chapter
+  // costs nothing and so warm() can pay for it in advance.
+  build(href) {
+    if (!this.documents.has(href)) {
+      // Identifies this attempt. retain() and close() drop the token, so a
+      // build that was still running when its blobs were revoked can tell
+      // that it is now stale and refuse to hand back a document naming
+      // dead URLs, instead of quietly resolving with one.
+      const token = {};
+      this.builds.set(href, token);
+      const pending = (async () => {
+        const entry = this.entries.get(href);
+        const doc = imageSpineTypes.has(entry?.type)
+          ? await this.imageSpineDocument(href, entry.type)
+          : await this.document(href);
+        if (this.closed || this.builds.get(href) !== token) throw Error("Publication resource released");
+        return new TextEncoder().encode(new XMLSerializer().serializeToString(doc));
+      })();
+      this.documents.set(href, pending);
+      pending.catch(() => { if (this.documents.get(href) === pending) this.documents.delete(href); });
+    }
+    return this.documents.get(href);
+  }
+
+  // Asks for a spine document nobody has requested yet. Readium only
+  // reaches for the next chapter once the reader is a position or two
+  // from the end of this one, which over a real network means the turn
+  // waits for a fetch that could have happened minutes earlier. This is a
+  // hint and nothing more: a failure here is swallowed so the reader is
+  // left exactly as it was, and the real read() can fail on its own terms
+  // with its own message.
+  warm(href) {
+    if (this.closed || !href || !this.entries.has(href)) return;
+    this.build(href).catch(() => {});
+  }
+
   get(link) {
     const owner = this;
     return new class extends Resource {
       async link() { return link; }
       async length() { return (await owner.bytes(link.href)).length; }
-      async read() {
-        const entry = owner.entries.get(link.href);
-        const doc = imageSpineTypes.has(entry?.type)
-          ? await owner.imageSpineDocument(link.href, entry.type)
-          : await owner.document(link.href);
-        return new TextEncoder().encode(new XMLSerializer().serializeToString(doc));
-      }
+      async read() { return owner.build(link.href); }
       close() {}
     }();
   }
@@ -302,6 +350,6 @@ export class ReaderPublication {
     this.closed = true;
     this.controller.abort();
     for (const url of this.urls) URL.revokeObjectURL(url);
-    this.urls.clear(); this.raw.clear(); this.blobs.clear(); this.referrers.clear();
+    this.urls.clear(); this.raw.clear(); this.blobs.clear(); this.documents.clear(); this.builds.clear(); this.referrers.clear();
   }
 }

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -399,6 +399,30 @@ check('the page painted something', png.length > 8000 && uniq > 40,
 // stopped two pages in. One click is not evidence of a working reader —
 // the reported bug survived one click — so this turns the page until the
 // book ends and asks how far it got.
+
+// Issue #60: the next chapter has to be fetched and built while this one
+// is still being read. Readium's own preload window is measured in
+// positions — roughly a kilobyte of text each — so left to itself it
+// does not reach for the next chapter until the reader is already
+// standing on the last screen or two of this one, and the turn then
+// waits for a network round trip. reader-engine.js warms both
+// neighbours on every section change instead; what that leaves behind is
+// a built document in the publication's cache, before anyone asks.
+const nextChapter = await evalIn("document.querySelector('readium-view').book.sections[1].id");
+// Assert the built document, not merely that a build was started: the
+// map entry appears the moment warming begins, so a check for its
+// presence would pass while the chapter was still on the wire — the very
+// thing this is here to prevent.
+const built = `!!document.querySelector('readium-view').resources?.documents?.has(${JSON.stringify(nextChapter)})`;
+let preloaded = false;
+for (let i = 0; i < 100 && !preloaded; i++) {
+  preloaded = await evalIn(built);
+  if (!preloaded) await new Promise(resolve => setTimeout(resolve, 50));
+}
+const bytes = preloaded && await evalIn(
+  `document.querySelector('readium-view').resources.documents.get(${JSON.stringify(nextChapter)}).then(b => b.length)`);
+check('the next chapter is built before the reader turns into it', bytes > 0, `${nextChapter}, ${bytes} bytes`);
+
 const seen = [];
 for (let i = 0; i < 10; i++) {
   const before = await evalIn("JSON.stringify(document.querySelector('readium-view').lastLocation.locator)");

--- a/internal/webui/testdata/readerpublication.test.mjs
+++ b/internal/webui/testdata/readerpublication.test.mjs
@@ -72,7 +72,7 @@ test('a fetch failure does not leave a stale cache entry', async () => {
 // plain Node has. Standing in for them keeps these tests on the part
 // that is actually under test: which chapters get built, how often, and
 // when the built document is released.
-function building(hrefs) {
+function building(t, hrefs) {
   const made = fixture(hrefs);
   const built = [];
   made.pub.document = async href => {
@@ -80,22 +80,30 @@ function building(hrefs) {
     await made.pub.bytes(href, href);
     return { href };
   };
-  globalThis.XMLSerializer ??= class {
+  // Scoped to the test that asked for it, so a test that should fail for
+  // want of a DOM still does.
+  const had = Object.hasOwn(globalThis, 'XMLSerializer');
+  const previous = globalThis.XMLSerializer;
+  globalThis.XMLSerializer = class {
     serializeToString(doc) { return `<x href="${doc.href}"/>`; }
   };
+  t.after(() => {
+    if (had) globalThis.XMLSerializer = previous;
+    else delete globalThis.XMLSerializer;
+  });
   return { ...made, built };
 }
 
-test('build() builds a spine document once and reuses it', async () => {
-  const { pub, built } = building(['c1.xhtml']);
+test('build() builds a spine document once and reuses it', async t => {
+  const { pub, built } = building(t, ['c1.xhtml']);
   const first = await pub.build('c1.xhtml');
   const second = await pub.build('c1.xhtml');
   assert.deepEqual(built, ['c1.xhtml']);
   assert.equal(first, second);
 });
 
-test('warm() builds a chapter nobody has asked for yet', async () => {
-  const { pub, built } = building(['c1.xhtml', 'c2.xhtml']);
+test('warm() builds a chapter nobody has asked for yet', async t => {
+  const { pub, built } = building(t, ['c1.xhtml', 'c2.xhtml']);
   pub.warm('c2.xhtml');
   await pub.documents.get('c2.xhtml');
   assert.deepEqual(built, ['c2.xhtml']);
@@ -104,16 +112,16 @@ test('warm() builds a chapter nobody has asked for yet', async () => {
   assert.deepEqual(built, ['c2.xhtml']);
 });
 
-test('warm() ignores a chapter that is not in the publication', async () => {
-  const { pub, built } = building(['c1.xhtml']);
+test('warm() ignores a chapter that is not in the publication', async t => {
+  const { pub, built } = building(t, ['c1.xhtml']);
   pub.warm('nowhere.xhtml');
   pub.warm(undefined);
   assert.deepEqual(built, []);
   assert.ok(!pub.documents.has('nowhere.xhtml'));
 });
 
-test('a warm that fails is swallowed and leaves no stale entry', async () => {
-  const { pub } = building(['c1.xhtml']);
+test('a warm that fails is swallowed and leaves no stale entry', async t => {
+  const { pub } = building(t, ['c1.xhtml']);
   pub.document = async () => { throw new Error('no'); };
   pub.warm('c1.xhtml');
   await new Promise(resolve => setTimeout(resolve, 0));
@@ -122,8 +130,8 @@ test('a warm that fails is swallowed and leaves no stale entry', async () => {
   await assert.rejects(() => pub.get({ href: 'c1.xhtml' }).read());
 });
 
-test('retain() releases a built document with the blobs it points at', async () => {
-  const { pub, built } = building(['c1.xhtml', 'c2.xhtml']);
+test('retain() releases a built document with the blobs it points at', async t => {
+  const { pub, built } = building(t, ['c1.xhtml', 'c2.xhtml']);
   await pub.build('c1.xhtml');
   await pub.build('c2.xhtml');
   // A serialised chapter names blob URLs by reference. Keeping it after
@@ -135,15 +143,15 @@ test('retain() releases a built document with the blobs it points at', async () 
   assert.deepEqual(built, ['c1.xhtml', 'c2.xhtml', 'c1.xhtml'], 'c1 must be rebuilt, not served stale');
 });
 
-test('close() drops the built documents too', async () => {
-  const { pub } = building(['c1.xhtml']);
+test('close() drops the built documents too', async t => {
+  const { pub } = building(t, ['c1.xhtml']);
   await pub.build('c1.xhtml');
   pub.close();
   assert.equal(pub.documents.size, 0);
 });
 
-test('a build released mid-flight refuses to hand back a stale document', async () => {
-  const { pub } = building(['c1.xhtml', 'c2.xhtml']);
+test('a build released mid-flight refuses to hand back a stale document', async t => {
+  const { pub } = building(t, ['c1.xhtml', 'c2.xhtml']);
   let release;
   pub.document = href => new Promise(resolve => {
     pub.addReferrer(href, href); // As bytes() would, before the fetch returns.
@@ -158,8 +166,8 @@ test('a build released mid-flight refuses to hand back a stale document', async 
   assert.ok(!pub.documents.has('c1.xhtml'));
 });
 
-test('a failed build does not evict the entry that replaced it', async () => {
-  const { pub } = building(['c1.xhtml']);
+test('a failed build does not evict the entry that replaced it', async t => {
+  const { pub } = building(t, ['c1.xhtml']);
   let fail;
   pub.document = () => new Promise((_, reject) => { fail = () => reject(new Error('gone')); });
   const first = pub.build('c1.xhtml');

--- a/internal/webui/testdata/readerpublication.test.mjs
+++ b/internal/webui/testdata/readerpublication.test.mjs
@@ -67,3 +67,123 @@ test('a fetch failure does not leave a stale cache entry', async () => {
   assert.ok(!pub.raw.has('c1.xhtml'));
   void bodies;
 });
+
+// build()/warm() reach document() and XMLSerializer, neither of which
+// plain Node has. Standing in for them keeps these tests on the part
+// that is actually under test: which chapters get built, how often, and
+// when the built document is released.
+function building(hrefs) {
+  const made = fixture(hrefs);
+  const built = [];
+  made.pub.document = async href => {
+    built.push(href);
+    await made.pub.bytes(href, href);
+    return { href };
+  };
+  globalThis.XMLSerializer ??= class {
+    serializeToString(doc) { return `<x href="${doc.href}"/>`; }
+  };
+  return { ...made, built };
+}
+
+test('build() builds a spine document once and reuses it', async () => {
+  const { pub, built } = building(['c1.xhtml']);
+  const first = await pub.build('c1.xhtml');
+  const second = await pub.build('c1.xhtml');
+  assert.deepEqual(built, ['c1.xhtml']);
+  assert.equal(first, second);
+});
+
+test('warm() builds a chapter nobody has asked for yet', async () => {
+  const { pub, built } = building(['c1.xhtml', 'c2.xhtml']);
+  pub.warm('c2.xhtml');
+  await pub.documents.get('c2.xhtml');
+  assert.deepEqual(built, ['c2.xhtml']);
+  // The read Readium eventually does must not fetch or build again.
+  await pub.get({ href: 'c2.xhtml' }).read();
+  assert.deepEqual(built, ['c2.xhtml']);
+});
+
+test('warm() ignores a chapter that is not in the publication', async () => {
+  const { pub, built } = building(['c1.xhtml']);
+  pub.warm('nowhere.xhtml');
+  pub.warm(undefined);
+  assert.deepEqual(built, []);
+  assert.ok(!pub.documents.has('nowhere.xhtml'));
+});
+
+test('a warm that fails is swallowed and leaves no stale entry', async () => {
+  const { pub } = building(['c1.xhtml']);
+  pub.document = async () => { throw new Error('no'); };
+  pub.warm('c1.xhtml');
+  await new Promise(resolve => setTimeout(resolve, 0));
+  assert.ok(!pub.documents.has('c1.xhtml'), 'a failed build must not be cached');
+  // And the real read still fails on its own terms rather than silently.
+  await assert.rejects(() => pub.get({ href: 'c1.xhtml' }).read());
+});
+
+test('retain() releases a built document with the blobs it points at', async () => {
+  const { pub, built } = building(['c1.xhtml', 'c2.xhtml']);
+  await pub.build('c1.xhtml');
+  await pub.build('c2.xhtml');
+  // A serialised chapter names blob URLs by reference. Keeping it after
+  // those blobs are revoked would hand Readium a chapter of dead URLs.
+  pub.retain(new Set(['c2.xhtml']));
+  assert.ok(!pub.documents.has('c1.xhtml'));
+  assert.ok(pub.documents.has('c2.xhtml'));
+  await pub.build('c1.xhtml');
+  assert.deepEqual(built, ['c1.xhtml', 'c2.xhtml', 'c1.xhtml'], 'c1 must be rebuilt, not served stale');
+});
+
+test('close() drops the built documents too', async () => {
+  const { pub } = building(['c1.xhtml']);
+  await pub.build('c1.xhtml');
+  pub.close();
+  assert.equal(pub.documents.size, 0);
+});
+
+test('a build released mid-flight refuses to hand back a stale document', async () => {
+  const { pub } = building(['c1.xhtml', 'c2.xhtml']);
+  let release;
+  pub.document = href => new Promise(resolve => {
+    pub.addReferrer(href, href); // As bytes() would, before the fetch returns.
+    release = () => resolve({ href });
+  });
+  const pending = pub.build('c1.xhtml');
+  // The reader jumps away, so retain() revokes the blob URLs this build's
+  // document is about to name. It must not resolve with them anyway.
+  pub.retain(new Set(['c2.xhtml']));
+  release();
+  await assert.rejects(() => pending, /released/);
+  assert.ok(!pub.documents.has('c1.xhtml'));
+});
+
+test('a failed build does not evict the entry that replaced it', async () => {
+  const { pub } = building(['c1.xhtml']);
+  let fail;
+  pub.document = () => new Promise((_, reject) => { fail = () => reject(new Error('gone')); });
+  const first = pub.build('c1.xhtml');
+  first.catch(() => {});
+  pub.documents.delete('c1.xhtml');
+  pub.document = async href => ({ href });
+  const second = pub.build('c1.xhtml');
+  fail();
+  await assert.rejects(() => first);
+  await second;
+  assert.equal(pub.documents.get('c1.xhtml'), second, 'the newer build must survive the older failure');
+});
+
+test('a failed fetch does not evict the bytes that replaced it', async () => {
+  const { pub } = fixture(['c1.xhtml']);
+  let fail;
+  pub.request = () => new Promise((_, reject) => { fail = () => reject(new Error('gone')); });
+  const first = pub.bytes('c1.xhtml');
+  first.catch(() => {});
+  pub.raw.delete('c1.xhtml');
+  pub.request = async () => ({ ok: true, arrayBuffer: async () => new Uint8Array([1]).buffer });
+  const second = pub.bytes('c1.xhtml');
+  fail();
+  await assert.rejects(() => first);
+  await second;
+  assert.ok(pub.raw.has('c1.xhtml'), 'the newer fetch must survive the older failure');
+});


### PR DESCRIPTION
## Summary

Fixes #60, though not as the issue describes it. The reported symptom was a blank page between chapters. It is not blank, it is slow: turning into a new chapter waited for that chapter to be fetched, parsed, rewritten and rebuilt, and over a real connection the wait is long enough to look like an empty screen.

Readium picks what to load ahead by counting reading positions, not chapters. A position is roughly a kilobyte of text, and its build window spans two of them, so it did not reach for the next chapter until the reader was already on its last screen or two. That work then landed in the same instant as the page turn.

The reader now prepares the neighbouring chapters as soon as it settles into one, so the fetch happens during the minutes somebody spends reading rather than in the moment they leave.

## Changes

- `reader-publication.js`: the built spine document is memoised instead of being reassembled on every visit, and `warm(href)` prepares a chapter nobody has asked for yet. A warm is a hint: it swallows its own failures so a real read still fails on its own terms.
- `reader-publication.js`: the memo is released by `retain()` and `close()` together with the blob URLs it names, and a build that was still running when its entry was released now refuses to hand back a document full of revoked URLs. Cache cleanup is conditional, so an old failure can no longer evict the entry that replaced it.
- `reader-engine.js`: `warmNeighbours()` runs on every section change, after the relocate event. Forward first and alone so the two do not compete for the connection, the chapter behind only if the reader has not moved on, and nothing at all for fixed-layout books, which load every page up front anyway.
- Tests: seven unit tests for the memo and the warm, three for the release races, and a browser assertion that the next chapter is built before the turn.

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [x] If `.templ` files changed: not applicable
- [x] If `docs/openapi.yaml` changed: not applicable
- [x] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable

`node --test internal/webui/testdata/readerpublication.test.mjs` is 14/14. The browser checks were run with `LISEUR_CHROME` set, so they ran rather than skipped, and the new assertion was confirmed to fail on `main` and pass here.

`TestReaderLiveInARealBrowser` fails on `main` untouched by this branch ("Timed out waiting for the initial annotations"). It is not caused by this change and is not addressed here.

## Screenshots, logs, or API examples

Measured with a throwaway CDP probe under `Network.emulateNetworkConditions`, one column at 1280x900, walking page turns through a real book. Times are from the click to content on screen.

| simulated latency | crossing into a new chapter, before | after |
|---|---|---|
| 300ms | 239ms, and the walk then stopped advancing after 10 turns | 54ms, 70 turns, 11 crossings |
| 700ms | 358ms, walk stopped after 7 turns | 53ms and 213ms |

A turn inside a chapter costs 53ms throughout, so after this change a chapter boundary costs what an ordinary page turn costs. The book used is a copyrighted local file, so no bytes, path or screenshot of it appear here.

## Found on the way, not fixed here

- Every page turn pushes an op, the server raises the `positions` topic for that user, and the live stream is per user rather than per device, so the device that wrote the op is told about its own write and pulls 9.7 kB of its own ops back. Worth its own issue: not echoing a notification to the connection that caused it means the notifier has to carry the originating device.
- At 700ms the reader can still stop advancing mid-chapter. Reproduces without this change.
- `FXLFramePoolManager.evict()` refuses eviction whenever the item is in the pool, which for a fixed-layout book is always, so its frame documents can outlive the asset URLs they name.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.