### PR TITLE
feat: Add sliding web sessions with configurable TTL

### DIFF
--- a/docs/adr/0038-a-web-session-that-renews-itself.md
+++ b/docs/adr/0038-a-web-session-that-renews-itself.md
@@ -1,0 +1,78 @@
+# ADR-0038: A web session that renews itself
+
+- **Status:** Accepted; implemented
+- **Date:** 2026-09-10
+
+## Context
+
+A browser session lasted seven days and never moved. The expiry was
+written once, at sign-in, into both the `auth_sessions` row and the
+cookie, and nothing extended it. So the owner of a personal server was
+signed out every week, forever, and the only remedy on offer was to
+raise the constant.
+
+Seven days is a defensible number for an application people sign in to.
+It is the wrong shape for this one. Reading is a habit: the same browser
+comes back most days for months, and the sign-in it is asked for adds no
+security — the account is not more protected by a password typed on a
+schedule into a machine that was already trusted yesterday.
+
+## Decision
+
+A web session lasts `web_session_ttl_days` (default 180) of **disuse**,
+and slides. Every authenticated request may push the expiry out to a
+fresh window, in the row and in the cookie, so a browser somebody reads
+in is never signed out, and one abandoned on a borrowed laptop still
+lapses.
+
+Three bounds keep it from being an unbounded credential:
+
+- **The write is throttled.** A request extends the session only when
+  the new expiry would be at least 24 hours beyond the stored one, so a
+  session costs at most one `UPDATE` per day however many pages it
+  loads. It needs no new column and no migration.
+- **The extension only moves forward, and never revives.** The `UPDATE`
+  is guarded on `revoked_at IS NULL` and on the row not having lapsed at
+  the time of the request, so a page view racing a sign-out cannot bring
+  the session back. It is best-effort: a store that refuses leaves the
+  session exactly as valid as it was, because a page must not fail over
+  a housekeeping write.
+- **Renewal happens behind authentication only**, in the one middleware
+  every signed-in route passes through. The signed-out visitor and the
+  login page never touch it.
+
+There is no "keep me signed in" checkbox. A checkbox asks every reader,
+on every device, to make a judgement they have no way to make, and the
+honest default was going to be "checked" anyway. One setting the
+operator chooses once is a smaller thing than a question asked forever.
+
+## Consequences
+
+A stolen session cookie is worth more than it was: up to half a year if
+the thief keeps using it, rather than a week. The mitigations are the
+ones that already existed and are unchanged — `HttpOnly`,
+`SameSite=Strict`, `Secure` unless `insecure_http`, no `Path` widening,
+sign-out revoking reader tokens across every session of the account, and
+the admin operations (disable, password reset, revoke-all) that cut
+every session at once. Every high-impact admin action still re-verifies
+the password, which matters more now that the cookie behind it is
+long-lived.
+
+Lowering the setting does not shorten sessions already issued; they keep
+the window they were minted with until they lapse. `Housekeep` is
+unchanged and still deletes expired and revoked sessions — the rows just
+live longer. On upgrade nobody is signed out: an existing seven-day
+session is simply extended on its next request.
+
+## Acceptance criteria
+
+- A fresh sign-in's cookie and row both expire one configured window
+  out, and the setting is what decides it.
+- A request on a session more than a day from its last extension renews
+  both cookie and row, keeping the same secret; a session renewed
+  moments ago is left untouched, with no `Set-Cookie` at all.
+- A revoked or lapsed session is never extended, at the store layer, on
+  either backend.
+- `web_session_ttl_days` is refused outside 1..3650 at startup, and
+  `docs/deployment.md` states the lifetime, the sliding behaviour, and
+  that lowering it does not shorten sessions already issued.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,6 +62,7 @@ loose ends that must come before any of it, are in
 | [0035](0035-naming-a-shelf-is-one-request.md) | Naming a shelf is one request | Client | Accepted; implemented | `POST /v1/books/resolve` for up to 500 books, one transaction and one answer each, `200` with per-item `not_found`/`ambiguous`; same `library-read` + `sync` pair; amends [0003](0003-catalog-work-identity.md) |
 | [0036](0036-one-bounded-offline-web-reader.md) | One bounded offline web reader | Later | Accepted; implemented pending iOS acceptance | Same-origin multi-book PWA under `/ui/offline/`, private IndexedDB publication/state storage, foreground-only reconnect, and explicit annotation conflict handling; separate reader origins leave it disabled |
 | [0037](0037-durable-online-reading.md) | Durable online reading, and a disagreement the reader answers | Now | Accepted; implemented | The online reader queues positions and sittings to the same IndexedDB outbox, drains through one shared lock and sender, keeps an agreed baseline per book and device, and presents a two-sided move as a conflict; same-origin deployments only; amends [0007](0007-web-reader.md), [0030](0030-web-reader-reading-sessions.md), [0036](0036-one-bounded-offline-web-reader.md) |
+| [0038](0038-a-web-session-that-renews-itself.md) | A web session that renews itself | Now | Accepted; implemented | Browser sessions last `web_session_ttl_days` (default 180) of disuse and slide forward on use, throttled to one write a day, never reviving a revoked or lapsed session; no "keep me signed in" checkbox |
 
 ## Convention
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -539,6 +539,28 @@ roots. `LISEUR_LISTEN_ADDR`, `LISEUR_DATABASE_DRIVER`,
 `LISEUR_TRUSTED_PROXIES`, and `LISEUR_READER_ORIGIN` keep their usual
 meanings.
 
+### Staying signed in
+
+A browser that signs in gets a session good for `web_session_ttl_days`,
+180 by default, and the window slides: every page view pushes the expiry
+back to a fresh 180 days. So a browser somebody reads in is never signed
+out, while one left alone lapses after half a year. There is no "keep me
+signed in" box — every sign-in is on the same terms, and the way to end
+a session early is to sign out, which also revokes the account's reader
+tokens.
+
+```toml
+web_session_ttl_days = 180
+```
+
+It is a top-level key, so it belongs above the first `[table]` header.
+Shorten it on a shared machine. Two things are worth knowing before you
+do: lowering it does not shorten sessions that were already issued —
+those keep the window they were minted with until they lapse — and the
+value is a lifetime for the cookie only. Disabling an account, resetting
+its password, or revoking its credentials cuts every session at once,
+whatever the setting says.
+
 ## Backup
 
 Back up the database. It holds users, tokens, reading state, folder rows

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/chmouel/liseur-sync/internal/epub"
 )
@@ -115,6 +116,17 @@ type Config struct {
 	} `toml:"ops"`
 
 	PairingCodeTTLMin int `toml:"pairing_code_ttl_min"` // default 15
+
+	// WebSessionTTLDays is how long a browser session stays valid
+	// without being used. It slides: every authenticated request pushes
+	// the expiry back to now + this, so an account somebody reads with
+	// never gets signed out, and one left alone lapses. Default 180.
+	WebSessionTTLDays int `toml:"web_session_ttl_days"`
+}
+
+// WebSessionTTL is the browser session window as a duration.
+func (c Config) WebSessionTTL() time.Duration {
+	return time.Duration(c.WebSessionTTLDays) * 24 * time.Hour
 }
 
 // Default returns the configuration with all documented defaults.
@@ -150,6 +162,7 @@ func Default() Config {
 	c.Ops.AnnotationMaxPerWork = 2000
 	c.Ops.AnnotationRetentionDays = 180
 	c.PairingCodeTTLMin = 15
+	c.WebSessionTTLDays = 180
 	return c
 }
 
@@ -267,6 +280,9 @@ func (c *Config) Validate() error {
 	}
 	if c.Ops.InferenceLateHours < minLateHours {
 		return fmt.Errorf("ops.inference_late_hours must cover ops.inference_gap_min")
+	}
+	if c.WebSessionTTLDays < 1 || c.WebSessionTTLDays > 3650 {
+		return fmt.Errorf("web_session_ttl_days must be between 1 and 3650")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"testing"
+	"time"
 )
 
 func TestDefaultEnablesCompaction(t *testing.T) {
@@ -62,5 +63,28 @@ func TestCacheDirEnvironmentOverride(t *testing.T) {
 func TestFolderRootsAreUnsetByDefault(t *testing.T) {
 	if roots := Default().Content.FolderRoots; len(roots) != 0 {
 		t.Fatalf("default folder roots: %v", roots)
+	}
+}
+
+// TestWebSessionLifetimeDefaultsAndValidation pins the browser session
+// window. It is a security default, so it is stated in a test rather
+// than only in the struct.
+func TestWebSessionLifetimeDefaultsAndValidation(t *testing.T) {
+	c := Default()
+	c.Content.CacheDir = "c"
+	if c.WebSessionTTLDays != 180 {
+		t.Fatalf("default: got %d days", c.WebSessionTTLDays)
+	}
+	if got := c.WebSessionTTL(); got != 180*24*time.Hour {
+		t.Fatalf("duration: got %v", got)
+	}
+	if err := c.Validate(); err != nil {
+		t.Fatalf("default config invalid: %v", err)
+	}
+	for _, days := range []int{0, -1, 3651} {
+		c.WebSessionTTLDays = days
+		if err := c.Validate(); err == nil {
+			t.Fatalf("%d days accepted", days)
+		}
 	}
 }

--- a/internal/config/load_test.go
+++ b/internal/config/load_test.go
@@ -33,6 +33,7 @@ func TestShippedExampleParsesIntoTheSettingsItNames(t *testing.T) {
 	for from, to := range map[string]string{
 		"insecure_http = false":                                "insecure_http = true",
 		"pairing_code_ttl_min = 15":                            "pairing_code_ttl_min = 42",
+		"web_session_ttl_days = 180":                           "web_session_ttl_days = 30",
 		`# trusted_proxies = ["10.0.0.0/8", "192.168.0.0/16"]`: `trusted_proxies = ["10.0.0.0/8"]`,
 		`# cors_allowed_origins = ["https://app.example.com"]`: `cors_allowed_origins = ["https://app.example.com"]`,
 		`# reader_origin = "https://read.example.com"`:         `reader_origin = "https://read.example.com"`,
@@ -60,6 +61,9 @@ func TestShippedExampleParsesIntoTheSettingsItNames(t *testing.T) {
 	}
 	if cfg.ReaderOrigin != "https://read.example.com" {
 		t.Fatalf("reader_origin: got %q", cfg.ReaderOrigin)
+	}
+	if cfg.WebSessionTTLDays != 30 {
+		t.Fatalf("web_session_ttl_days: got %d", cfg.WebSessionTTLDays)
 	}
 }
 

--- a/internal/store/postgres/authsessions.go
+++ b/internal/store/postgres/authsessions.go
@@ -42,12 +42,14 @@ func (s *Store) AuthSessionByHash(ctx context.Context, sha256 string) (store.Aut
 	return a, err
 }
 
-func (s *Store) ExtendAuthSession(ctx context.Context, userID, id string, expiresAt, now time.Time) error {
+func (s *Store) ExtendAuthSession(
+	ctx context.Context, userID, id string, expiresAt, renewBefore, now time.Time,
+) error {
 	res, err := s.db.ExecContext(ctx, q(
 		`UPDATE auth_sessions SET expires_at = ?
 		 WHERE user_id = ? AND id = ? AND revoked_at IS NULL
 		   AND expires_at > ? AND expires_at < ?`),
-		expiresAt.UTC(), userID, id, now.UTC(), expiresAt.UTC())
+		expiresAt.UTC(), userID, id, now.UTC(), renewBefore.UTC())
 	if err != nil {
 		return err
 	}

--- a/internal/store/postgres/authsessions.go
+++ b/internal/store/postgres/authsessions.go
@@ -42,6 +42,25 @@ func (s *Store) AuthSessionByHash(ctx context.Context, sha256 string) (store.Aut
 	return a, err
 }
 
+func (s *Store) ExtendAuthSession(ctx context.Context, userID, id string, expiresAt, now time.Time) error {
+	res, err := s.db.ExecContext(ctx, q(
+		`UPDATE auth_sessions SET expires_at = ?
+		 WHERE user_id = ? AND id = ? AND revoked_at IS NULL
+		   AND expires_at > ? AND expires_at < ?`),
+		expiresAt.UTC(), userID, id, now.UTC(), expiresAt.UTC())
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) RevokeAuthSession(ctx context.Context, userID, id string) error {
 	res, err := s.db.ExecContext(ctx, q(
 		`UPDATE auth_sessions SET revoked_at = ? WHERE user_id = ? AND id = ? AND revoked_at IS NULL`),

--- a/internal/store/sqlite/authsessions.go
+++ b/internal/store/sqlite/authsessions.go
@@ -55,12 +55,14 @@ func (s *Store) AuthSessionByHash(ctx context.Context, sha256 string) (store.Aut
 	return a, nil
 }
 
-func (s *Store) ExtendAuthSession(ctx context.Context, userID, id string, expiresAt, now time.Time) error {
+func (s *Store) ExtendAuthSession(
+	ctx context.Context, userID, id string, expiresAt, renewBefore, now time.Time,
+) error {
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE auth_sessions SET expires_at = ?
 		 WHERE user_id = ? AND id = ? AND revoked_at IS NULL
 		   AND expires_at > ? AND expires_at < ?`,
-		formatTime(expiresAt), userID, id, formatTime(now), formatTime(expiresAt))
+		formatTime(expiresAt), userID, id, formatTime(now), formatTime(renewBefore))
 	if err != nil {
 		return err
 	}

--- a/internal/store/sqlite/authsessions.go
+++ b/internal/store/sqlite/authsessions.go
@@ -55,6 +55,25 @@ func (s *Store) AuthSessionByHash(ctx context.Context, sha256 string) (store.Aut
 	return a, nil
 }
 
+func (s *Store) ExtendAuthSession(ctx context.Context, userID, id string, expiresAt, now time.Time) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE auth_sessions SET expires_at = ?
+		 WHERE user_id = ? AND id = ? AND revoked_at IS NULL
+		   AND expires_at > ? AND expires_at < ?`,
+		formatTime(expiresAt), userID, id, formatTime(now), formatTime(expiresAt))
+	if err != nil {
+		return err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return store.ErrNotFound
+	}
+	return nil
+}
+
 func (s *Store) RevokeAuthSession(ctx context.Context, userID, id string) error {
 	res, err := s.db.ExecContext(ctx,
 		`UPDATE auth_sessions SET revoked_at = ? WHERE user_id = ? AND id = ? AND revoked_at IS NULL`,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1891,12 +1891,13 @@ type Store interface {
 	RevokeAuthSession(ctx context.Context, userID, id string) error
 	// ExtendAuthSession pushes a live session's expiry out to
 	// expiresAt, which is how a web session in regular use stays signed
-	// in without ever being reissued. It only ever moves the expiry
-	// forward, and it refuses a session that is revoked or already
-	// lapsed at now: a request racing a sign-out must not bring the
-	// session back. Neither case is an error the caller can act on, so
-	// both are ErrNotFound.
-	ExtendAuthSession(ctx context.Context, userID, id string, expiresAt, now time.Time) error
+	// in without ever being reissued. It only updates a row whose
+	// current expiry is before renewBefore, making the renewal throttle
+	// atomic. It refuses a session that is revoked or already lapsed at
+	// now: a request racing a sign-out must not bring the session back.
+	// Neither case is an error the caller can act on, so both are
+	// ErrNotFound.
+	ExtendAuthSession(ctx context.Context, userID, id string, expiresAt, renewBefore, now time.Time) error
 
 	// kosync pairing codes and device credentials.
 	CreatePairingCode(ctx context.Context, p PairingCode) error

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1889,6 +1889,14 @@ type Store interface {
 	CreateAuthSession(ctx context.Context, a AuthSession) error
 	AuthSessionByHash(ctx context.Context, sha256 string) (AuthSession, error)
 	RevokeAuthSession(ctx context.Context, userID, id string) error
+	// ExtendAuthSession pushes a live session's expiry out to
+	// expiresAt, which is how a web session in regular use stays signed
+	// in without ever being reissued. It only ever moves the expiry
+	// forward, and it refuses a session that is revoked or already
+	// lapsed at now: a request racing a sign-out must not bring the
+	// session back. Neither case is an error the caller can act on, so
+	// both are ErrNotFound.
+	ExtendAuthSession(ctx context.Context, userID, id string, expiresAt, now time.Time) error
 
 	// kosync pairing codes and device credentials.
 	CreatePairingCode(ctx context.Context, p PairingCode) error

--- a/internal/store/storetest/storetest.go
+++ b/internal/store/storetest/storetest.go
@@ -41,6 +41,7 @@ func Run(t *testing.T, open OpenFunc) {
 	t.Run("UserCredentialOperations", func(t *testing.T) {
 		testUserCredentialOperations(t, open)
 	})
+	t.Run("ExtendAuthSession", func(t *testing.T) { testExtendAuthSession(t, open) })
 	t.Run("ListUsersPage", func(t *testing.T) { testListUsersPage(t, open) })
 	t.Run("DisabledUser", func(t *testing.T) { testDisabledUser(t, open) })
 	t.Run("Tokens", func(t *testing.T) { testTokens(t, open) })

--- a/internal/store/storetest/usercredentials.go
+++ b/internal/store/storetest/usercredentials.go
@@ -168,3 +168,56 @@ func names(us []store.User) []string {
 	}
 	return out
 }
+
+// testExtendAuthSession covers the sliding web session: a session in
+// use moves its own expiry out, and the two states that must never be
+// revived by a request that arrives at the wrong moment.
+func testExtendAuthSession(t *testing.T, open OpenFunc) {
+	s := open(t)
+	ctx := context.Background()
+	u := MkUser(t, s, "sliding")
+	now := time.Date(2026, time.May, 1, 12, 0, 0, 0, time.UTC)
+
+	mk := func(id string, expires time.Time) {
+		if err := s.CreateAuthSession(ctx, store.AuthSession{
+			ID: id, UserID: u.ID, SHA256: "sha-" + id, Kind: "web",
+			CreatedAt: now, ExpiresAt: expires,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mk("live", now.Add(24*time.Hour))
+	mk("revoked", now.Add(24*time.Hour))
+	mk("lapsed", now.Add(-time.Hour))
+
+	want := now.Add(180 * 24 * time.Hour)
+	if err := s.ExtendAuthSession(ctx, u.ID, "live", want, now); err != nil {
+		t.Fatal(err)
+	}
+	a, err := s.AuthSessionByHash(ctx, "sha-live")
+	if err != nil || !a.ExpiresAt.Equal(want) {
+		t.Fatalf("expiry not moved: %v %v", a.ExpiresAt, err)
+	}
+	// Backwards is a no-op, so lowering the configured window cannot
+	// silently shorten a session that was issued under a longer one.
+	if err := s.ExtendAuthSession(ctx, u.ID, "live", now.Add(time.Hour), now); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("backwards: want ErrNotFound, got %v", err)
+	}
+	if a, err := s.AuthSessionByHash(ctx, "sha-live"); err != nil || !a.ExpiresAt.Equal(want) {
+		t.Fatalf("expiry moved backwards: %v %v", a.ExpiresAt, err)
+	}
+
+	if err := s.RevokeAuthSession(ctx, u.ID, "revoked"); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range []string{"revoked", "lapsed", "nosuch"} {
+		if err := s.ExtendAuthSession(ctx, u.ID, id, want, now); !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("%s: want ErrNotFound, got %v", id, err)
+		}
+	}
+	// Another account cannot extend a session it does not own.
+	other := MkUser(t, s, "sliding-other")
+	if err := s.ExtendAuthSession(ctx, other.ID, "live", want.Add(time.Hour), now); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("cross-account: want ErrNotFound, got %v", err)
+	}
+}

--- a/internal/store/storetest/usercredentials.go
+++ b/internal/store/storetest/usercredentials.go
@@ -191,7 +191,7 @@ func testExtendAuthSession(t *testing.T, open OpenFunc) {
 	mk("lapsed", now.Add(-time.Hour))
 
 	want := now.Add(180 * 24 * time.Hour)
-	if err := s.ExtendAuthSession(ctx, u.ID, "live", want, now); err != nil {
+	if err := s.ExtendAuthSession(ctx, u.ID, "live", want, want, now); err != nil {
 		t.Fatal(err)
 	}
 	a, err := s.AuthSessionByHash(ctx, "sha-live")
@@ -200,24 +200,29 @@ func testExtendAuthSession(t *testing.T, open OpenFunc) {
 	}
 	// Backwards is a no-op, so lowering the configured window cannot
 	// silently shorten a session that was issued under a longer one.
-	if err := s.ExtendAuthSession(ctx, u.ID, "live", now.Add(time.Hour), now); !errors.Is(err, store.ErrNotFound) {
+	if err := s.ExtendAuthSession(ctx, u.ID, "live", now.Add(time.Hour), now.Add(time.Hour), now); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("backwards: want ErrNotFound, got %v", err)
 	}
 	if a, err := s.AuthSessionByHash(ctx, "sha-live"); err != nil || !a.ExpiresAt.Equal(want) {
 		t.Fatalf("expiry moved backwards: %v %v", a.ExpiresAt, err)
+	}
+	// The throttle is part of the conditional update, so concurrent
+	// requests that observed the old expiry cannot all extend it.
+	if err := s.ExtendAuthSession(ctx, u.ID, "live", want.Add(24*time.Hour), want, now); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("throttled renewal: want ErrNotFound, got %v", err)
 	}
 
 	if err := s.RevokeAuthSession(ctx, u.ID, "revoked"); err != nil {
 		t.Fatal(err)
 	}
 	for _, id := range []string{"revoked", "lapsed", "nosuch"} {
-		if err := s.ExtendAuthSession(ctx, u.ID, id, want, now); !errors.Is(err, store.ErrNotFound) {
+		if err := s.ExtendAuthSession(ctx, u.ID, id, want, want, now); !errors.Is(err, store.ErrNotFound) {
 			t.Fatalf("%s: want ErrNotFound, got %v", id, err)
 		}
 	}
 	// Another account cannot extend a session it does not own.
 	other := MkUser(t, s, "sliding-other")
-	if err := s.ExtendAuthSession(ctx, other.ID, "live", want.Add(time.Hour), now); !errors.Is(err, store.ErrNotFound) {
+	if err := s.ExtendAuthSession(ctx, other.ID, "live", want.Add(time.Hour), want.Add(time.Hour), now); !errors.Is(err, store.ErrNotFound) {
 		t.Fatalf("cross-account: want ErrNotFound, got %v", err)
 	}
 }

--- a/internal/webui/adminusers.templ
+++ b/internal/webui/adminusers.templ
@@ -419,8 +419,9 @@ templ adminUserBody(prefix string, csrf string, v adminUserView, flash Flash) {
 }
 
 // adminPasswordField is the re-verification every high-impact action
-// carries. A seven-day session cookie is not a good enough
-// authorization for taking over somebody else's account.
+// carries. A session cookie that renews itself for as long as somebody
+// keeps reading is not a good enough authorization for taking over
+// somebody else's account.
 templ adminPasswordField(csrf string) {
 	<label>
 		Confirm with your password

--- a/internal/webui/layout.templ
+++ b/internal/webui/layout.templ
@@ -181,9 +181,8 @@ templ loginPage(prefix string, u userCtx, errMsg string) {
 
 templ loginBody(prefix string, errMsg string) {
 	@authFrame(prefix) {
-		<p class="auth-eyebrow">Your reading space</p>
-		<h1>Welcome back.</h1>
-		<p class="auth-intro">Sign in and pick up your next chapter.</p>
+		<p class="auth-eyebrow">Liseur Sync</p>
+		<h1>Sign in</h1>
 		if errMsg != "" {
 			<p class="error" role="alert">{ errMsg }</p>
 		}
@@ -201,9 +200,9 @@ templ authFrame(prefix string) {
 			<aside class="auth-story" aria-label="Liseur Sync">
 				<p class="auth-brand">Liseur <span>sync</span></p>
 				<img class="auth-icon" src={ prefix + "static/icon.svg" } width="112" height="112" alt=""/>
-				<p class="auth-headline">Every book.<br/>Right where<br/><em>you left it.</em></p>
-				<p class="auth-story-copy">A home for your books, with your reading place kept across devices.</p>
-				<p class="auth-story-foot"><span aria-hidden="true">✦</span> Self-hosted. Made for readers.</p>
+				<p class="auth-headline">Your books.<br/><em>Your place in them.</em></p>
+				<p class="auth-story-copy">Liseur Sync keeps your library and your reading position on your own server.</p>
+				<p class="auth-story-foot">Self-hosted reading sync.</p>
 			</aside>
 			<section class="auth-panel">
 				{ children... }
@@ -222,9 +221,9 @@ templ setupPage(prefix string, u userCtx, errMsg string) {
 
 templ setupBody(prefix string, errMsg string) {
 	@authFrame(prefix) {
-		<p class="auth-eyebrow">Your first chapter</p>
-		<h1>Make yourself at home.</h1>
-		<p class="auth-intro">Create your account to start your library.</p>
+		<p class="auth-eyebrow">First run</p>
+		<h1>Create the first account</h1>
+		<p class="auth-intro">No accounts exist on this server yet.</p>
 		if errMsg != "" {
 			<p class="error" role="alert">{ errMsg }</p>
 		}

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -528,14 +528,15 @@ func (s *Server) startSession(w http.ResponseWriter, r *http.Request, u store.Us
 // written, so minting a session and extending one cannot drift apart in
 // how the browser is told to keep it.
 //
-// No Path attribute: the RFC 6265 default-path (the directory of the
-// request URL) scopes the cookie to /ui/ — or to the proxy subpath
-// (e.g. /sync/ui/) when served under one.
+// Path remains at the UI root even when a nested page renews it. Without
+// this, the browser gives the renewed cookie the nested request's
+// directory, leaving the original /ui/ cookie to expire.
 func (s *Server) setSessionCookie(w http.ResponseWriter, secret string, expires time.Time) {
 	http.SetCookie(w, &http.Cookie{
 		Name: cookieName, Value: secret,
 		HttpOnly: true, SameSite: http.SameSiteStrictMode,
 		Secure:  !s.Cfg.InsecureHTTP,
+		Path:    "/ui/",
 		Expires: expires,
 	})
 }
@@ -558,7 +559,11 @@ func (s *Server) renewSession(w http.ResponseWriter, r *http.Request, a store.Au
 	}
 	now := time.Now()
 	want := now.Add(s.Cfg.WebSessionTTL())
-	if want.Sub(a.ExpiresAt) < renewalFloor {
+	floor := renewalFloor
+	if ttl := s.Cfg.WebSessionTTL(); ttl <= floor {
+		floor = ttl / 2
+	}
+	if want.Sub(a.ExpiresAt) < floor {
 		return
 	}
 	if err := s.St.ExtendAuthSession(r.Context(), a.UserID, a.ID, want, now); err != nil {
@@ -578,6 +583,8 @@ func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
 		_ = s.Auth.RevokeReaderTokens(r.Context(), a.UserID)
 		_ = s.St.RevokeAuthSession(r.Context(), a.UserID, a.ID)
 	}
-	http.SetCookie(w, &http.Cookie{Name: cookieName, Value: "", MaxAge: -1})
+	http.SetCookie(w, &http.Cookie{
+		Name: cookieName, Value: "", Path: "/ui/", MaxAge: -1,
+	})
 	redirectRel(w, "./", http.StatusSeeOther)
 }

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -563,10 +563,7 @@ func (s *Server) renewSession(w http.ResponseWriter, r *http.Request, a store.Au
 	if ttl := s.Cfg.WebSessionTTL(); ttl <= floor {
 		floor = ttl / 2
 	}
-	if want.Sub(a.ExpiresAt) < floor {
-		return
-	}
-	if err := s.St.ExtendAuthSession(r.Context(), a.UserID, a.ID, want, now); err != nil {
+	if err := s.St.ExtendAuthSession(r.Context(), a.UserID, a.ID, want, want.Add(-floor), now); err != nil {
 		return
 	}
 	s.setSessionCookie(w, c.Value, want)

--- a/internal/webui/server.go
+++ b/internal/webui/server.go
@@ -410,6 +410,7 @@ func (s *Server) requireAuth(next func(http.ResponseWriter, *http.Request, store
 			redirectRel(w, relPrefix(r.URL.Path)+"login", http.StatusSeeOther)
 			return
 		}
+		s.renewSession(w, r, a)
 		next(w, withAdmin(r, s.adminFlag(r, u)), a, u)
 	}
 }
@@ -515,20 +516,55 @@ func (s *Server) startSession(w http.ResponseWriter, r *http.Request, u store.Us
 	if err := s.St.CreateAuthSession(r.Context(), store.AuthSession{
 		ID: id, UserID: u.ID, SHA256: auth.HashSecret(secret), Kind: "web",
 		CSRFHash: auth.HashSecret(csrf), CreatedAt: now,
-		ExpiresAt: now.Add(7 * 24 * time.Hour),
+		ExpiresAt: now.Add(s.Cfg.WebSessionTTL()),
 	}); err != nil {
 		return err
 	}
-	// No Path attribute: the RFC 6265 default-path (the directory of
-	// the request URL) scopes the cookie to /ui/ — or to the proxy
-	// subpath (e.g. /sync/ui/) when served under one.
+	s.setSessionCookie(w, secret, now.Add(s.Cfg.WebSessionTTL()))
+	return nil
+}
+
+// setSessionCookie is the one place the cookie's attributes are
+// written, so minting a session and extending one cannot drift apart in
+// how the browser is told to keep it.
+//
+// No Path attribute: the RFC 6265 default-path (the directory of the
+// request URL) scopes the cookie to /ui/ — or to the proxy subpath
+// (e.g. /sync/ui/) when served under one.
+func (s *Server) setSessionCookie(w http.ResponseWriter, secret string, expires time.Time) {
 	http.SetCookie(w, &http.Cookie{
 		Name: cookieName, Value: secret,
 		HttpOnly: true, SameSite: http.SameSiteStrictMode,
 		Secure:  !s.Cfg.InsecureHTTP,
-		Expires: now.Add(7 * 24 * time.Hour),
+		Expires: expires,
 	})
-	return nil
+}
+
+// renewalFloor is how far the expiry must move before a request is
+// worth a write. The window is measured in months, so refreshing it at
+// most once a day per session costs nothing a reader would notice and
+// keeps a busy tab from writing a row on every page.
+const renewalFloor = 24 * time.Hour
+
+// renewSession slides a live session's expiry forward, so that a
+// browser somebody actually reads in is never signed out while a
+// browser left alone still lapses. It is deliberately best-effort:
+// a store that refuses the update leaves the session exactly as valid
+// as it was, and a page must not fail over a housekeeping write.
+func (s *Server) renewSession(w http.ResponseWriter, r *http.Request, a store.AuthSession) {
+	c, err := r.Cookie(cookieName)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	want := now.Add(s.Cfg.WebSessionTTL())
+	if want.Sub(a.ExpiresAt) < renewalFloor {
+		return
+	}
+	if err := s.St.ExtendAuthSession(r.Context(), a.UserID, a.ID, want, now); err != nil {
+		return
+	}
+	s.setSessionCookie(w, c.Value, want)
 }
 
 func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {

--- a/internal/webui/session_test.go
+++ b/internal/webui/session_test.go
@@ -19,7 +19,7 @@ func mintSession(t *testing.T, st store.Store, id, secret string, expires time.T
 	t.Helper()
 	if err := st.CreateAuthSession(t.Context(), store.AuthSession{
 		ID: id, UserID: "u1", SHA256: auth.HashSecret(secret), Kind: "web",
-		CSRFHash: auth.HashSecret("csrf-" + id),
+		CSRFHash:  auth.HashSecret("csrf-" + id),
 		CreatedAt: time.Now(), ExpiresAt: expires,
 	}); err != nil {
 		t.Fatal(err)

--- a/internal/webui/session_test.go
+++ b/internal/webui/session_test.go
@@ -69,6 +69,9 @@ func TestSessionLifetimeIsConfigured(t *testing.T) {
 	if d := c.Expires.Sub(want); d > time.Minute || d < -time.Minute {
 		t.Fatalf("cookie expiry %v, want about %v", c.Expires, want)
 	}
+	if c.Path != "/ui/" {
+		t.Fatalf("cookie path %q, want /ui/", c.Path)
+	}
 	if got := sessionExpiry(t, st, c.Value); got.Sub(want) > time.Minute {
 		t.Fatalf("stored expiry %v, want about %v", got, want)
 	}
@@ -91,9 +94,9 @@ func TestSessionSlidesOnUse(t *testing.T) {
 	// A session near the end of its life is pushed back out, in the
 	// cookie and in the store.
 	old := mintSession(t, st, "old", "old-secret", time.Now().Add(time.Hour))
-	resp := getWithCookie(t, ts, old, "/ui/library")
-	if resp.StatusCode != 200 {
-		t.Fatalf("library: %d", resp.StatusCode)
+	resp := getWithCookie(t, ts, old, "/ui/books/missing/read")
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("reader: %d", resp.StatusCode)
 	}
 	got := sessionCookie(resp)
 	if got == nil {
@@ -110,6 +113,9 @@ func TestSessionSlidesOnUse(t *testing.T) {
 	if got.Value != old.Value {
 		t.Fatal("renewal reissued the session secret instead of extending it")
 	}
+	if got.Path != "/ui/" {
+		t.Fatalf("renewed cookie path %q, want /ui/", got.Path)
+	}
 
 	// A session renewed moments ago is left alone: the expiry would
 	// move by less than a day, which is not worth a write.
@@ -120,6 +126,22 @@ func TestSessionSlidesOnUse(t *testing.T) {
 	}
 	if c := sessionCookie(resp); c != nil {
 		t.Fatalf("a fresh session was rewritten: %+v", c)
+	}
+}
+
+// TestOneDaySessionSlides confirms the shortest accepted TTL still renews
+// before the session expires.
+func TestOneDaySessionSlides(t *testing.T) {
+	ts, st := testServerCfg(t, func(cfg *config.Config) {
+		cfg.WebSessionTTLDays = 1
+	}, nil)
+	c := mintSession(t, st, "one-day", "one-day-secret", time.Now().Add(11*time.Hour))
+	resp := getWithCookie(t, ts, c, "/ui/library")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("library: %d", resp.StatusCode)
+	}
+	if got := sessionCookie(resp); got == nil {
+		t.Fatal("a one-day session was not renewed")
 	}
 }
 

--- a/internal/webui/session_test.go
+++ b/internal/webui/session_test.go
@@ -1,0 +1,142 @@
+package webui
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/chmouel/liseur-sync/internal/auth"
+	"github.com/chmouel/liseur-sync/internal/config"
+	"github.com/chmouel/liseur-sync/internal/store"
+)
+
+// mintSession writes a web session with a chosen expiry and hands back
+// the cookie a browser holding it would send. Going through the store
+// rather than through the login form is the only way to test a session
+// that is already old.
+func mintSession(t *testing.T, st store.Store, id, secret string, expires time.Time) *http.Cookie {
+	t.Helper()
+	if err := st.CreateAuthSession(t.Context(), store.AuthSession{
+		ID: id, UserID: "u1", SHA256: auth.HashSecret(secret), Kind: "web",
+		CSRFHash: auth.HashSecret("csrf-" + id),
+		CreatedAt: time.Now(), ExpiresAt: expires,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return &http.Cookie{Name: cookieName, Value: secret}
+}
+
+// getWithCookie returns the response itself, because what this file is
+// about is a header rather than a body.
+func getWithCookie(t *testing.T, ts *httptest.Server, c *http.Cookie, path string) *http.Response {
+	t.Helper()
+	req, _ := http.NewRequest("GET", ts.URL+path, nil)
+	req.AddCookie(c)
+	resp, err := noRedirect().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	return resp
+}
+
+func sessionCookie(resp *http.Response) *http.Cookie {
+	for _, c := range resp.Cookies() {
+		if c.Name == cookieName {
+			return c
+		}
+	}
+	return nil
+}
+
+func sessionExpiry(t *testing.T, st store.Store, secret string) time.Time {
+	t.Helper()
+	a, err := st.AuthSessionByHash(t.Context(), auth.HashSecret(secret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a.ExpiresAt
+}
+
+// TestSessionLifetimeIsConfigured pins the window a fresh sign-in gets,
+// on the cookie and on the row alike, and that the setting is what
+// decides it.
+func TestSessionLifetimeIsConfigured(t *testing.T) {
+	ts, st := testServer(t)
+	c := loginCookie(t, ts)
+	want := time.Now().Add(config.Default().WebSessionTTL())
+	if d := c.Expires.Sub(want); d > time.Minute || d < -time.Minute {
+		t.Fatalf("cookie expiry %v, want about %v", c.Expires, want)
+	}
+	if got := sessionExpiry(t, st, c.Value); got.Sub(want) > time.Minute {
+		t.Fatalf("stored expiry %v, want about %v", got, want)
+	}
+
+	short, _ := testServerCfg(t, func(cfg *config.Config) { cfg.WebSessionTTLDays = 2 }, nil)
+	c = loginCookie(t, short)
+	want = time.Now().Add(2 * 24 * time.Hour)
+	if d := c.Expires.Sub(want); d > time.Minute || d < -time.Minute {
+		t.Fatalf("short cookie expiry %v, want about %v", c.Expires, want)
+	}
+}
+
+// TestSessionSlidesOnUse is the point of the long window: a browser
+// somebody reads in keeps its session, and does not pay a write per
+// page view for it.
+func TestSessionSlidesOnUse(t *testing.T) {
+	ts, st := testServer(t)
+	ttl := config.Default().WebSessionTTL()
+
+	// A session near the end of its life is pushed back out, in the
+	// cookie and in the store.
+	old := mintSession(t, st, "old", "old-secret", time.Now().Add(time.Hour))
+	resp := getWithCookie(t, ts, old, "/ui/library")
+	if resp.StatusCode != 200 {
+		t.Fatalf("library: %d", resp.StatusCode)
+	}
+	got := sessionCookie(resp)
+	if got == nil {
+		t.Fatal("a stale session was not renewed")
+	}
+	want := time.Now().Add(ttl)
+	if d := got.Expires.Sub(want); d > time.Minute || d < -time.Minute {
+		t.Fatalf("renewed cookie expiry %v, want about %v", got.Expires, want)
+	}
+	if stored := sessionExpiry(t, st, "old-secret"); stored.Sub(want) > time.Minute ||
+		want.Sub(stored) > time.Minute {
+		t.Fatalf("renewed row expiry %v, want about %v", stored, want)
+	}
+	if got.Value != old.Value {
+		t.Fatal("renewal reissued the session secret instead of extending it")
+	}
+
+	// A session renewed moments ago is left alone: the expiry would
+	// move by less than a day, which is not worth a write.
+	fresh := mintSession(t, st, "fresh", "fresh-secret", time.Now().Add(ttl-time.Hour))
+	resp = getWithCookie(t, ts, fresh, "/ui/library")
+	if resp.StatusCode != 200 {
+		t.Fatalf("library: %d", resp.StatusCode)
+	}
+	if c := sessionCookie(resp); c != nil {
+		t.Fatalf("a fresh session was rewritten: %+v", c)
+	}
+}
+
+// TestSignedOutSessionIsNotRenewed keeps renewal on the authenticated
+// side of the fence: a session that no longer signs anybody in must not
+// be handed a new expiry on its way to the login page.
+func TestSignedOutSessionIsNotRenewed(t *testing.T) {
+	ts, st := testServer(t)
+	c := mintSession(t, st, "revoked", "revoked-secret", time.Now().Add(time.Hour))
+	if err := st.RevokeAuthSession(t.Context(), "u1", "revoked"); err != nil {
+		t.Fatal(err)
+	}
+	resp := getWithCookie(t, ts, c, "/ui/library")
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("revoked session: want a bounce to login, got %d", resp.StatusCode)
+	}
+	if got := sessionCookie(resp); got != nil {
+		t.Fatalf("revoked session was renewed: %+v", got)
+	}
+}

--- a/internal/webui/session_test.go
+++ b/internal/webui/session_test.go
@@ -72,7 +72,8 @@ func TestSessionLifetimeIsConfigured(t *testing.T) {
 	if c.Path != "/ui/" {
 		t.Fatalf("cookie path %q, want /ui/", c.Path)
 	}
-	if got := sessionExpiry(t, st, c.Value); got.Sub(want) > time.Minute {
+	if got := sessionExpiry(t, st, c.Value); got.Sub(want) > time.Minute ||
+		want.Sub(got) > time.Minute {
 		t.Fatalf("stored expiry %v, want about %v", got, want)
 	}
 

--- a/internal/webui/static/style.css
+++ b/internal/webui/static/style.css
@@ -634,7 +634,6 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--primary); flex
 .auth-headline em { color: #a2e7cf; font-weight: 400; }
 .auth-story-copy { max-width: 25ch; margin: 0 0 2.5rem; color: #b0c6c7; font-size: .95rem; line-height: 1.7; }
 .auth-story-foot { margin: auto 0 0; padding-top: 1rem; font-size: .72rem; letter-spacing: .035em; color: #b0c6c7; }
-.auth-story-foot span { color: #f5d291; margin-right: .5rem; }
 .auth-panel { padding: 3.75rem 3rem; align-self: center; min-width: 0; }
 .auth-eyebrow { margin: 0 0 .85rem; color: var(--ink-dim); font-size: .68rem; font-weight: 600; letter-spacing: .15em; text-transform: uppercase; }
 .auth-panel h1 { margin: 0 0 .75rem; max-width: 14ch; font-family: ui-sans-serif, system-ui, sans-serif; font-size: 2rem; line-height: 1.18; letter-spacing: -.045em; font-weight: 650; }
@@ -669,7 +668,6 @@ input[type="checkbox"], input[type="radio"] { accent-color: var(--primary); flex
 	.auth-icon { grid-column: 1; grid-row: 1 / 3; width: 4rem; height: 4rem; margin: 0; }
 	.auth-headline, .auth-story-copy { display: none; }
 	.auth-story-foot { grid-column: 2; margin: .3rem 0 0; padding: 0; font-size: .65rem; }
-	.auth-story-foot span { display: none; }
 	.auth-panel { padding: 2rem 1.75rem; }
 	.auth-panel h1 { font-size: 1.9rem; max-width: none; }
 }

--- a/liseur-sync.example.toml
+++ b/liseur-sync.example.toml
@@ -32,6 +32,12 @@ insecure_http = false
 
 pairing_code_ttl_min = 15
 
+# How long a signed-in browser stays signed in without being used. The
+# window slides: every page view pushes it back, so a browser in regular
+# use is never signed out, and one left alone lapses after this many
+# days. Lowering it does not shorten sessions already issued.
+web_session_ttl_days = 180
+
 [database]
 driver = "sqlite"                  # sqlite | postgres
 url = "liseur-sync.db"             # sqlite path, or postgres DSN


### PR DESCRIPTION
Implemented automatic web session renewal to prevent regular readers from being signed out weekly. Added the `web_session_ttl_days` configuration option, defaulting to 180 days, which extends session expiries on authenticated requests when throttled to a daily write limit.

## Summary

<!-- What does this change do, and why? Link related issues with "Fixes #123". -->

## Changes

-

## Testing

- [ ] `go test -race ./...`
- [ ] `go vet ./...`
- [ ] `gofmt -l ./cmd ./internal` reports no files
- [ ] If `.templ` files changed: `go tool templ generate ./internal/webui/` and committed generated output
- [ ] If `docs/openapi.yaml` changed: `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish`
- [ ] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable

## Screenshots, logs, or API examples

<!-- Include relevant evidence for UI or protocol changes. Remove credentials,
tokens, private URLs, personal information, and copyrighted book files. -->

## Checklist

- [ ] I have kept this change focused and documented user-facing behavior.
- [ ] I have added or updated tests where needed.
- [ ] I have updated related API and integration documentation where needed.
- [ ] I have documented deployment or migration impact where applicable.
- [ ] I have not included secrets, private data, copyrighted book files, or generated build artifacts.
