### PR TITLE
fix: reopen a reloaded book where the reader left off

### DIFF
--- a/internal/webui/readerbrowser_ext_test.go
+++ b/internal/webui/readerbrowser_ext_test.go
@@ -118,8 +118,11 @@ func browserTestEPUB(t *testing.T) []byte {
 	if _, err := stored.Write([]byte("application/epub+zip")); err != nil {
 		t.Fatal(err)
 	}
-	body := strings.Repeat(
-		"<p>Call me Ishmael. Some years ago, never mind how long precisely.</p>\n", 60)
+	// The fortieth paragraph carries an id so a position can name it.
+	paragraph := "<p>Call me Ishmael. Some years ago, never mind how long precisely.</p>\n"
+	body := strings.Repeat(paragraph, 39) +
+		strings.Replace(paragraph, "<p>", `<p id="ishmael40">`, 1) +
+		strings.Repeat(paragraph, 20)
 	// Announced but never seen. epub.js measures the whole document, so
 	// this is what used to make a chapter forty blank pages long.
 	offscreen := `<h2 class="offscreen">Chapter heading for a screen reader</h2>`
@@ -419,65 +422,7 @@ const seededStaleOpID = "00000000-0000-4000-8000-00000000feed"
 
 func seedStalePosition(t *testing.T, base string, cookie *http.Cookie, bookID string) {
 	t.Helper()
-	req, _ := http.NewRequest(http.MethodGet, base+"/ui/books/"+bookID+"/read", nil)
-	req.AddCookie(cookie)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	raw, _ := io.ReadAll(resp.Body)
-	resp.Body.Close()
-	html := string(raw)
-	const marker = `data-csrf="`
-	i := strings.Index(html, marker)
-	if i < 0 {
-		t.Fatal("no csrf on the reader page")
-	}
-	csrf := html[i+len(marker):]
-	csrf = csrf[:strings.Index(csrf, `"`)]
-
-	// The same credential path the reader itself takes: a short-lived
-	// token from the session, then the native API with it.
-	req, _ = http.NewRequest(http.MethodPost, base+"/ui/reader/token",
-		strings.NewReader(url.Values{"csrf": {csrf}}.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.AddCookie(cookie)
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	var minted struct {
-		Token string `json:"token"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&minted); err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
-
-	api := func(path, body string) map[string]any {
-		req, _ := http.NewRequest(http.MethodPost, base+path, strings.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", "Bearer "+minted.Token)
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode >= 300 {
-			raw, _ := io.ReadAll(resp.Body)
-			t.Fatalf("%s: %d %s", path, resp.StatusCode, raw)
-		}
-		var out map[string]any
-		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-			t.Fatal(err)
-		}
-		return out
-	}
-
-	workID, _ := api("/v1/books/"+bookID+"/resolve", "{}")["work_id"].(string)
-	if workID == "" {
-		t.Fatal("the book did not resolve to a work")
-	}
+	api, workID := readerAPIFor(t, base, cookie, bookID)
 	op := map[string]any{
 		"op_id": seededStaleOpID, "work_id": workID,
 		"client_ts":   time.Now().UTC().Format(time.RFC3339),
@@ -541,6 +486,90 @@ func seedStalePosition(t *testing.T, base string, cookie *http.Cookie, bookID st
 			}
 		}
 	}
+}
+
+// seedPosition files one position op for the book the way a device
+// would, so the browser check can watch the reader reopen on it.
+func seedPosition(t *testing.T, base string, cookie *http.Cookie, bookID, opID string, progression float64, locator map[string]any) {
+	t.Helper()
+	api, workID := readerAPIFor(t, base, cookie, bookID)
+	op := map[string]any{
+		"op_id": opID, "work_id": workID,
+		"client_ts":   time.Now().UTC().Format(time.RFC3339),
+		"progression": progression,
+		"locator":     locator,
+	}
+	payload, _ := json.Marshal(map[string]any{"ops": []any{op}})
+	out := api("/v1/ops", string(payload))
+	if results, ok := out["results"].([]any); !ok || len(results) != 1 ||
+		results[0].(map[string]any)["status"] != "applied" {
+		t.Fatalf("position seeding: %v", out)
+	}
+}
+
+// readerAPIFor takes the same credential path the reader itself takes —
+// a short-lived token from the session, then the native API with it —
+// and returns a JSON POST bound to that token plus the book's work id.
+func readerAPIFor(t *testing.T, base string, cookie *http.Cookie, bookID string) (func(path, body string) map[string]any, string) {
+	t.Helper()
+	req, _ := http.NewRequest(http.MethodGet, base+"/ui/books/"+bookID+"/read", nil)
+	req.AddCookie(cookie)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	html := string(raw)
+	const marker = `data-csrf="`
+	i := strings.Index(html, marker)
+	if i < 0 {
+		t.Fatal("no csrf on the reader page")
+	}
+	csrf := html[i+len(marker):]
+	csrf = csrf[:strings.Index(csrf, `"`)]
+
+	req, _ = http.NewRequest(http.MethodPost, base+"/ui/reader/token",
+		strings.NewReader(url.Values{"csrf": {csrf}}.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.AddCookie(cookie)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var minted struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&minted); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	api := func(path, body string) map[string]any {
+		req, _ := http.NewRequest(http.MethodPost, base+path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+minted.Token)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			raw, _ := io.ReadAll(resp.Body)
+			t.Fatalf("%s: %d %s", path, resp.StatusCode, raw)
+		}
+		var out map[string]any
+		if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+			t.Fatal(err)
+		}
+		return out
+	}
+
+	workID, _ := api("/v1/books/"+bookID+"/resolve", "{}")["work_id"].(string)
+	if workID == "" {
+		t.Fatal("the book did not resolve to a work")
+	}
+	return api, workID
 }
 
 // TestReaderOpensInARealBrowser is the only test that can judge whether
@@ -825,6 +854,118 @@ func TestReaderRefusesANaNPositionButRecovers(t *testing.T) {
 	if !recovered {
 		t.Error("the finite position pushed after the NaN never reached the op log")
 	}
+}
+
+// reopenCheck seeds one stored position for alice, opens the book in a
+// browser and runs testdata/readerreload.mjs against it with the given
+// expectations (RELOAD_* variables).
+func reopenCheck(t *testing.T, opID string, progression float64, locator map[string]any, expect ...string) {
+	t.Helper()
+	chrome := findChrome()
+	if chrome == "" {
+		t.Skip("no chromium; set LISEUR_CHROME to run the browser check")
+	}
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("no node to drive the browser with")
+	}
+
+	parallelBrowser(t)
+	f := newBooksFixture(t)
+	bookID := f.addBook(t, "novel", browserTestEPUB(t))
+
+	ts := httptest.NewUnstartedServer(nil)
+	wholeServer(t, f, ts, "")
+	cookie := f.loginTo(t, ts, "alice")
+	seedPosition(t, ts.URL, cookie, bookID, opID, progression, locator)
+
+	cmd := exec.Command(node, filepath.Join("testdata", "readerreload.mjs"))
+	cmd.Env = append(append(os.Environ(),
+		"SMOKE_CHROME="+chrome,
+		"SMOKE_URL="+ts.URL+"/ui/books/"+bookID+"/read",
+		"SMOKE_COOKIE="+cookie.Name+"="+cookie.Value,
+		"SMOKE_HOST="+strings.TrimPrefix(ts.URL, "http://"),
+	), expect...)
+	out, err := cmd.CombinedOutput()
+	t.Logf("%s", out)
+	if err != nil {
+		t.Fatalf("the reader did not reopen where it should have: %v", err)
+	}
+}
+
+// TestReaderReopensWhereItWasAfterAReload is the check the other
+// browser tests never make: they open a book once. A reload is where a
+// stored position is read back and handed to the engine's first load,
+// and that load looks its starting locator up in the position list by
+// `position` — a number another client, or a regenerated list, spells
+// differently. The seeded op carries a foreign one and no CFI, which is
+// exactly what every position written since the reader switched to
+// Readium's positions looks like; a reader that trusted it, or dropped
+// it and let the load throw, opened every reloaded book at page one.
+func TestReaderReopensWhereItWasAfterAReload(t *testing.T) {
+	// Spine slot 3 is chapter3; 812 is a page count from some other list.
+	reopenCheck(t, "00000000-0000-4000-8000-00000000c0de", 0.3,
+		map[string]any{
+			"href": "OEBPS/chapter3.xhtml", "type": "application/xhtml+xml",
+			"locations": map[string]any{
+				"fragments": []string{}, "progression": 0, "totalProgression": 0.3, "position": 812,
+			},
+		},
+		"RELOAD_SECTION=3", "RELOAD_RELOAD=1")
+}
+
+// TestReaderReopensByFractionAlone is the last rung of the ladder: a
+// position whose chapter this copy of the book does not have — another
+// edition's file name — leaves only the fraction of the whole, and the
+// locator the reader builds from it has no `position` either. It has to
+// open the chapter that fraction falls in, not page one.
+func TestReaderReopensByFractionAlone(t *testing.T) {
+	reopenCheck(t, "00000000-0000-4000-8000-00000000f4ac", 0.3,
+		map[string]any{
+			"href": "OEBPS/elsewhere.xhtml", "type": "application/xhtml+xml",
+			"locations": map[string]any{
+				"fragments": []string{}, "progression": 0.5, "totalProgression": 0.3, "position": 812,
+			},
+		},
+		"RELOAD_SECTION=3")
+}
+
+// TestReaderReopensOnTheQuotedPassage pins the finer half of a restore:
+// a position that quotes the passage on screen — the shape both this
+// reader and the app write (reader-anchor.js) — reopens on that
+// passage, not merely at the progression beside it. The seeded op says
+// the start of the chapter by progression and its fortieth paragraph by
+// quote, in the app's spelling of the href, and the quote must win.
+func TestReaderReopensOnTheQuotedPassage(t *testing.T) {
+	reopenCheck(t, "00000000-0000-4000-8000-00000000a11c", 0.1,
+		map[string]any{
+			"href": "/OEBPS/chapter1.xhtml", "type": "application/xhtml+xml",
+			"locations": map[string]any{
+				"fragments": []string{}, "progression": 0, "totalProgression": 0.1, "position": 812,
+				"liseurAnchor": 1,
+				"cssSelector":  "body > div:nth-of-type(1) > div:nth-of-type(1) > p:nth-of-type(40)",
+			},
+			"text": map[string]any{
+				"before": "", "highlight": "Call me Ishmael", "after": ". Some years ago, never mind",
+			},
+		},
+		"RELOAD_SECTION=1", "RELOAD_INSIDE=1")
+}
+
+// TestReaderReopensOnTheNamedFragment is the same promise for a
+// position that names an element instead of quoting one, with the
+// fragment spelled on the href the way a link does. The restore ladder
+// canonicalizes the href against this book's spine; the fragment must
+// survive that and choose the page.
+func TestReaderReopensOnTheNamedFragment(t *testing.T) {
+	reopenCheck(t, "00000000-0000-4000-8000-00000000f7a6", 0.1,
+		map[string]any{
+			"href": "OEBPS/chapter1.xhtml#ishmael40", "type": "application/xhtml+xml",
+			"locations": map[string]any{
+				"fragments": []string{}, "progression": 0, "totalProgression": 0.1, "position": 812,
+			},
+		},
+		"RELOAD_SECTION=1", "RELOAD_INSIDE=1")
 }
 
 // TestReaderRecordsReadingSessions is the browser side of ADR-0030: a

--- a/internal/webui/static/reader-engine.js
+++ b/internal/webui/static/reader-engine.js
@@ -150,10 +150,41 @@ export class ReaderEngine extends HTMLElement {
       tap: () => true,
       click: () => true,
       handleLocator: () => false,
-    }, this.positionList, target, { preferences: this.preferences, defaults: {} });
+    }, this.positionList, this.positioned(target), { preferences: this.preferences, defaults: {} });
     try { await this.navigator.load(); }
     catch (error) { await this.navigator.destroy(); this.navigator = null; throw error; }
     this.relocate(this.navigator.currentLocator);
+    // The first load shows the resource at its progression and nothing
+    // finer. A locator that quotes the passage, or names a fragment, is
+    // then walked the way any navigation is: that is the path where the
+    // navigator searches the quote inside its block. The progression
+    // page is already on screen, so a quote that is not found costs
+    // nothing.
+    if (target.text?.highlight || target.locations.fragments?.length) {
+      await this.navigate(target).catch(() => {});
+    }
+  }
+
+  // positioned keys a locator by this publication's own position list.
+  //
+  // The navigator's first load looks its starting locator up in that
+  // list by `locations.position`, and throws when nothing matches. Only
+  // the resource is decided by that lookup — the page inside it comes
+  // from `locations.progression` — so the position is taken from the
+  // list's entry for the locator's resource, never from the locator
+  // itself: another client's position counts pages by its own toolkit's
+  // reckoning, and a locator built from a fraction or a bare href never
+  // had one.
+  positioned(locator) {
+    const href = locator.href.split("#")[0];
+    const own = this.positionList.filter(entry => entry.href === href);
+    if (!own.length) return locator;
+    const progression = locator.locations.progression || 0;
+    let entry = own[0];
+    for (const candidate of own) {
+      if ((candidate.locations.progression || 0) <= progression) entry = candidate;
+    }
+    return locator.copyWithLocations({ position: entry.locations.position });
   }
 
   relocate(locator) {

--- a/internal/webui/static/reader-restore.js
+++ b/internal/webui/static/reader-restore.js
@@ -1,8 +1,9 @@
 // Where to reopen a book, given what some client wrote down about where
 // its reader was.
 //
-// The clients do not agree on much. This reader records a CFI and a
-// spine index; the Android app records a resource, a fraction of that
+// The clients do not agree on much. This reader records a resource, a
+// fraction of that resource and a page number from the list it was
+// served; the Android app records a resource, a fraction of that
 // resource, and sometimes a quote of the passage on screen. The one
 // thing everything writes is a fraction of the whole book — and that is
 // the least useful of them, because the two clients do not compute it
@@ -101,16 +102,22 @@ export function startCandidates(op, view) {
       const locator = structuredClone(op.locator);
       locator.href = href;
       locator.locations = { ...locations };
-      // This reader writes `position` as the spine index plus one, and
-      // relies on it to reopen a page it saved with no CFI. The app on
-      // a phone writes Readium's synthetic position into the same field
-      // — a count of pages through the whole book, which indexes into
-      // somewhere else entirely here. The field is kept only while it
-      // still says what this reader means by it, which a foreign one
-      // will not. The resource and the progression within it are what
-      // travel between clients.
-      const spine = (view.sections || []).findIndex((s) => s && s.id === href);
-      if (locator.locations.position !== spine + 1) delete locator.locations.position;
+      // `position` is a count of pages through the whole book, and the
+      // count is the writing toolkit's: the app on a phone numbers the
+      // same book differently from the list this reader was served,
+      // and even this reader's own number is only good against the
+      // list it had that day. The engine keys the open by its own list
+      // and the resource named here; the resource and the progression
+      // within it are what travel between clients.
+      delete locator.locations.position;
+      // A fragment spelled on the href names an element in the chapter,
+      // and the engine looks for one in `fragments`; carry it there
+      // rather than lose it with the spelling.
+      const hash = op.locator.href.indexOf("#");
+      if (hash >= 0 && hash < op.locator.href.length - 1 && !cfiOf(op) &&
+          !(Array.isArray(locator.locations.fragments) && locator.locations.fragments.length)) {
+        locator.locations.fragments = [op.locator.href.slice(hash + 1)];
+      }
       out.push(locator);
     }
   }

--- a/internal/webui/testdata/readerreload.mjs
+++ b/internal/webui/testdata/readerreload.mjs
@@ -1,0 +1,192 @@
+// Reopening a book where it was: drives real Chromium over CDP through
+// the one thing readerbrowser.mjs never does, a page reload.
+//
+// The Go side files a position before the browser opens. This opens the
+// reader on it and checks the section it lands in (and, when asked, that
+// it is not the section's first page — the quoted passage, not the
+// progression, decided). It then reads on, waits for the page to be
+// acknowledged, reloads like F5, and checks the reader comes back to the
+// same page. Neither open may push a position: a restored page is never
+// published.
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const chrome = process.env.SMOKE_CHROME;
+const url = process.env.SMOKE_URL;
+const cookie = process.env.SMOKE_COOKIE;
+const host = process.env.SMOKE_HOST;
+// The spine index the seeded position names.
+const expectSection = Number(process.env.RELOAD_SECTION);
+// Whether the seeded position must reopen past the section's first page.
+const expectInside = process.env.RELOAD_INSIDE === '1';
+// Whether to read on and reload.
+const doReload = process.env.RELOAD_RELOAD === '1';
+
+const profile = mkdtempSync(join(tmpdir(), 'reload-'));
+const proc = spawn(chrome, [
+  '--headless=new', '--disable-gpu', '--no-sandbox', '--window-size=800,600',
+  '--remote-debugging-port=0', `--user-data-dir=${profile}`, 'about:blank',
+], { stdio: ['ignore', 'ignore', 'pipe'] });
+const removeProfile = () => {
+  try { rmSync(profile, { recursive: true, force: true, maxRetries: 3 }); } catch { /* best effort */ }
+};
+process.on('exit', () => { proc.kill(); removeProfile(); });
+const finish = async (code) => {
+  proc.kill();
+  await new Promise((resolve) => {
+    const guard = setTimeout(resolve, 4000);
+    proc.once('close', () => { clearTimeout(guard); resolve(); });
+  });
+  removeProfile();
+  process.exit(code);
+};
+process.on('uncaughtException', (e) => { console.error(e); finish(1); });
+process.on('unhandledRejection', (e) => { console.error(e); finish(1); });
+
+const wsURL = await new Promise((resolve, reject) => {
+  let buf = '';
+  const timer = setTimeout(() => reject(new Error('no devtools url: ' + buf)), 20000);
+  proc.stderr.on('data', (d) => {
+    buf += d;
+    const m = buf.match(/ws:\/\/[^\s]+/);
+    if (m) { clearTimeout(timer); resolve(m[0]); }
+  });
+});
+const ws = new WebSocket(wsURL);
+await new Promise((resolve) => ws.addEventListener('open', resolve, { once: true }));
+let nextID = 0;
+const pending = new Map();
+const consoleErrors = [];
+ws.addEventListener('message', (ev) => {
+  const msg = JSON.parse(ev.data);
+  if (msg.id && pending.has(msg.id)) {
+    const { resolve, reject } = pending.get(msg.id);
+    pending.delete(msg.id);
+    msg.error ? reject(new Error(JSON.stringify(msg.error))) : resolve(msg.result);
+    return;
+  }
+  if (msg.method === 'Runtime.exceptionThrown') {
+    consoleErrors.push(JSON.stringify(msg.params.exceptionDetails).slice(0, 400));
+  }
+});
+function send(method, params = {}, sessionId) {
+  const id = ++nextID;
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => { pending.delete(id); reject(new Error('CDP timeout: ' + method)); }, 15000);
+    pending.set(id, {
+      resolve: (v) => { clearTimeout(timer); resolve(v); },
+      reject: (e) => { clearTimeout(timer); reject(e); },
+    });
+    ws.send(JSON.stringify({ id, method, params, sessionId }));
+  });
+}
+const { targetId } = await send('Target.createTarget', { url: 'about:blank' });
+const { sessionId } = await send('Target.attachToTarget', { targetId, flatten: true });
+const S = (m, p) => send(m, p, sessionId);
+await S('Page.enable');
+await S('Runtime.enable');
+await S('Network.enable');
+const [name, value] = cookie.split('=');
+await S('Network.setCookie', { name, value, domain: host.split(':')[0], path: '/' });
+
+// Every document this tab loads — including the one after the reload —
+// records the positions it pushes and which of them the server took.
+await S('Page.addScriptToEvaluateOnNewDocument', { source: `(() => {
+  const original = window.fetch;
+  window.__pushed = []; window.__delivered = [];
+  window.fetch = async function (input, init = {}) {
+    const url = typeof input === 'string' ? input : input.url;
+    const ops = url.endsWith('v1/ops') && init.body ? (JSON.parse(init.body).ops || []) : [];
+    for (const op of ops) window.__pushed.push({ op_id: op.op_id, progression: op.progression });
+    const resp = await original.call(this, input, init);
+    if (ops.length && resp.ok) for (const op of ops) window.__delivered.push(op.op_id);
+    return resp;
+  };
+})()` });
+
+const evalIn = async (expr) => {
+  const r = await S('Runtime.evaluate', { expression: expr, awaitPromise: true, returnByValue: true });
+  if (r.exceptionDetails) throw new Error('eval threw: ' + JSON.stringify(r.exceptionDetails));
+  return r.result.value;
+};
+const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+async function waitFor(expression, description, timeout = 15000) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    if (await evalIn(expression)) return;
+    await pause(50);
+  }
+  throw new Error('Timed out waiting for ' + description);
+}
+const opened = `(() => {
+  const view = document.querySelector('readium-view');
+  return Number.isFinite(view?.lastLocation?.fraction) &&
+    view?.renderer?.getContents?.().some(({ doc }) => doc?.body) &&
+    document.getElementById('reader-status')?.textContent === '';
+})()`;
+const where = async () => JSON.parse(await evalIn(`(() => {
+  const l = document.querySelector('readium-view').lastLocation;
+  return JSON.stringify({
+    fraction: l.fraction, section: l.section?.current, sectionFraction: l.sectionFraction,
+    page: document.getElementById('reader-page')?.textContent,
+  });
+})()`));
+
+const fail = [];
+const check = (name, ok, extra = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${extra ? ' — ' + extra : ''}`);
+  if (!ok) fail.push(name);
+};
+
+await S('Page.navigate', { url });
+await waitFor(opened, 'the publication to open');
+// The open settles: a restore that walks a quote arrives a beat later.
+await pause(1500);
+const first = await where();
+check('the seeded position reopens in its section', first.section === expectSection,
+  JSON.stringify(first));
+if (expectInside) {
+  // The seeded progression says the start of the chapter; the anchor
+  // names its fortieth paragraph of sixty. Landing past the middle can
+  // only be the anchor's doing.
+  check('the anchor, not the progression, chose the page', first.sectionFraction >= 0.5,
+    JSON.stringify(first));
+}
+check('opening pushed no position', (await evalIn('window.__pushed.length')) === 0);
+
+if (doReload) {
+  // Read on the way a reader does — a key, then pages — so the new page
+  // is this device's own and is filed.
+  await evalIn(`document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight' })); true`);
+  for (let i = 0; i < 2; i++) {
+    await evalIn("document.getElementById('reader-next').click()");
+    await pause(700);
+  }
+  // The page on screen must be the one the server took, or the reload
+  // is asked to restore a page that was never filed.
+  await waitFor(`window.__pushed.length > 0 &&
+    window.__delivered.includes(window.__pushed.at(-1).op_id) &&
+    window.__pushed.at(-1).progression === document.querySelector('readium-view').lastLocation.fraction`,
+  'the page on screen to be acknowledged');
+  await pause(500);
+  const before = await where();
+  check('reading on moved the page', before.fraction > first.fraction, JSON.stringify(before));
+
+  await S('Page.reload', { ignoreCache: false });
+  await pause(500);
+  await waitFor(opened, 'the publication to reopen after the reload', 20000);
+  await pause(1500);
+  const after = await where();
+  check('the reload reopens on the page being read',
+    Math.abs(after.fraction - before.fraction) < 0.005,
+    `before ${JSON.stringify(before)} after ${JSON.stringify(after)}`);
+  await pause(2000);
+  check('reopening pushed no position', (await evalIn('window.__pushed.length')) === 0,
+    await evalIn('JSON.stringify(window.__pushed)'));
+}
+
+check('no uncaught errors', consoleErrors.length === 0, consoleErrors.join(' | '));
+ws.close();
+await finish(fail.length ? 1 : 0);

--- a/internal/webui/testdata/readerrestore.test.mjs
+++ b/internal/webui/testdata/readerrestore.test.mjs
@@ -79,23 +79,51 @@ test("the chapter is tried before the fraction", () => {
 
 test("another client's page number does not come along", () => {
   // 812 is Readium's synthetic position on a phone: a count of pages
-  // through the whole book. This reader means the spine index by that
-  // field, so a foreign one indexes into somewhere else entirely.
+  // through the whole book by the phone's reckoning, which is not the
+  // list this reader was served. The engine keys the open by its own
+  // list and the resource named here.
   const out = startCandidates(phoneOp(), view());
   assert.equal("position" in out[0].locations, false);
 });
 
-test("this reader's own spine index survives, because it means that", () => {
-  // A page saved here with no CFI reopens on it.
+test("this reader's own page number does not come along either", () => {
+  // A page saved here carries the position the list of that day gave
+  // it. A list can be regenerated; the resource and the progression
+  // within it are what reopen the page, whoever wrote them.
   const own = phoneOp({
     edition_sha: undefined,
     locator: {
       href: "OEBPS/ch2 the%20long one.xhtml",
-      locations: { progression: 0.74, totalProgression: 0.31, position: 3 },
+      locations: { progression: 0.74, totalProgression: 0.31, position: 285 },
     },
   });
   const out = startCandidates(own, view());
-  assert.equal(out[0].locations.position, 3);
+  assert.equal("position" in out[0].locations, false);
+  assert.equal(out[0].locations.progression, 0.74);
+});
+
+test("a fragment spelled on the href is kept as a fragment", () => {
+  // The href is canonicalized to this book's spelling, which drops the
+  // fragment; an element it named must still be there for the engine
+  // to walk to.
+  const out = startCandidates(
+    phoneOp({ locator: { href: "/OEBPS/ch2 the%20long one.xhtml#p42", locations: {} } }),
+    view(),
+  );
+  assert.equal(out[0].href, "OEBPS/ch2 the%20long one.xhtml");
+  assert.deepEqual(out[0].locations.fragments, ["p42"]);
+  // A CFI already in `fragments` is the finer pointer and is left alone.
+  const cfi = startCandidates(
+    phoneOp({
+      locator: {
+        href: "/OEBPS/ch2 the%20long one.xhtml#p42",
+        locations: { fragments: ["epubcfi(/6/4!/4/2)"] },
+      },
+    }),
+    view(),
+  );
+  assert.equal(cfi[0], "epubcfi(/6/4!/4/2)");
+  assert.deepEqual(cfi[1].locations.fragments, ["epubcfi(/6/4!/4/2)"]);
 });
 
 test("a position in another edition falls to the fraction", () => {
@@ -202,7 +230,7 @@ test("an op the phone actually wrote climbs the ladder here", () => {
   assert.equal(cfiOf(fromPhone), null);
   assert.equal(out[0].href, "OEBPS/ch1.xhtml");
   assert.equal(out[0].locations.progression, 0.74);
-  // 812 is a page number in the phone's book, and spine slot 812 here.
+  // 812 is a page number in the phone's book, not in this list.
   assert.equal(out[0].locations.position, undefined);
   // The anchor is carried through untouched for the engine to walk.
   assert.equal(out[0].locations.cssSelector, "body > p:nth-of-type(3)");


### PR DESCRIPTION
## Summary

Reloading the web reader, or opening a book in a new tab, has sent the book back to page 1 since 69e4ad1. The saved position was on the server the whole time; the reader failed to apply it on a fresh load. Page turns, the table of contents and the "go there" prompt still worked, so only a reload showed it.

Cause: 69e4ad1 dropped the saved `position` from every restored locator because the phone app and this reader count pages differently. The vendored Readium navigator requires a `position` from its own position list on the *first* load and throws without one. Every rung of the restore ladder failed silently and the book opened at the first position. In-page navigation uses a different path that does not need it, which is why only the initial load broke. The small test fixture (13 positions, 13 spine items) hid this because there `position` happened to equal `spine + 1`.

## Changes

- The engine keys its starting locator by the book's own position list (chapter href, then the largest progression at or below the saved one), so the first load can no longer fail for want of a `position`.
- After that load, a locator that quotes the passage or names a fragment is walked with `navigate()`, the path where Readium searches the quote inside its CSS selector. A book synced from the phone reopens on the sentence being read, not only on the right page.
- The restore ladder always drops the incoming `position` (it was another toolkit's count, or this reader's earlier list) and now carries a `#fragment` spelled on the href into `locations.fragments`.
- Browser tests that actually reload: restore across a reload, restore from the fraction alone, restore onto a quoted passage, restore onto a named element.

| Book, saved position | Before | After |
|---|---|---|
| Production EPUB (761 positions), reader's own op | 1 of 761 | 285 of 761 |
| Same book, phone's op newest | 1 of 761 | 287 of 761 |
| Progression deliberately wrong, quoted passage right | 1 of 761 | 285 of 761 |

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [ ] If `.templ` files changed: `go tool templ generate ./internal/webui/` and committed generated output (no `.templ` change)
- [ ] If `docs/openapi.yaml` changed: `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish` (no API change)
- [x] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable

## Screenshots, logs, or API examples

Headless Chromium against the production book and its real op shape, before the fix:

```
readium-view.init: Locator not found in position list: undefined > 761
```

After: `{"page":"285 of 761","fraction":0.373,"section":37}`.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed. (none affected: browser-side only)
- [x] I have documented deployment or migration impact where applicable. (none: static JS only, no migration)
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.