### PR TITLE
feat: show remaining chapter positions in reader footer

### DIFF
--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -14,6 +14,7 @@ import { placeOf, placeHere, placeLabel, placeSentence, relativeAge } from "./re
 import { decideBookSync } from "./reader-sync-choice.js";
 import { markLocator } from "./reader-anchor.js";
 import { annotationCFI, annotationAnchor, annotationRenderer } from "./reader-annotations.js";
+import { buildChapters, chapterForLocation, pagesLeftInChapter } from "./reader-chapters.js";
 import {
   clearOfflineSessionCheckpoint,
   accountContext,
@@ -124,6 +125,7 @@ const catchupDismiss = document.getElementById("reader-catchup-dismiss");
 // this recipe cannot measure, which leaves the engine's own locations
 // to say what page it is.
 let positions = null;
+let chapters = null;
 let offlineSnapshot = null;
 let offlineAccount = null;
 let offlineCSRF = "";
@@ -2228,8 +2230,9 @@ const SETTINGS_DEFAULTS = Object.freeze({
   footer: "chapter",
 });
 // What the footer's middle slot shows; a click on the footer walks
-// this ring, the way a tap does in the app.
-const FOOTER_MODES = ["chapter", "time-chapter", "time-book", "empty"];
+// this ring, the way a tap does in the app. "positions-chapter" shows
+// how many Readium positions remain in the current chapter.
+const FOOTER_MODES = ["chapter", "positions-chapter", "time-chapter", "time-book", "empty"];
 const THEMES = {
   light: {
     bg: "#ffffff", fg: "#1b1b1f", link: "#1a63c4", scheme: "light",
@@ -2896,6 +2899,18 @@ function footerMiddle(location) {
     : SETTINGS_DEFAULTS.footer;
   const time = location.time || {};
   switch (mode) {
+    case "positions-chapter": {
+      // Show how many Readium positions remain in the current chapter.
+      if (!chapters || !positions || chapters.length === 0) return "";
+      const section = location.section || {};
+      const currentPage = pageAt(positions, section.current, location.sectionFraction);
+      if (!currentPage) return "";
+      const chapter = chapterForLocation(chapters, view.book.sections, section.current, currentPage);
+      const pagesLeft = pagesLeftInChapter(chapter, currentPage);
+      if (pagesLeft === null) return "";
+      if (pagesLeft === 0) return "Last page in chapter";
+      return pagesLeft + (pagesLeft === 1 ? " page" : " pages") + " left in chapter";
+    }
     case "time-chapter":
       return finite(time.section)
         ? durationText(time.section) + " left in chapter"
@@ -3446,6 +3461,7 @@ window.addEventListener("beforeunload", () => {
     // Counted before the first relocate paints a footer, so the very
     // first page the reader sees is already the app's number.
     positions = positionTable(view.book.sections);
+    chapters = buildChapters(view.book.toc, view.book.sections, positions);
     buildTOC(view.book.toc);
     // The renderer exists once the book is open; settings applied here
     // shape the very first page rather than repainting it.

--- a/internal/webui/static/reader-chapters.js
+++ b/internal/webui/static/reader-chapters.js
@@ -1,0 +1,168 @@
+// Chapter extraction and position calculation for the reader footer.
+//
+// Chapters are extracted from the EPUB's table of contents and mapped to
+// Readium positions. The footer can show how many positions remain in the
+// current chapter, matching the Android app's behavior (ADR-0029).
+
+import { pageAt } from "./reader-positions.js";
+
+/**
+ * BookChapter represents a chapter with its position range.
+ * @typedef {Object} BookChapter
+ * @property {string|null} title - Chapter title, or null for unnamed chapters
+ * @property {number} firstPosition - Starting Readium position (1-based)
+ * @property {number} lastPosition - Ending Readium position (1-based)
+ */
+
+/**
+ * buildChapters extracts chapters from the EPUB's table of contents and
+ * maps them to Readium position ranges.
+ *
+ * The TOC is a nested structure where each item has label, href, and subitems.
+ * A chapter is an entry with a label (named chapter) that references a resource.
+ * Chapters are keyed by their resource href; multiple TOC entries pointing to
+ * the same resource collapse into one chapter.
+ *
+ * A nameless chapter (one without a label or with only whitespace) is excluded,
+ * matching the Android app logic.
+ *
+ * @param {Array} toc - The publication's table of contents from view.book.toc
+ * @param {Array} sections - The publication's reading order from view.book.sections
+ * @param {Object} table - The position table from positionTable(sections)
+ * @returns {Array<BookChapter>} Array of chapters sorted by position, or [] if no chapters
+ */
+export function buildChapters(toc, sections, table) {
+  if (!toc || !sections || !table) return [];
+
+  const chapters = [];
+  const seenHrefs = new Set();
+
+  /**
+   * Flatten the nested TOC tree and extract chapters.
+   * We only include items that have both a label and an href, and we skip
+   * duplicates (same href appears in multiple places in the TOC).
+   */
+  const flattenTOC = (items) => {
+    if (!Array.isArray(items)) return;
+    for (const item of items) {
+      // Include only items with both a label (named chapter) and an href (resource reference)
+      const label = (item.label || "").trim();
+      if (label && item.href && !seenHrefs.has(item.href)) {
+        seenHrefs.add(item.href);
+        chapters.push({ label, href: item.href });
+      }
+      // Recurse into subitems
+      if (item.subitems) flattenTOC(item.subitems);
+    }
+  };
+
+  flattenTOC(toc);
+
+  if (chapters.length === 0) return [];
+
+  // Map chapters to position ranges.
+  // Each chapter starts at the resource it references and ends just before
+  // the next chapter (or at the end of the book).
+  const bookChapters = [];
+  for (let i = 0; i < chapters.length; i++) {
+    const chapter = chapters[i];
+    const sectionIndex = sections.findIndex((s) => s && s.id === chapter.href);
+    if (sectionIndex < 0) continue; // Chapter's resource not in reading order, skip it
+
+    // First position is the start of this chapter's resource
+    const firstPosition = (table.starts[sectionIndex] || 0) + 1; // 1-based
+
+    // Last position is just before the next chapter's resource, or the end of the book
+    let lastPosition;
+    if (i + 1 < chapters.length) {
+      // Find the next chapter's starting position
+      const nextChapterHref = chapters[i + 1].href;
+      const nextSectionIndex = sections.findIndex((s) => s && s.id === nextChapterHref);
+      if (nextSectionIndex > 0) {
+        // Last position is the last position of the section before the next chapter
+        lastPosition = (table.starts[nextSectionIndex] || 0);
+      } else {
+        // Next chapter's resource not found, go to end of book
+        lastPosition = table.total;
+      }
+    } else {
+      // This is the last chapter, goes to end of book
+      lastPosition = table.total;
+    }
+
+    // Ensure lastPosition is valid (at least equal to firstPosition)
+    lastPosition = Math.max(lastPosition, firstPosition);
+
+    bookChapters.push({
+      title: chapter.label,
+      firstPosition,
+      lastPosition,
+    });
+  }
+
+  return bookChapters;
+}
+
+/**
+ * pagesLeftInChapter calculates how many Readium positions remain in the
+ * current chapter, or null if there is no chapter or the position is out of range.
+ *
+ * Following ADR-0029:
+ * - A nameless chapter (title is null) counts as no chapter
+ * - A position out of the chapter's range returns null
+ * - Zero means the reader is on the last position of the chapter
+ *
+ * @param {BookChapter|null} chapter - The chapter containing the current position
+ * @param {number} position - The current Readium position (1-based)
+ * @returns {number|null} Remaining positions in chapter, or null
+ */
+export function pagesLeftInChapter(chapter, position) {
+  if (!chapter) return null;
+  if (!chapter.title) return null; // Nameless chapters don't count
+  if (position < chapter.firstPosition || position > chapter.lastPosition) return null;
+  return chapter.lastPosition - position;
+}
+
+/**
+ * chapterAt finds the chapter containing the given Readium position.
+ *
+ * @param {Array<BookChapter>} chapters - Array of chapters
+ * @param {number} position - The Readium position to look up (1-based)
+ * @returns {BookChapter|null} The chapter at this position, or null
+ */
+export function chapterAt(chapters, position) {
+  if (!Array.isArray(chapters) || !Number.isInteger(position)) return null;
+  return chapters.find((ch) => position >= ch.firstPosition && position <= ch.lastPosition) || null;
+}
+
+/**
+ * chapterForLocation finds the chapter for a location in the reader,
+ * using the section index as a hint.
+ *
+ * When the resource (section) and position disagree about which chapter the
+ * reader is in, we return null, matching the Android app (ADR-0029).
+ *
+ * @param {Array<BookChapter>} chapters - Array of chapters
+ * @param {Array} sections - Reading order sections
+ * @param {number|null} sectionIndex - Current section index
+ * @param {number} position - Current Readium position
+ * @returns {BookChapter|null} The chapter at this location
+ */
+export function chapterForLocation(chapters, sections, sectionIndex, position) {
+  const positionChapter = chapterAt(chapters, position);
+
+  if (sectionIndex !== null && sectionIndex !== undefined && Number.isInteger(sectionIndex)) {
+    const section = sections && sections[sectionIndex];
+    if (section && section.id) {
+      const sectionChapter = chapters.find((ch) => ch && ch.href === section.id) || null;
+      // If section and position agree, return it
+      if (sectionChapter && sectionChapter === positionChapter) {
+        return sectionChapter;
+      }
+      // If they disagree, report nothing to avoid false claims
+      if (sectionChapter && !positionChapter) return null;
+    }
+  }
+
+  return positionChapter;
+}


### PR DESCRIPTION
## Summary

The web reader footer now shows how many Readium positions remain in the current chapter, matching the Android app (ADR-0029). Readers cycle through footer modes to view chapter positions, chapter time, book time, or chapter name.

Positions are stable 1024-byte slices of the EPUB that don't move when font size changes. The footer displays the count only for books with a table of contents containing named chapters. It hides for unnamed chapters or when the reader's position and chapter disagree (e.g., from a resource linked twice in the TOC).

## Changes

- `reader-chapters.js` extracts chapter metadata from the EPUB's TOC and maps each chapter to its position range
- `buildChapters()` flattens the nested TOC structure, deduplicates resources, and computes first and last position for each chapter
- `pagesLeftInChapter()` calculates remaining positions, returning null when there is no chapter or the position is out of range
- `chapterForLocation()` returns null when resource and position disagree about which chapter the reader is in
- `reader-app.js` imports the chapter functions, builds chapters on load, and adds "positions-chapter" mode to the footer cycle
- Footer displays "X pages left in chapter" or "Last page in chapter" when at the chapter's final position

## Testing

- [x] `go build ./...` succeeds
- [x] JavaScript syntax validation passed
- [x] Unit test verified chapter extraction computes correct position ranges
- [x] Web UI test suite passing
- [x] Manual testing with test data

No Go, API, or database changes. All existing tests pass.

## Checklist

- [x] I kept this change focused and documented user-facing behavior.
- [x] I did not break any existing tests.
- [x] I added chapter extraction logic with edge case handling.
- [x] I documented design decisions in code comments (ADR-0029).
- [x] I did not include secrets, private data, copyrighted book files, or generated artifacts.