### PR TITLE
Quote a whole passage when offering another device's page

### DIFF
--- a/docs/adr/0040-asking-rather-than-waiting-to-be-asked.md
+++ b/docs/adr/0040-asking-rather-than-waiting-to-be-asked.md
@@ -83,11 +83,20 @@ position *is*:
 - **How long ago.** A clock is not evidence about which position is
   right — that is decided by movement away from an agreed baseline, and
   never here — but it is what lets a reader recognise their own evening.
-- **The passage that was on screen**, from `locator.text.highlight`,
-  which `reader-anchor.js` already writes in exactly the shape Android's
-  `ExactLocatorAnchor` reads. It is another device's text: it is set as
-  a text node, capped by the presenter and clamped to two lines, because
-  a partner sending a chapter must not push the buttons off the screen.
+- **The passage that was on screen**, from the three text fields
+  `reader-anchor.js` writes in exactly the shape Android's
+  `ExactLocatorAnchor` reads: the words before the first visible word,
+  that word, and the words after it, read back as one passage the way
+  `ExactLocatorAnchor.excerpt` reads them. `highlight` alone is a single
+  word by construction — that is what an anchor pins — and a single word
+  places nobody. Showing more of the page by *capturing* more is not the
+  lever it looks like: the phone compares the three fields verbatim to
+  decide two devices are on the same spot, so a client that captured a
+  longer `after` would never agree with one that did not. The fields are
+  a wire contract; how much of them a reader is shown is not. It is
+  another device's text: it is set as a text node, capped by the
+  presenter and clamped to two lines, because a partner sending a
+  chapter must not push the buttons off the screen.
 
 **The catch-up panel gains those three facts** and changes nothing else:
 it still appears only at a quiet moment, and either answer still settles
@@ -118,7 +127,13 @@ navigator, database or server in sight:
 
 That last one is worth its own words. Two identical page numbers over
 two different buttons is a riddle, and the excerpt is the only thing
-that tells the sides apart.
+that tells the sides apart. So the dialog quotes *both* passages: this
+device's comes from the anchor the page on screen would be written with,
+so the two sides are described by the same capture and can be read
+against each other. A page whose first visible word is not unique in its
+block yields no anchor, and a side with nothing to quote quotes nothing.
+(The catch-up panel still shows one passage, the other device's. It is a
+small panel that already carries two places and two buttons.)
 
 **The agreed baseline is what makes this answerable.** This reader's own
 last position, read back from the server, has exactly the shape of

--- a/internal/webui/reader.templ
+++ b/internal/webui/reader.templ
@@ -385,6 +385,7 @@ templ readerPage(v ReaderView, csrf string) {
 					<section class="reader-sync-side">
 						<h3>Here</h3>
 						<p id="reader-sync-here" class="reader-sync-place"></p>
+						<p id="reader-sync-here-excerpt" class="reader-catchup-excerpt" hidden></p>
 					</section>
 					<section class="reader-sync-side" id="reader-sync-there-side">
 						<h3>Another device</h3>

--- a/internal/webui/static/reader-app.js
+++ b/internal/webui/static/reader-app.js
@@ -589,8 +589,9 @@ function placeDetail(place, name) {
   return age ? `${said}, ${age}` : said;
 }
 
-// Another device's text, so it is set as a text node and nothing else.
-// It is capped by the presenter; the two-line clamp is in the CSS.
+// A passage from a document, so it is set as a text node and nothing
+// else — another device's most of all. It is capped by the presenter;
+// the two-line clamp is in the CSS.
 function showExcerpt(element, place) {
   if (!element) return;
   const excerpt = place?.excerpt;
@@ -826,6 +827,7 @@ const syncButton = document.getElementById("reader-sync");
 const syncDialog = document.getElementById("reader-sync-dialog");
 const syncSummary = document.getElementById("reader-sync-summary");
 const syncHereText = document.getElementById("reader-sync-here");
+const syncHereExcerpt = document.getElementById("reader-sync-here-excerpt");
 const syncThereText = document.getElementById("reader-sync-there");
 const syncThereSide = document.getElementById("reader-sync-there-side");
 const syncExcerpt = document.getElementById("reader-sync-excerpt");
@@ -974,6 +976,7 @@ function presentBookSync(remote, note) {
   syncHereText.textContent = placeLabel(mine) || "Not known yet";
   syncThereText.textContent = placeSentence(there) || "";
   syncThereSide.hidden = !other;
+  showExcerpt(syncHereExcerpt, mine);
   showExcerpt(syncExcerpt, there);
 
   syncTake.hidden = !takeable;
@@ -2187,10 +2190,12 @@ function startCandidates(op) {
 
 // What the presenter needs to turn an op into a page a reader can
 // check: the same facts the restore ladder stands on, plus the position
-// table. Before the book has opened there is only the table, which is
-// enough for a percentage and honest about the rest.
+// table and this page's own anchor. Before the book has opened there is
+// only the table, which is enough for a percentage and honest about the
+// rest.
 function placeView() {
-  return view ? { ...restoreView(), table: positions } : { table: positions };
+  if (!view) return { table: positions };
+  return { ...restoreView(), table: positions, anchor: view.visibleAnchor() };
 }
 
 // ------------------------------------------------------ appearance

--- a/internal/webui/static/reader-place.js
+++ b/internal/webui/static/reader-place.js
@@ -23,6 +23,7 @@
 // Nothing here touches the DOM, the network or a clock it was not
 // given.
 
+import { MAX_AFTER, MAX_BEFORE } from "./reader-anchor.js";
 import { pageAt } from "./reader-positions.js";
 import { sameEdition, sectionHrefIn } from "./reader-restore.js";
 
@@ -39,12 +40,29 @@ const squash = (value) =>
 
 const ELLIPSIS = "…";
 
-// Both context fields are cut at a fixed number of code points, so both
-// ends usually land inside a word. Half a word is not worth reading and
-// is not the writer's text either, so it goes; a side with no space at
-// all is one long partial word and goes whole.
+// A context field is cut only when the capture ran out of room: it
+// takes a fixed number of code points, and a shorter one stopped
+// because the block did. So a short side is whole text, kept whole and
+// claiming no elision, and only a side at the limit is treated as
+// ending inside a word.
+const wasCut = (value, limit) => Array.from(value || "").length >= limit;
+
 const dropPartialHead = (text) => text.replace(/^\S*\s*/, "");
 const dropPartialTail = (text) => text.replace(/\s*\S*$/, "");
+
+// A side of the passage: the text to show, and whether text was taken
+// off this end. Dropping the half word at a cut is worth it in a script
+// that separates words; in one that does not — Japanese, Chinese, Thai
+// — there is no word boundary to find, and dropping back to the last
+// space would throw the whole side away and leave the reader with the
+// single word this exists to escape. So the cut text stays.
+function sideOf(raw, limit, drop) {
+  const text = squash(raw);
+  if (!text.trim()) return { text: "", cut: false };
+  if (!wasCut(raw, limit)) return { text, cut: false };
+  const dropped = drop(text);
+  return { text: dropped.trim() ? dropped : text, cut: true };
+}
 
 const cap = (text) => {
   const points = Array.from(text);
@@ -77,11 +95,12 @@ const cap = (text) => {
 export function passageOf(text) {
   const highlight = squash(text?.highlight).trim();
   if (!highlight) return null;
-  const before = dropPartialHead(squash(text?.before));
-  const after = dropPartialTail(squash(text?.after));
-  if (!before && !after) return cap(highlight);
+  const before = sideOf(text?.before, MAX_BEFORE, dropPartialHead);
+  const after = sideOf(text?.after, MAX_AFTER, dropPartialTail);
+  if (!before.text && !after.text) return cap(highlight);
   return cap(
-    (before ? ELLIPSIS + before : "") + highlight + (after ? after + ELLIPSIS : ""),
+    (before.cut ? ELLIPSIS : "") + before.text + highlight + after.text +
+      (after.cut ? ELLIPSIS : ""),
   );
 }
 

--- a/internal/webui/static/reader-place.js
+++ b/internal/webui/static/reader-place.js
@@ -34,6 +34,57 @@ const finite = (value) => typeof value === "number" && Number.isFinite(value);
 const fractionOf = (value) =>
   finite(value) && value >= 0 && value <= 1 ? value : null;
 
+const squash = (value) =>
+  typeof value === "string" ? value.replace(/\s+/g, " ") : "";
+
+const ELLIPSIS = "…";
+
+// Both context fields are cut at a fixed number of code points, so both
+// ends usually land inside a word. Half a word is not worth reading and
+// is not the writer's text either, so it goes; a side with no space at
+// all is one long partial word and goes whole.
+const dropPartialHead = (text) => text.replace(/^\S*\s*/, "");
+const dropPartialTail = (text) => text.replace(/\s*\S*$/, "");
+
+const cap = (text) => {
+  const points = Array.from(text);
+  if (points.length <= EXCERPT_CHARS) return text;
+  return points.slice(0, EXCERPT_CHARS - 1).join("") + ELLIPSIS;
+};
+
+/**
+ * passageOf reads an anchor's three text fields as one passage.
+ *
+ * `before`, `highlight` and `after` are a single continuous run of text
+ * from one block — the words leading up to the first visible word, that
+ * word, and the words following it — so they are joined with nothing
+ * between them. Any whitespace inside them is a line in a document
+ * rather than a pause in a sentence, so it collapses.
+ *
+ * An anchor's context is the whole point of this: `highlight` alone is
+ * one word by construction (`reader-anchor.js` pins the first visible
+ * word, exactly as Android's `ExactLocatorAnchor` does), and one word
+ * places nobody. Capturing *more* text instead is not the lever it
+ * looks like: the phone compares the three fields verbatim to decide
+ * that two devices are on the same spot, so a client that captured a
+ * longer `after` would never agree with one that did not. The fields
+ * are a wire contract; how much of them a reader is shown is not.
+ *
+ * A locator carrying only `highlight` is left as it is. Some clients
+ * write a whole selection there and no context at all, and dressing
+ * that up as an elided fragment would say something untrue about it.
+ */
+export function passageOf(text) {
+  const highlight = squash(text?.highlight).trim();
+  if (!highlight) return null;
+  const before = dropPartialHead(squash(text?.before));
+  const after = dropPartialTail(squash(text?.after));
+  if (!before && !after) return cap(highlight);
+  return cap(
+    (before ? ELLIPSIS + before : "") + highlight + (after ? after + ELLIPSIS : ""),
+  );
+}
+
 /**
  * excerptOf is the passage the writing client had on screen.
  *
@@ -42,10 +93,7 @@ const fractionOf = (value) =>
  * point of display so that every caller gets it.
  */
 export function excerptOf(op) {
-  const text = op?.locator?.text;
-  const highlight = typeof text?.highlight === "string" ? text.highlight.trim() : "";
-  if (!highlight) return null;
-  return Array.from(highlight).slice(0, EXCERPT_CHARS).join("");
+  return passageOf(op?.locator?.text);
 }
 
 /**
@@ -95,13 +143,20 @@ export function placeOf(op, view = {}) {
  * It is the side the reader can check by looking down, so it is never
  * interpolated: the engine says which section and how far into it, and
  * that is the same arithmetic the footer does.
+ *
+ * `view.anchor` is this page's own first visible word and its context,
+ * captured the way a position is written. Two sides a page apart are
+ * told apart by their numbers; two sides on the same page and not the
+ * same spot are told apart by nothing else at all. Nothing is read from
+ * the document here — the anchor arrives already taken.
  */
 export function placeHere(location, view = {}) {
   if (!location) return null;
   const table = view.table || null;
   const place = {
     fraction: fractionOf(location.fraction), page: null,
-    total: table?.total || null, exact: false, excerpt: null, at: null,
+    total: table?.total || null, exact: false,
+    excerpt: passageOf(view.anchor), at: null,
   };
   if (!table) return place;
   const page = pageAt(table, location.section?.current, location.sectionFraction);

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -1604,9 +1604,9 @@ async function liveGuard(evalIn, check, S) {
         // deliberately something that would be markup if anybody were
         // careless enough to parse it.
         text: {
-          before: 'oking up at ',
+          before: 'e was standing there, looking up at ',
           highlight: 'the passage <b>another device</b> had on screen',
-          after: ' before the night fel',
+          after: ' before the night fell over the whole harbour',
         },
       },
     }] });
@@ -1752,9 +1752,10 @@ async function durableGuard(evalIn, check, { pause, wait, remote, visibility, po
   // An anchor's highlight is one word — the first one visible there —
   // so a panel that quoted only it would place nobody.
   check('the passage carries the words either side of it',
-    excerpt.includes('up at') && excerpt.includes('before the night'), excerpt);
+    excerpt.includes('standing there, looking up at') &&
+    excerpt.includes('before the night fell over the whole'), excerpt);
   check('the halves of a word the capture cut are not shown',
-    !excerpt.includes('oking') && !excerpt.includes('fel'), excerpt);
+    !excerpt.includes('e was standing') && !excerpt.includes('harbour'), excerpt);
   check('another device\'s passage is text, never markup',
     await evalIn("!document.getElementById('reader-catchup-excerpt').querySelector('b')"));
   check('a disagreement is marked as one',
@@ -1831,7 +1832,7 @@ async function durableGuard(evalIn, check, { pause, wait, remote, visibility, po
     await evalIn("document.getElementById('reader-sync-there').textContent"));
   check('the other side quotes its passage, with its context',
     (await evalIn("document.getElementById('reader-sync-excerpt').textContent"))
-      .includes('up at the passage'),
+      .includes('looking up at the passage'),
     await evalIn("document.getElementById('reader-sync-excerpt').textContent"));
   // This side's passage is taken from the page on screen, and a page
   // whose first visible word is not unique in its block yields no

--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -1598,9 +1598,16 @@ async function liveGuard(evalIn, check, S) {
       client_ts: new Date().toISOString(), progression: ${fraction},
       locator: {
         locations: { totalProgression: ${fraction}, fragments: ['epubcfi(/6/9998!/4/2)'] },
-        // Another device's text, and deliberately something that would
-        // be markup if anybody were careless enough to parse it.
-        text: { highlight: 'the passage <b>another device</b> had on screen' },
+        // Another device's text, in the shape an anchor is written in:
+        // the first visible word, and the words either side of it cut
+        // mid-word the way a fixed-length capture cuts them. And
+        // deliberately something that would be markup if anybody were
+        // careless enough to parse it.
+        text: {
+          before: 'oking up at ',
+          highlight: 'the passage <b>another device</b> had on screen',
+          after: ' before the night fel',
+        },
       },
     }] });
     return out.results[0].status;
@@ -1742,6 +1749,12 @@ async function durableGuard(evalIn, check, { pause, wait, remote, visibility, po
   const excerpt = await evalIn("document.getElementById('reader-catchup-excerpt').textContent");
   check('the disagreement shows what the other device had on screen',
     excerpt.includes('another device') && excerpt.includes('<b>'), excerpt);
+  // An anchor's highlight is one word — the first one visible there —
+  // so a panel that quoted only it would place nobody.
+  check('the passage carries the words either side of it',
+    excerpt.includes('up at') && excerpt.includes('before the night'), excerpt);
+  check('the halves of a word the capture cut are not shown',
+    !excerpt.includes('oking') && !excerpt.includes('fel'), excerpt);
   check('another device\'s passage is text, never markup',
     await evalIn("!document.getElementById('reader-catchup-excerpt').querySelector('b')"));
   check('a disagreement is marked as one',
@@ -1816,6 +1829,21 @@ async function durableGuard(evalIn, check, { pause, wait, remote, visibility, po
   check('the other side says how long ago it was',
     (await evalIn("document.getElementById('reader-sync-there').textContent")).includes('just now'),
     await evalIn("document.getElementById('reader-sync-there').textContent"));
+  check('the other side quotes its passage, with its context',
+    (await evalIn("document.getElementById('reader-sync-excerpt').textContent"))
+      .includes('up at the passage'),
+    await evalIn("document.getElementById('reader-sync-excerpt').textContent"));
+  // This side's passage is taken from the page on screen, and a page
+  // whose first visible word is not unique in its block yields no
+  // anchor. So what is asked is that it says nothing or quotes text —
+  // never that it has something to say.
+  check('this side quotes text, or says nothing at all',
+    await evalIn(`(() => {
+      const el = document.getElementById('reader-sync-here-excerpt');
+      if (el.hidden) return el.textContent === '';
+      return el.textContent.trim().length > 0 && el.children.length === 0;
+    })()`),
+    await evalIn("document.getElementById('reader-sync-here-excerpt').textContent"));
 
   // Cancelling is a real answer and changes nothing: not the page, not
   // what the two sides have agreed on. Asking again asks the same thing.

--- a/internal/webui/testdata/readerplace.test.mjs
+++ b/internal/webui/testdata/readerplace.test.mjs
@@ -132,11 +132,67 @@ test("the excerpt is the passage, trimmed and capped", () => {
   assert.equal(excerptOf(null), null);
   const long = excerptOf(op({ text: { highlight: "x".repeat(1000) } }));
   assert.equal(long.length, EXCERPT_CHARS);
+  assert.ok(long.endsWith("…"), "a passage the cap cut says so");
+});
+
+// The highlight of an anchor is one word by construction — the first
+// word visible on the other device — so the context either side of it
+// is the whole of what a reader can recognise their place by.
+test("an anchor's context is read with its word", () => {
+  assert.equal(
+    excerptOf(op({
+      text: {
+        before: "é de ses mots. ", highlight: "Alors", after: ", je me levai et par",
+      },
+    })),
+    "…de ses mots. Alors, je me levai et…",
+  );
+});
+
+test("the halves of a word at each cut are not shown", () => {
+  // Nothing but a partial word on a side: there is no whole word to
+  // keep, so the side goes rather than showing half of one.
+  assert.equal(
+    excerptOf(op({ text: { before: "Alo", highlight: "Alors", after: "sui" } })),
+    "Alors",
+  );
+});
+
+test("a line in a document is not a pause in a sentence", () => {
+  assert.equal(
+    excerptOf(op({
+      text: { before: "the\n  sky was ", highlight: "very", after: " blue\nthat\tday xx" },
+    })),
+    "…sky was very blue that day…",
+  );
+});
+
+test("a passage with no context is not dressed up as a fragment", () => {
+  // Some clients write a whole selection into `highlight` and no
+  // context at all. Ellipses would claim something was cut away.
+  assert.equal(
+    excerptOf(op({ text: { highlight: "Call me Ishmael.", before: "", after: "" } })),
+    "Call me Ishmael.",
+  );
 });
 
 test("an excerpt is counted in characters a reader would count", () => {
   const emoji = "🙂".repeat(EXCERPT_CHARS + 10);
   assert.equal(Array.from(excerptOf(op({ text: { highlight: emoji } }))).length, EXCERPT_CHARS);
+});
+
+test("this device's side shows its own passage when one was taken", () => {
+  const anchor = { before: "in the ", highlight: "beginning", after: " of it all" };
+  const place = placeHere(
+    { fraction: 0.5, section: { current: 1 }, sectionFraction: 0.5 }, { ...view, anchor },
+  );
+  assert.equal(place.excerpt, "…the beginning of it…");
+  // A page whose first word is not unique in its block yields no
+  // anchor, and a side with nothing to quote quotes nothing.
+  assert.equal(
+    placeHere({ fraction: 0.5, section: { current: 1 }, sectionFraction: 0.5 }, view).excerpt,
+    null,
+  );
 });
 
 test("how long ago, said the way a person would", () => {

--- a/internal/webui/testdata/readerplace.test.mjs
+++ b/internal/webui/testdata/readerplace.test.mjs
@@ -137,33 +137,67 @@ test("the excerpt is the passage, trimmed and capped", () => {
 
 // The highlight of an anchor is one word by construction — the first
 // word visible on the other device — so the context either side of it
-// is the whole of what a reader can recognise their place by.
+// is the whole of what a reader can recognise their place by. A capture
+// that filled its 32 code points stopped where it ran out of room,
+// which is usually inside a word.
 test("an anchor's context is read with its word", () => {
   assert.equal(
     excerptOf(op({
       text: {
-        before: "é de ses mots. ", highlight: "Alors", after: ", je me levai et par",
+        before: "é de ses mots. Il leva les yeux. ",
+        highlight: "Alors",
+        after: ", je me levai et partis vers la porte",
       },
     })),
-    "…de ses mots. Alors, je me levai et…",
+    "…de ses mots. Il leva les yeux. Alors, je me levai et partis vers la…",
   );
 });
 
-test("the halves of a word at each cut are not shown", () => {
-  // Nothing but a partial word on a side: there is no whole word to
-  // keep, so the side goes rather than showing half of one.
+test("context the capture did not have to cut is kept whole", () => {
+  // `captureAnchor` cuts only when the block outruns the limit. A short
+  // side stopped at the block's own edge, so its first and last words
+  // are the writer's, and an ellipsis there would mark a cut nobody
+  // made.
   assert.equal(
-    excerptOf(op({ text: { before: "Alo", highlight: "Alors", after: "sui" } })),
-    "Alors",
+    excerptOf(op({ text: { before: "The ", highlight: "Carpet", after: "-Bag ends." } })),
+    "The Carpet-Bag ends.",
+  );
+});
+
+test("a script that does not space its words keeps its context", () => {
+  // Japanese has no word boundary to drop back to, so dropping one
+  // would throw the whole side away and leave the single word this
+  // exists to escape.
+  const before = "むかしむかし、あるところにおじいさんとおばあさんがすんでいましたと";
+  const after = "。おじいさんは山へしばかりに、おばあさんは川へせんたくにいきました";
+  const passage = excerptOf(op({ text: { before, highlight: "た", after } }));
+  assert.ok(passage.includes("おじいさん"), passage);
+  assert.equal(passage, "…" + before + "た" + after + "…");
+});
+
+test("the half of a word the capture cut is not shown", () => {
+  assert.equal(
+    excerptOf(op({
+      text: {
+        before: "orning he stood there and looked up ",
+        highlight: "at",
+        after: " the sky and then the night fell over everyth",
+      },
+    })),
+    "…he stood there and looked up at the sky and then the night fell over…",
   );
 });
 
 test("a line in a document is not a pause in a sentence", () => {
   assert.equal(
     excerptOf(op({
-      text: { before: "the\n  sky was ", highlight: "very", after: " blue\nthat\tday xx" },
+      text: {
+        before: "the\n  sky was\nbright and wide and very ",
+        highlight: "very",
+        after: " blue\nthat\tday and the next one after that xx",
+      },
     })),
-    "…sky was very blue that day…",
+    "…sky was bright and wide and very very blue that day and the next one after that…",
   );
 });
 
@@ -186,7 +220,7 @@ test("this device's side shows its own passage when one was taken", () => {
   const place = placeHere(
     { fraction: 0.5, section: { current: 1 }, sectionFraction: 0.5 }, { ...view, anchor },
   );
-  assert.equal(place.excerpt, "…the beginning of it…");
+  assert.equal(place.excerpt, "in the beginning of it all");
   // A page whose first word is not unique in its block yields no
   // anchor, and a side with nothing to quote quotes nothing.
   assert.equal(


### PR DESCRIPTION
## Summary

When a book has been read further on another device, the reader asks whether to
continue from there and quotes the passage that was on screen. It quoted one
word, which is not enough to recognise a place. It now quotes the words around
it.

The one word was not a truncation bug: a position is anchored to the first
visible word on the page, and that word is what the anchor stores. The
surrounding text already travels in the same position record and was simply not
being shown. The Android app has always shown all of it.

## Changes

- The passage shown for another device is built from the words before and after
  the anchored word, not from the anchored word alone. A half word left where
  the capture ran out of room is dropped and the cut is marked with an ellipsis.
  Context that ended at the paragraph's own edge is kept whole and marked with
  nothing, and a script that does not put spaces between words, such as Japanese
  or Chinese, keeps its context instead of losing it to a search for a word
  boundary that is not there.
- The manual sync dialog now quotes the page on this screen as well. When two
  devices report the same page but not the same spot, the two passages are the
  only thing that tells them apart.
- Positions already stored on the server show their context immediately. Nothing
  about what clients send or store changed, and the capture itself is untouched:
  the phone compares those text fields exactly when deciding that two devices
  are on the same spot, so capturing more text would make every matching
  position look like a disagreement.
- ADR-0040 says where the passage comes from, and why capturing more is not the
  way to get a longer one.

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [x] If `.templ` files changed: `go tool templ generate ./internal/webui/` and committed generated output
- [ ] If `docs/openapi.yaml` changed: `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish`
- [x] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable

The race suite passes apart from the browser checks, which CI skips. Those were
run locally against Chrome 153 with `LISEUR_CHROME` set: the new assertions in
the reader walk pass, and the five failures that remain fail the same way on
`origin/main` with this branch removed, so none of them belong to this change.
`docs/openapi.yaml` is untouched. Generated templ output is gitignored in this
repository, so there is nothing to commit for it.

## Screenshots, logs, or API examples

From the reader walk, the catch-up panel and both sides of the sync dialog:

```
the disagreement shows what the other device had on screen
  "…up at the passage <b>another device</b> had on screen before the night…"
both sides are shown
  Here  Page 11 of 13  "The Carpet-Bag, part…"
  Another device  Near page 12 of 13 · just now
  "…up at the passage <b>another device</b> had on screen before the night…"
```

The angle brackets are deliberate: another device's text is set as a text node,
never parsed as markup, and the walk checks that.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.
