### PR TITLE
test: drop the annotation wait the reader no longer answers

### DIFF
--- a/internal/webui/testdata/readerbrowser.mjs
+++ b/internal/webui/testdata/readerbrowser.mjs
@@ -13,7 +13,6 @@ const host = process.env.SMOKE_HOST;
 // somewhere, and it is not in DNS. Chrome will map it for us.
 const mapHost = process.env.SMOKE_MAP;
 const detached = process.env.SMOKE_DETACHED === '1';
-const withAnnotations = process.env.SMOKE_ANNOTATIONS === '1';
 // NaN-guard mode (the position-jumps fix): synthetic relocate events
 // with a NaN then a finite fraction, watching whether the reader pushes.
 const nan = process.env.SMOKE_NAN === '1';
@@ -225,10 +224,6 @@ await waitFor(`(() => {
     view?.renderer?.getContents?.().some(({ doc }) => doc?.body) &&
     document.getElementById('reader-status')?.textContent === '';
 })()`, 'the publication to open');
-if (withAnnotations || liveMode) {
-  await waitFor(`document.querySelector('readium-view').renderer.getContents()
-    .some(({ doc }) => doc.defaultView.CSS?.highlights?.size > 0)`, 'the initial annotations');
-}
 
 const fail = [];
 const check = (name, ok, extra = '') => {
@@ -341,17 +336,6 @@ const probe = `(() => {
     ran: doc ? !!doc.documentElement.dataset.publicationRan : null,
     svgRan: doc ? !!doc.documentElement.dataset.svgRan : null,
     extRan: doc ? typeof doc.defaultView.htmx !== 'undefined' : null,
-    overlay: (() => {
-      if (!doc) return null;
-      const registry = doc.defaultView.CSS.highlights;
-      if (registry && registry.size) {
-        const [name, ranges] = [...registry][0];
-        return { rects: [...ranges].reduce((n,r) => n + r.getClientRects().length, 0),
-          fill: doc.defaultView.getComputedStyle(doc.body, '::highlight(' + name + ')').backgroundColor };
-      }
-      const marks = [...doc.querySelectorAll('[data-highlight-id] .readium-highlight')];
-      return marks.length ? { rects: marks.length, fill: doc.defaultView.getComputedStyle(marks[0]).backgroundColor } : null;
-    })(),
     pageTitle: document.title,
     fontSize: body ? doc.defaultView.getComputedStyle(body).fontSize : '',
     wrapWidth: body && body.firstElementChild
@@ -442,35 +426,6 @@ await setReaderTheme('light', 'rgb(27,27,31)');
 // what stripping might miss. This is the promise the vendored engine
 // had to keep.
 check('publication script did not run', diag.ran === false, String(diag.ran));
-
-// Annotations (ADR-0028), when the harness seeded them: the highlight
-// whose CFI anchors in this very chapter must have actually drawn —
-// rects in the overlayer SVG, filled with the palette's green, never
-// raw CSS from the wire — and the two that cannot draw must be listed
-// in the sidebar rather than reported as errors.
-if (withAnnotations) {
-  check('a synced highlight draws over the text',
-    !!diag.overlay && diag.overlay.rects > 0 && /(?:129,\s*199,\s*132|#81c784)/.test(diag.overlay.fill),
-    JSON.stringify(diag.overlay));
-  const anns = JSON.parse(await evalIn(`JSON.stringify((() => {
-    const panel = document.getElementById('reader-annotations');
-    return {
-      hidden: panel ? panel.hidden : null,
-      entries: [...(panel?.querySelectorAll('.reader-ann-text') ?? [])]
-        .map((s) => s.textContent),
-    };
-  })())`));
-  check('the sidebar lists the note',
-    anns.hidden === false &&
-      anns.entries.some((t) => t.includes('A thought about the whale')),
-    JSON.stringify(anns));
-  check('an unanchorable highlight degrades to a sidebar entry',
-    anns.entries.some((t) => t.includes('an unanchored highlight')),
-    JSON.stringify(anns));
-  check('the drawn highlight is not duplicated in the sidebar',
-    !anns.entries.some((t) => t.includes('title page, absolut')),
-    JSON.stringify(anns));
-}
 
 // It must have actually painted: an engine that renders nothing still
 // reports a chapter.


### PR DESCRIPTION
## Summary

`TestReaderLiveInARealBrowser` has been failing locally on every run,
timing out on "the initial annotations" before it could check anything
else.

The walk waits for a drawn highlight (`CSS.highlights.size > 0`) before
the first check. Commit 84ac08a ("hide reader annotation UI") removed
every call to `loadAnnotations()`, so the reader no longer loads
annotations at all and nothing ever draws one. The same commit dropped
`SMOKE_ANNOTATIONS=1` and the checks behind it, but left the wait alive
behind `|| liveMode`, which is why only the live reader check still
hits it.

Confirmed by probing a live run: the server returns all three seeded
annotations (200), the CFI resolves to a locator in the open chapter,
the frame supports the highlight API — and the engine's annotation map
is empty, because `loadAnnotations` has no callers.

The seeding in `seedStalePosition` stays: it still exercises the
annotations API through the route a device uses, and the Go side
asserts every write applied.

## Changes

- Remove the annotation wait from `readerbrowser.mjs`.
- Remove the `SMOKE_ANNOTATIONS` flag and the checks behind it, which
  nothing has set since 84ac08a.
- Remove the `overlay` field from the page probe, read only by those
  checks.

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [ ] If `.templ` files changed: `go tool templ generate ./internal/webui/` and committed generated output
- [ ] If `docs/openapi.yaml` changed: `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish`
- [x] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable

`LISEUR_CHROME=... go test ./internal/webui/ -run TestReaderLiveInARealBrowser`
now passes (it timed out at 10s on every run before). Browser tests are
skipped in CI.

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.
