### PR TITLE
fix: wire the chapter on screen even when Gecko says nothing

### DIFF
--- a/internal/webui/static/reader-engine.js
+++ b/internal/webui/static/reader-engine.js
@@ -27,6 +27,7 @@ export class ReaderEngine extends HTMLElement {
     this.renderer.goTo = target => this.goTo(target);
     this.renderer.render = () => { if (this.navigator) this.relocate(this.navigator.currentLocator); };
     this.annotations = new Map();
+    this.announced = new WeakSet();
     this.settings = {};
     this.styleText = "";
     this.preferences = {};
@@ -128,7 +129,20 @@ export class ReaderEngine extends HTMLElement {
   }
 
   frameLoaded(wnd) {
-    const doc = wnd.document;
+    this.announce(wnd.document);
+  }
+
+  // announce is the one place a chapter document is handed to the rest
+  // of the reader, and it is idempotent because the navigator's own
+  // announcement cannot be relied on. Gecko drops most of them: over a
+  // whole reading walk Firefox reported one document out of eleven, and
+  // everything hung on that report — the reading keys, the tap that
+  // turns a page — was simply missing from the chapter on screen. So
+  // every relocation looks at what is rendered and announces anything
+  // nobody has seen yet.
+  announce(doc) {
+    if (!doc || !doc.documentElement || this.announced.has(doc)) return;
+    this.announced.add(doc);
     const href = doc.documentElement.getAttribute("data-reader-href");
     this.applyDocumentStyle(doc);
     doc.addEventListener("click", event => {
@@ -190,6 +204,7 @@ export class ReaderEngine extends HTMLElement {
 
   relocate(locator) {
     if (!locator) return;
+    for (const { doc } of this.contents()) this.announce(doc);
     const index = this.book.sections.findIndex(s => s.id === locator.href);
     if (index < 0) return;
     const sectionFraction = locator.locations.progression || 0;

--- a/internal/webui/testdata/readerfirefox.mjs
+++ b/internal/webui/testdata/readerfirefox.mjs
@@ -432,26 +432,32 @@ const ffReached = JSON.parse(await chromeState());
 check('reaching for the top of the window brings the chrome back',
   ffReached.state === 'visible' && ffReached.bar === '1', JSON.stringify(ffReached));
 
+// The page fraction is read raw here rather than through the probe,
+// which rounds it to four places. A rounded reading is usually already
+// smaller than the live one it is compared against, so the wait below
+// would be satisfied by a page that never turned, and the check would
+// then report two equal numbers with nothing to explain them.
+const ffFraction = () => evalIn(
+  `document.querySelector('readium-view').lastLocation.fraction`);
+
 await new Promise((r) => setTimeout(r, 2600));
-const ffBefore = JSON.parse(await evalIn(probe));
+const ffBefore = await ffFraction();
 await ffTap('right', 'touch');
-await waitFor(`document.querySelector('readium-view').lastLocation.fraction > ${ffBefore.fraction} &&
+await waitFor(`document.querySelector('readium-view').lastLocation.fraction > ${ffBefore} &&
   document.querySelector('readium-view').renderer.getContents().some(({ doc }) => doc?.body)`, 'the touch page turn');
-const ffForward = JSON.parse(await evalIn(probe));
+const ffForward = await ffFraction();
 check('a tap on the right of the text turns the page',
-  ffForward.fraction > ffBefore.fraction,
-  `${ffBefore.fraction} -> ${ffForward.fraction}`);
+  ffForward > ffBefore, `${ffBefore} -> ${ffForward}`);
 
 // The mouse path is the one that has to ask Gecko where the caret is.
 // Let the 700ms suppression of synthetic mouse events after touch expire.
 await new Promise(resolve => setTimeout(resolve, 750));
 await ffTap('right', 'mouse');
-await waitFor(`document.querySelector('readium-view').lastLocation.fraction > ${ffForward.fraction} &&
+await waitFor(`document.querySelector('readium-view').lastLocation.fraction > ${ffForward} &&
   document.querySelector('readium-view').renderer.getContents().some(({ doc }) => doc?.body)`, 'the mouse page turn');
-const ffMouse = JSON.parse(await evalIn(probe));
+const ffMouse = await ffFraction();
 check('a mouse click on the right of the text turns the page',
-  ffMouse.fraction > ffForward.fraction,
-  `${ffForward.fraction} -> ${ffMouse.fraction}`);
+  ffMouse > ffForward, `${ffForward} -> ${ffMouse}`);
 
 await evalIn(`(() => {
   const doc = document.querySelector('readium-view').renderer.getContents()[0].doc;
@@ -465,10 +471,10 @@ await evalIn(`(() => {
   return true;
 })()`);
 await new Promise((r) => setTimeout(r, 1200));
-const ffSelected = JSON.parse(await evalIn(probe));
+const ffSelected = await ffFraction();
 check('a click while text is selected is not a page turn',
-  ffSelected.fraction === ffMouse.fraction,
-  `${ffMouse.fraction} -> ${ffSelected.fraction}`);
+  ffSelected === ffMouse,
+  `${ffMouse} -> ${ffSelected}`);
 await evalIn(`(() => {
   document.querySelector('readium-view').renderer.getContents()[0]
     .doc.getSelection().removeAllRanges();


### PR DESCRIPTION
## Summary

In Firefox, tapping the side of the text does not turn the page, and
the arrow keys stop working as soon as a click moves focus into the
chapter. Only the toolbar buttons work, which is why the reader still
looks fine at a glance.

The reader attaches the reading keys and the tap handler when the
engine announces a chapter document (`frameLoaded` → the `load` event).
Gecko rarely delivers that announcement. Instrumenting a full Firefox
walk — ten page turns plus a `goTo` — showed exactly one announcement,
for `chapter3.xhtml`, while the document on screen at the end was
`chapter1.xhtml` and carried no handlers at all. I confirmed the tap
itself is fine: the synthetic events arrive at the frame document, the
geometry maps to viewport x=1360 in the `next` zone, there is no
selection, and a keydown on the page (whose handler is bound to the
reader page, not the frame) does turn the page.

So the engine now announces documents itself: every relocation looks at
what it has rendered and announces anything the reader has not seen.
Announcement is idempotent, so a browser that does deliver `frameLoaded`
behaves exactly as before.

The Firefox check should have caught this and could not. It compared a
page fraction rounded to four places against the live value, and
`0.07692307... > 0.0769` is true before anything happens — so the wait
returned without a page turn, and the failure surfaced as two equal
numbers rather than a timeout.

## Changes

- `reader-engine.js`: `frameLoaded` becomes an idempotent `announce`,
  guarded by a `WeakSet`, and `relocate` announces any rendered document
  that has not been announced yet.
- `readerfirefox.mjs`: read `lastLocation.fraction` raw for the gesture
  checks instead of the probe's rounded copy.

## Testing

- [x] `go test -race ./...`
- [x] `go vet ./...`
- [x] `gofmt -l ./cmd ./internal` reports no files
- [ ] If `.templ` files changed: `go tool templ generate ./internal/webui/` and committed generated output
- [ ] If `docs/openapi.yaml` changed: `npx -y @redocly/cli@latest lint docs/openapi.yaml --format stylish`
- [x] Manually tested the affected API, adapter, web UI, or deployment behavior, if applicable

`TestReaderOpensInFirefox` passes (it failed on both gesture checks
before), and every Chromium browser check still passes, so that path is
unaffected. Browser tests are skipped in CI.

```
PASS  a tap on the right of the text turns the page — 0.07692307692307693 -> 0.08974358974358974
PASS  a mouse click on the right of the text turns the page — 0.08974358974358974 -> 0.10256410256410256
PASS  a click while text is selected is not a page turn — 0.10256410256410256 -> 0.10256410256410256
```

## Checklist

- [x] I have kept this change focused and documented user-facing behavior.
- [x] I have added or updated tests where needed.
- [x] I have updated related API and integration documentation where needed.
- [x] I have documented deployment or migration impact where applicable.
- [x] I have not included secrets, private data, copyrighted book files, or generated build artifacts.
